### PR TITLE
add colon symbol to numeric keyboard

### DIFF
--- a/res/xml/numeric.xml
+++ b/res/xml/numeric.xml
@@ -28,7 +28,7 @@
   <row height="0.95">
     <key width="1.5" key0="ctrl" key3="switch_text"/>
     <key width="1.5" key0="0"/>
-    <key width="0.75" key0="." key2=","/>
+    <key width="0.75" key0="." key1=":" key2=","/>
     <key width="0.75" key0="space" key1="&quot;" key2="'" key4="_"/>
     <key width="1.5" key0="enter" key1="±" key2="action" key3="="/>
   </row>


### PR DESCRIPTION
The colon symbol : is used together with numbers really all the time, it should be available in the numeric keypad
