### PR TITLE
Add delete-word-key

### DIFF
--- a/res/xml/azerty.xml
+++ b/res/xml/azerty.xml
@@ -32,7 +32,7 @@
     <key key0="v" key3=";" key4="."/>
     <key key0="b" key3=":" key4="/"/>
     <key key0="n" key1="accent_tilde" key2="§" key4="!"/>
-    <key width="2.0" key0="backspace" key2="delete"/>
+    <key width="2.0" key0="backspace" key1="ctrl_backspace" key2="delete"/>
   </row>
   <row height="0.95">
     <key width="1.8" key0="ctrl" key3="switch_numeric"/>

--- a/res/xml/qwerty.xml
+++ b/res/xml/qwerty.xml
@@ -32,7 +32,7 @@
     <key key0="b" key2="\?" key3="/"/>
     <key key0="n" key1="accent_tilde" key2=":" key3=";"/>
     <key key0="m" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" key0="backspace" key1="ctrl_backspace" key2="delete"/>
   </row>
   <row height="0.95">
     <key width="1.8" key0="ctrl" key3="switch_numeric"/>

--- a/res/xml/qwerty_lv.xml
+++ b/res/xml/qwerty_lv.xml
@@ -32,7 +32,7 @@
     <key key0="b" key3="&lt;" key4="&gt;" />
     <key key0="n" key1="ņ" key2="`" key3=":" key4=";" />
     <key key0="m" key1="'" key2="&quot;" key3="," key4="\?" />
-    <key width="1.5" key0="backspace" key2="delete" />
+    <key width="1.5" key0="backspace" key1="ctrl_backspace" key2="delete" />
   </row>
   <row height="0.95">
     <key width="1.8" key0="ctrl" key3="switch_numeric" />

--- a/res/xml/qwertz.xml
+++ b/res/xml/qwertz.xml
@@ -32,7 +32,7 @@
     <key key0="b" key1=";" key3=","/>
     <key key0="n" key1=":" key3="." key4="accent_tilde"/>
     <key key0="m" key1="_" />
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" key0="backspace" key1="ctrl_backspace" key2="delete"/>
   </row>
   <row height="0.95">
     <key width="1.8" key0="ctrl" key3="switch_numeric"/>

--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -234,6 +234,7 @@ class KeyValue
     addEventKey("home", "↖", KeyEvent.KEYCODE_MOVE_HOME);
     addEventKey("end", "↗", KeyEvent.KEYCODE_MOVE_END);
     addEventKey("backspace", "⌫", KeyEvent.KEYCODE_DEL, FLAG_PRECISE_REPEAT);
+    addEventKey("ctrl_backspace", "⌫⌫", KeyEvent.KEYCODE_DEL, FLAG_PRECISE_REPEAT | FLAG_CTRL);
     addEventKey("delete", "⌦", KeyEvent.KEYCODE_FORWARD_DEL, FLAG_PRECISE_REPEAT);
     addEventKey("insert", "Ins", KeyEvent.KEYCODE_INSERT);
     addEventKey("f1", "F1", KeyEvent.KEYCODE_F1);


### PR DESCRIPTION
Implement a delete-word key (=`Ctrl-backspace`) and add it as top-left corner key to the backspace key (in all layouts). This does not exactly implement #46 but it makes deleting a whole word much easier.

![Screenshot_2022-02-03-19-09-04-22_c7d7c78e17792d54d6e4296d9f6a5da4](https://user-images.githubusercontent.com/13970628/152403539-e123537e-2b85-4d6b-9140-fc1879868140.jpg)

Maybe you have an idea for a better symbol than `⌫⌫` for deleting a whole word.