### PR TITLE
Allow edge keys instead of corner keys (swipe vertically/horizontally)

### DIFF
--- a/res/xml/azerty.xml
+++ b/res/xml/azerty.xml
@@ -38,7 +38,7 @@
     <key width="1.8" key0="ctrl" key3="switch_numeric"/>
     <key width="1.2" key0="alt" key1="fn" key2="change_method" key3="switch_emoji" key4="config"/>
     <key width="4.0" key0="space"/>
-    <key width="1.2" key1="up" key2="right" key3="left" key4="down"/>
+    <key width="1.2" key1="up" key2="right" key3="left" key4="down" edgekeys="true"/>
     <key width="1.8" key0="enter" key2="action"/>
   </row>
 </keyboard>

--- a/res/xml/numeric.xml
+++ b/res/xml/numeric.xml
@@ -13,7 +13,7 @@
     <key width="0.75" key0="tab" key1=";" key2="|" key4="\\"/>
     <key width="0.75" key0=")" key2="]" key4="}"/>
     <key key0="4"/>
-    <key key0="5" key1="up" key2="right" key3="left" key4="down"/>
+    <key key0="5" key1="up" key2="right" key3="left" key4="down" edgekeys="true"/>
     <key key0="6"/>
     <key width="0.75" key0="+" key1="Σ" key2="$"/>
     <key width="0.75" key0="-" key2="^"/>

--- a/res/xml/qwerty.xml
+++ b/res/xml/qwerty.xml
@@ -38,7 +38,7 @@
     <key width="1.8" key0="ctrl" key3="switch_numeric"/>
     <key width="1.2" key0="alt" key1="fn" key2="change_method" key3="switch_emoji" key4="config"/>
     <key width="4.0" key0="space"/>
-    <key width="1.2" key1="up" key2="right" key3="left" key4="down"/>
+    <key width="1.2" key1="up" key2="right" key3="left" key4="down" edgekeys="true"/>
     <key width="1.8" key0="enter" key2="action"/>
   </row>
 </keyboard>

--- a/res/xml/qwerty_lv.xml
+++ b/res/xml/qwerty_lv.xml
@@ -38,7 +38,7 @@
     <key width="1.8" key0="ctrl" key3="switch_numeric" />
     <key width="1.2" key0="alt" key1="fn" key2="change_method" key3="switch_emoji" key4="config" />
     <key width="4.0" key0="space" />
-    <key width="1.2" key0="." key1="up" key2="right" key3="left" key4="down" />
+    <key width="1.2" key0="." key1="up" key2="right" key3="left" key4="down" edgekeys="true"/>
     <key width="1.8" key0="enter" key2="action" />
   </row>
 </keyboard>

--- a/res/xml/qwertz.xml
+++ b/res/xml/qwertz.xml
@@ -38,7 +38,7 @@
     <key width="1.8" key0="ctrl" key3="switch_numeric"/>
     <key width="1.2" key0="alt" key1="fn" key2="change_method" key3="switch_emoji" key4="config"/>
     <key width="4.0" key0="space"/>
-    <key width="1.2" key1="up" key2="right" key3="left" key4="down"/>
+    <key width="1.2" key1="up" key2="right" key3="left" key4="down" edgekeys="true"/>
     <key width="1.8" key0="enter" key2="action"/>
   </row>
 </keyboard>

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -40,6 +40,13 @@ public class Keyboard2View extends View
 
   private static RectF _tmpRect = new RectF();
 
+  enum Vertical
+  {
+    TOP,
+    CENTER,
+    BOTTOM
+  }
+
   public Keyboard2View(Context context, AttributeSet attrs)
   {
     super(context, attrs);
@@ -157,13 +164,27 @@ public class Keyboard2View extends View
       float absDist = Math.abs(moveX) + Math.abs(moveY);
       key.ptrDist = absDist;
       if (absDist < _config.swipe_dist_px)
+      {
         newValue = key.key.key0;
-      else if (moveX < 0)
-        newValue = (moveY < 0) ? key.key.key1 : key.key.key3;
-      else if (moveY < 0)
-        newValue = key.key.key2;
+      }
+      else if (key.key.edgekeys)
+      {
+        if (Math.abs(moveY) > Math.abs(moveX)) // vertical swipe
+          newValue = (moveY < 0) ? key.key.key1 : key.key.key4;
+        else if (moveX < 0) // left swipe
+          newValue = key.key.key3;
+        else // right swipe
+          newValue = key.key.key2;
+      }
       else
-        newValue = key.key.key4;
+      {
+        if (moveX < 0)
+          newValue = (moveY < 0) ? key.key.key1 : key.key.key3;
+        else if (moveY < 0)
+          newValue = key.key.key2;
+        else
+          newValue = key.key.key4;
+      }
       if (newValue != null && newValue != key.value)
       {
         if (key.timeoutWhat != -1)
@@ -368,14 +389,28 @@ public class Keyboard2View extends View
         if (k.key0 != null)
           drawLabel(canvas, k.key0, keyW / 2f + x, (keyH + _theme.labelTextSize) / 2f + y, keyDown);
         float subPadding = _config.keyPadding;
-        if (k.key1 != null)
-          drawSubLabel(canvas, k.key1, x + subPadding, y + subPadding, false, true, keyDown);
-        if (k.key3 != null)
-          drawSubLabel(canvas, k.key3, x + subPadding, y + keyH - subPadding, false, false, keyDown);
-        if (k.key2 != null)
-          drawSubLabel(canvas, k.key2, x + keyW - subPadding, y + subPadding, true, true, keyDown);
-        if (k.key4 != null)
-          drawSubLabel(canvas, k.key4, x + keyW - subPadding, y + keyH - subPadding, true, false, keyDown);
+        if (k.edgekeys)
+        {
+          if (k.key1 != null) // top key
+            drawSubLabel(canvas, k.key1, x + keyW / 2f, y + subPadding, Paint.Align.CENTER, Vertical.TOP, keyDown);
+          if (k.key3 != null) // left key
+            drawSubLabel(canvas, k.key3, x + subPadding, y + keyH / 2f, Paint.Align.LEFT, Vertical.CENTER, keyDown);
+          if (k.key2 != null) // right key
+            drawSubLabel(canvas, k.key2, x + keyW - subPadding, y + keyH / 2f, Paint.Align.RIGHT, Vertical.CENTER, keyDown);
+          if (k.key4 != null) // bottom key
+            drawSubLabel(canvas, k.key4, x + keyW / 2f, y + keyH - subPadding, Paint.Align.CENTER, Vertical.BOTTOM, keyDown);
+        }
+        else
+        {
+          if (k.key1 != null) // top left key
+            drawSubLabel(canvas, k.key1, x + subPadding, y + subPadding, Paint.Align.LEFT, Vertical.TOP, keyDown);
+          if (k.key3 != null) // bottom left key
+            drawSubLabel(canvas, k.key3, x + subPadding, y + keyH - subPadding, Paint.Align.LEFT, Vertical.BOTTOM, keyDown);
+          if (k.key2 != null) // top right key
+            drawSubLabel(canvas, k.key2, x + keyW - subPadding, y + subPadding, Paint.Align.RIGHT, Vertical.TOP, keyDown);
+          if (k.key4 != null) // bottom right key
+            drawSubLabel(canvas, k.key4, x + keyW - subPadding, y + keyH - subPadding, Paint.Align.RIGHT, Vertical.BOTTOM, keyDown);
+        }
         x += _keyWidth * k.width;
       }
       y += row.height * _config.keyHeight;
@@ -413,13 +448,16 @@ public class Keyboard2View extends View
     canvas.drawText(k.symbol, x, y, p);
   }
 
-  private void drawSubLabel(Canvas canvas, KeyValue k, float x, float y, boolean right, boolean up, KeyDown keyDown)
+  private void drawSubLabel(Canvas canvas, KeyValue k, float x, float y, Paint.Align a, Vertical v, KeyDown keyDown)
   {
     k = KeyModifier.handleFlags(k, _flags);
-    Paint p = _theme.subLabelPaint(((k.flags & KeyValue.FLAG_KEY_FONT) != 0), right);
+    Paint p = _theme.subLabelPaint(((k.flags & KeyValue.FLAG_KEY_FONT) != 0), a);
     p.setColor(labelColor(k, keyDown, _theme.subLabelColor));
     p.setTextSize(_theme.sublabelTextSize * scaleTextSize(k));
-    y -= up ? p.ascent() : p.descent();
+    if (v == Vertical.CENTER)
+      y -= (p.ascent() + p.descent()) / 2f;
+    else
+      y -= (v == Vertical.TOP) ? p.ascent() : p.descent();
     canvas.drawText(k.symbol, x, y, p);
   }
 

--- a/srcs/juloo.keyboard2/KeyboardData.java
+++ b/srcs/juloo.keyboard2/KeyboardData.java
@@ -131,8 +131,10 @@ class KeyboardData
     public final float width;
     /* Extra empty space on the left of the key. */
     public final float shift;
+    /* Put keys 1 to 4 on the edges instead of the corners. */
+    public final boolean edgekeys;
 
-    public Key(KeyValue k0, KeyValue k1, KeyValue k2, KeyValue k3, KeyValue k4, float w, float s)
+    public Key(KeyValue k0, KeyValue k1, KeyValue k2, KeyValue k3, KeyValue k4, float w, float s, boolean e)
     {
       key0 = k0;
       key1 = k1;
@@ -141,6 +143,12 @@ class KeyboardData
       key4 = k4;
       width = w;
       shift = s;
+      edgekeys = e;
+    }
+
+    public Key(KeyValue k0, KeyValue k1, KeyValue k2, KeyValue k3, KeyValue k4, float w, float s)
+    {
+      this(k0, k1, k2, k3, k4, w, s, false);
     }
 
     public static Key parse(XmlResourceParser parser) throws Exception
@@ -152,14 +160,15 @@ class KeyboardData
       KeyValue k4 = KeyValue.getKeyByName(parser.getAttributeValue(null, "key4"));
       float width = parser.getAttributeFloatValue(null, "width", 1f);
       float shift = parser.getAttributeFloatValue(null, "shift", 0.f);
+      boolean edgekeys = parser.getAttributeBooleanValue(null, "edgekeys", false);
       while (parser.next() != XmlResourceParser.END_TAG)
         continue ;
-      return new Key(k0, k1, k2, k3, k4, width, shift);
+      return new Key(k0, k1, k2, k3, k4, width, shift, edgekeys);
     }
 
     public Key replaceKeys(MapKeys f)
     {
-      return new Key(f.map(key0), f.map(key1), f.map(key2), f.map(key3), f.map(key4), width, shift);
+      return new Key(f.map(key0), f.map(key1), f.map(key2), f.map(key3), f.map(key4), width, shift, edgekeys);
     }
   }
 

--- a/srcs/juloo.keyboard2/Theme.java
+++ b/srcs/juloo.keyboard2/Theme.java
@@ -54,10 +54,10 @@ public class Theme
     return p;
   }
 
-  public Paint subLabelPaint(boolean special_font, boolean align_right)
+  public Paint subLabelPaint(boolean special_font, Paint.Align align)
   {
     Paint p = special_font ? _specialKeySubLabelPaint : _keySubLabelPaint;
-    p.setTextAlign(align_right ? Paint.Align.RIGHT : Paint.Align.LEFT);
+    p.setTextAlign(align);
     return p;
   }
 


### PR DESCRIPTION
Fix/implement #56.

Add a new boolean parameter "edgekeys" for defining keys that have the additional (swipe) keys on the edges (top, right, left, bottom) instead of at the corners (top left, top right, bottom left, bottom right).

Example:

```xml
<key width="1.2" key1="up" key2="right" key3="left" key4="down" edgekeys="true"/>
```

If the `edgekeys` parameter is omitted, it defaults to `false` (swipe diagonally for additional keys).

This pull request also changes the arrow keys in all layouts to the alternative edge style:

Before:
![Arrow key](https://user-images.githubusercontent.com/13970628/152235656-40c456c1-b30d-4cf5-9be5-3a3f0836913c.png)

After:
![Arrow key edges](https://user-images.githubusercontent.com/13970628/152235675-e26111be-5625-481e-b0e5-25dab82cb53b.png)

