### PR TITLE
add-ordinal-numbers-symbol-system

### DIFF
--- a/res/xml/numeric.xml
+++ b/res/xml/numeric.xml
@@ -20,7 +20,7 @@
   </row>
   <row>
     <key shift="0.35" width="1.15" key0="shift" key2="fn" key4="alt"/>
-    <key key0="1" key1="superscript" key3="subscript"/>
+    <key key0="1" key1="superscript" key2="ordinal" key3="subscript"/>
     <key key0="2"/>
     <key key0="3"/>
     <key width="1.15" key0="backspace" key2="delete"/>

--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -113,6 +113,22 @@ class KeyModifier
         {
           default: return (char)KeyCharacterMap.getDeadChar('\u00AF', c);
         }
+      case KeyValue.FLAG_ACCENT_ORDINAL:
+        switch (c)
+        {
+          case 'a': return 'ª';
+          case 'o': return 'º';
+          case '1': return 'ª';
+          case '2': return 'º';
+          case '3': return 'ⁿ';
+          case '4': return 'ᵈ';
+          case '5': return 'ᵉ';
+          case '6': return 'ʳ';
+          case '7': return 'ˢ';
+          case '8': return 'ᵗ';
+          case '9': return 'ʰ';
+          default: return c;
+        }
       case KeyValue.FLAG_ACCENT_SUPERSCRIPT:
         switch (c)
         {

--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -46,11 +46,13 @@ class KeyValue
   public static final int FLAG_ACCENT_RING = (1 << 24);
   public static final int FLAG_ACCENT_CARON = (1 << 26);
   public static final int FLAG_ACCENT_MACRON = (1 << 27);
+  public static final int FLAG_ACCENT_ORDINAL = (1 << 28);
+
 
   public static final int FLAGS_ACCENTS = FLAG_ACCENT1 | FLAG_ACCENT2 |
     FLAG_ACCENT3 | FLAG_ACCENT4 | FLAG_ACCENT5 | FLAG_ACCENT6 |
     FLAG_ACCENT_CARON | FLAG_ACCENT_MACRON | FLAG_ACCENT_SUPERSCRIPT |
-    FLAG_ACCENT_SUBSCRIPT | FLAG_ACCENT_RING;
+    FLAG_ACCENT_SUBSCRIPT | FLAG_ACCENT_ORDINAL | FLAG_ACCENT_RING;
 
   // Language specific keys
   public static final int FLAG_LANG_SZLIG = (1 << 25);
@@ -58,7 +60,7 @@ class KeyValue
   public static final int FLAGS_LANGS = FLAG_LANG_SZLIG;
 
   public static final int FLAGS_NOT_HIDDEN_ACCENTS = FLAG_ACCENT_SUPERSCRIPT |
-    FLAG_ACCENT_SUBSCRIPT;
+    FLAG_ACCENT_SUBSCRIPT | FLAG_ACCENT_ORDINAL;
   // Keys that have to be enabled per language
   public static final int FLAGS_HIDDEN_KEYS =
     (FLAGS_ACCENTS & ~FLAGS_NOT_HIDDEN_ACCENTS) | FLAGS_LANGS;
@@ -164,6 +166,7 @@ class KeyValue
     addModifierKey("accent_ring", "◌̊", FLAG_ACCENT_RING);
     addModifierKey("superscript", "◌͆", FLAG_ACCENT_SUPERSCRIPT);
     addModifierKey("subscript", "◌̺", FLAG_ACCENT_SUBSCRIPT);
+    addModifierKey("ordinal", "ºʳᵈ", FLAG_ACCENT_ORDINAL);
     addModifierKey("fn", "Fn", FLAG_FN);
     addModifierKey("meta", "◆", FLAG_META);
 


### PR DESCRIPTION
Add a way to input ordinal markers, using the accent system inside the numeric keypad.
So we can type 1ª (primeira) , 2º (segundo) , 1ˢᵗ , 2ⁿᵈ , 3ʳᵈ, 20ᵗʰ, 50ʳᵉ, 60ᵈᵉʳ
(note that especially the ª º are NOT superscript 'a o'. they are specific symbols for ordinals)
The other letters can be combined for a broad range of different languages ᵉ ᵉʳᵈ ᵈᵉʳ ʳᵉ ˢᵗ ʳᵉˢ ᵈᵉʳˢ ᵉˢ ᵈˢ ⁿᵈ ʳᵈ ᵗʰ

![Screenshot_20220217-063733_Brave_1](https://user-images.githubusercontent.com/25059996/154476823-1239c455-f6f5-44d7-8052-b561864c7f72.jpg)

![Screenshot_20220217-063749_Brave_1](https://user-images.githubusercontent.com/25059996/154476862-ddcb0c92-24b2-4abf-b30b-cc7ab82aff1d.jpg)


