### PR TITLE
Use symbols for configuration and emoji keys

### DIFF
--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -209,10 +209,10 @@ class KeyValue
     addCharKey(')', KeyEvent.KEYCODE_NUMPAD_RIGHT_PAREN);
     addCharKey('ß', EVENT_NONE, FLAG_LANG_SZLIG);
 
-    addSpecialKey("config", "Conf", EVENT_CONFIG);
+    addSpecialKey("config", "⛭", EVENT_CONFIG);
     addSpecialKey("switch_text", "ABC", EVENT_SWITCH_TEXT);
     addSpecialKey("switch_numeric", "123+", EVENT_SWITCH_NUMERIC);
-    addSpecialKey("switch_emoji", ":)", EVENT_SWITCH_EMOJI);
+    addSpecialKey("switch_emoji", "☻", EVENT_SWITCH_EMOJI);
     addSpecialKey("switch_back_emoji", "ABC", EVENT_SWITCH_BACK_EMOJI);
     addSpecialKey("change_method", "⊞", EVENT_CHANGE_METHOD);
     addSpecialKey("action", "Action", EVENT_ACTION); // Will always be replaced


### PR DESCRIPTION
`srcs/juloo.keyboard2/KeyValue.java` was updated to replace `Conf` with
`⛭` (`\u2699`) and `:)` with `☻` (`\u263B`).

![image](https://user-images.githubusercontent.com/9976861/150629303-2ecabe2a-87b9-46f8-814d-c13f925725ec.png)
