### PR TITLE
Makefile: Pass full path when calling apksigner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ $(DEBUG_KEYSTORE):
 		-keyalg rsa -storepass $(DEBUG_PASSWD) -validity 10000
 
 _build/%.debug.apk: _build/%.debug.unsigned-apk $(DEBUG_KEYSTORE)
-	apksigner sign --in "$<" --out "$@" \
+	$(ANDROID_BUILD_TOOLS)/apksigner sign --in "$<" --out "$@" \
 		--ks $(DEBUG_KEYSTORE) --ks-key-alias debug --ks-pass "pass:$(DEBUG_PASSWD)"
 
 # Debug apk


### PR DESCRIPTION
Fix #55.

Pass full path when calling `apksigner` (using the variable `$(ANDROID_BUILD_TOOLS)`).