### PR TITLE
Add a missing full stop to Latvian QWERTY layout

### DIFF
--- a/res/xml/qwerty_lv.xml
+++ b/res/xml/qwerty_lv.xml
@@ -29,9 +29,9 @@
     <key key0="x"/>
     <key key0="c" key1="č"/>
     <key key0="v"/>
-    <key key0="b" key3="&lt;" key4="&gt;"/>
+    <key key0="b" key2="\?" key3="&lt;" key4="&gt;"/>
     <key key0="n" key1="ņ" key2="`" key3=":" key4=";"/>
-    <key key0="m" key1="'" key2="&quot;" key3="," key4="\?"/>
+    <key key0="m" key1="'" key2="&quot;" key3="," key4="."/>
     <key width="1.5" key0="backspace" key2="delete"/>
   </row>
 </keyboard>


### PR DESCRIPTION
`res/xml/qwerty_lv.xml` was updated to add the missing full stop character (`.`) as it got lost when the bottom row was moved to a separate XML `res/xml/bottom_row.xml` as it was placed on the arrows key.
Additionally `?` was relocated, giving its place to the full stop.
