### PR TITLE
Add Latvian specific QWERTY layout

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -4,12 +4,14 @@
     <item>system</item>
     <item>azerty</item>
     <item>qwerty</item>
+    <item>qwerty_lv</item>
     <item>qwertz</item>
   </string-array>
   <string-array name="pref_layout_entries">
     <item>@string/pref_layout_e_system</item>
     <item>AZERTY</item>
     <item>QWERTY</item>
+    <item>QWERTY (Latvian)</item>
     <item>QWERTZ</item>
   </string-array>
   <string-array name="pref_accents_entries">

--- a/res/xml/method.xml
+++ b/res/xml/method.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <input-method xmlns:android="http://schemas.android.com/apk/res/android" android:settingsActivity="juloo.keyboard2.SettingsActivity" android:supportsSwitchingToNextInputMethod="true">
-  <subtype android:label="%s" android:languageTag="de" android:imeSubtypeLocale="de_DE" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwerty,extra_keys=trema|szlig"/>
+  <subtype android:label="%s" android:languageTag="de" android:imeSubtypeLocale="de_DE" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwertz,extra_keys=trema|szlig"/>
   <subtype android:label="%s" android:languageTag="en" android:imeSubtypeLocale="en_US" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwerty"/>
   <subtype android:label="%s" android:languageTag="es" android:imeSubtypeLocale="es_ES" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwerty,extra_keys=aigu|tilde|trema"/>
   <subtype android:label="%s" android:languageTag="fr" android:imeSubtypeLocale="fr_FR" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=azerty,extra_keys=grave|aigu|circonflexe|cedille|trema"/>
   <subtype android:label="%s" android:languageTag="it" android:imeSubtypeLocale="it_IT" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwerty,extra_keys=grave|aigu"/>
-  <subtype android:label="%s" android:languageTag="lv" android:imeSubtypeLocale="lv_LV" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwerty,extra_keys=caron|cedille|macron"/>
+  <subtype android:label="%s" android:languageTag="lv" android:imeSubtypeLocale="lv_LV" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwerty_lv,extra_keys=caron|cedille|macron"/>
   <subtype android:label="%s" android:languageTag="sv" android:imeSubtypeLocale="sv_SE" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwerty,extra_keys=aigu|trema|ring"/>
 </input-method>

--- a/res/xml/qwerty_lv.xml
+++ b/res/xml/qwerty_lv.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<keyboard>
+  <row>
+    <key key0="q" key1="esc" key2="1" key3="~" key4="!" />
+    <key key0="w" key2="2" key3="\@" />
+    <key key0="e" key1="ē" key2="3" key3="\#" />
+    <key key0="r" key1="ŗ" key2="4" key3="$" />
+    <key key0="t" key2="5" key3="%" />
+    <key key0="y" key2="6" key3="^" />
+    <key key0="u" key1="ū" key2="7" key3="&amp;" />
+    <key key0="i" key1="ī" key2="8" key3="*" />
+    <key key0="o" key1="ō" key2="9" key3="(" key4=")" />
+    <key key0="p" key2="0" key3="{" key4="}" />
+  </row>
+  <row>
+    <key shift="0.5" key0="a" key1="ā" />
+    <key key0="s" key1="š" />
+    <key key0="d" />
+    <key key0="f" />
+    <key key0="g" key1="ģ" />
+    <key key0="h" key2="accent_macron" key3="accent_caron" key4="accent_cedille" />
+    <key key0="j" key1="+" key2="=" key3="-" key4="_" />
+    <key key0="k" key1="ķ" key3="[" key4="]" />
+    <key key0="l" key1="ļ" key2="|" key3="/" key4="\\" />
+  </row>
+  <row>
+    <key width="1.5" key0="shift" key1="tab" />
+    <key key0="z" key1="ž" />
+    <key key0="x" />
+    <key key0="c" key1="č" />
+    <key key0="v" />
+    <key key0="b" key3="&lt;" key4="&gt;" />
+    <key key0="n" key1="ņ" key2="`" key3=":" key4=";" />
+    <key key0="m" key1="'" key2="&quot;" key3="," key4="\?" />
+    <key width="1.5" key0="backspace" key2="delete" />
+  </row>
+  <row height="0.95">
+    <key width="1.8" key0="ctrl" key3="switch_numeric" />
+    <key width="1.2" key0="alt" key1="fn" key2="change_method" key3="switch_emoji" key4="config" />
+    <key width="4.0" key0="space" />
+    <key width="1.2" key0="." key1="up" key2="right" key3="left" key4="down" />
+    <key width="1.8" key0="enter" key2="action" />
+  </row>
+</keyboard>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -110,6 +110,7 @@ final class Config
     {
       case "azerty": return R.xml.azerty;
       case "qwerty": return R.xml.qwerty;
+      case "qwerty_lv": return R.xml.qwerty_lv;
       case "qwertz": return R.xml.qwertz;
       case "system": default: return -1;
     }


### PR DESCRIPTION
A customised Latvian specific QWERTY layout (QWERTY (Latvian)) was added to access all Latvian diacritic characters with a swipe.
Additionally caron, cedille and macron accents were enabled for this layout.

This is what I had in mind when I started working on #27 - to access Latvian diacritic characters with a swipe. I figured out that adding a new and customised Latvian specific QWERTY layout would be the best approach because if everybody who would like to access language specific characters with a swipe added those to the QWERTY layout, all key slots soon would be filled.
Is this acceptable/not against the idea or vision behind this keyboard application?

This pull request depends on #27 because of the new accents - caron and macron.

![image](https://user-images.githubusercontent.com/9976861/150629342-6e076dab-0d40-4ca2-8dc3-ab394019cf8f.png)
