### PR TITLE
Replace unusual return symbol

### DIFF
--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -224,7 +224,7 @@ class KeyValue
     addSpecialKey("action", "Action", EVENT_ACTION); // Will always be replaced
 
     addEventKey("esc", "Esc", KeyEvent.KEYCODE_ESCAPE);
-    addEventKey("enter", "\uE800", KeyEvent.KEYCODE_ENTER, FLAG_KEY_FONT);
+    addEventKey("enter", "\u23CE", KeyEvent.KEYCODE_ENTER, FLAG_KEY_FONT);
     addEventKey("up", "\uE80B", KeyEvent.KEYCODE_DPAD_UP, FLAG_KEY_FONT | FLAG_PRECISE_REPEAT);
     addEventKey("right", "\uE80C", KeyEvent.KEYCODE_DPAD_RIGHT, FLAG_KEY_FONT | FLAG_PRECISE_REPEAT);
     addEventKey("down", "\uE809", KeyEvent.KEYCODE_DPAD_DOWN, FLAG_KEY_FONT | FLAG_PRECISE_REPEAT);


### PR DESCRIPTION
Fix #53.

Before:
![return key upside down](https://user-images.githubusercontent.com/13970628/152239492-855d8ebe-f981-40cb-8494-38b089c73034.png)

After:
![Screenshot_2022-02-02-22-15-37-09_c7d7c78e17792d54d6e4296d9f6a5da4](https://user-images.githubusercontent.com/13970628/152239477-a9e23748-cfc1-4a3a-9c33-fe448c78a1fd.jpg)