### PR TITLE
Increase max size of char label, for big screens

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -26,7 +26,7 @@
   <string name="pref_keyboard_height_title">Keyboard height</string>
   <string name="pref_horizontal_margin_title">Horizontal margin</string>
   <string name="pref_character_size_title">Label size</string>
-  <string name="pref_character_size_summary">Size of characters displayed on the keyboard (%.2fx)</string>
+  <string name="pref_character_size_summary">Size of characters displayed on the keyboard (%.2fx) \r\nA value greater than 1.2 is intended for big screens,ex tablets</string>
   <string name="pref_theme">Theme</string>
   <string name="pref_theme_e_system">System settings</string>
   <string name="pref_theme_e_dark">Dark</string>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -19,7 +19,7 @@
     <juloo.common.IntSlideBarPreference android:key="margin_bottom" android:title="@string/pref_margin_bottom_title" android:summary="%sdp" android:defaultValue="5" min="0" max="100"/>
     <juloo.common.IntSlideBarPreference android:key="keyboard_height" android:title="@string/pref_keyboard_height_title" android:summary="%s%%" android:defaultValue="35" min="25" max="50"/>
     <juloo.common.IntSlideBarPreference android:key="horizontal_margin" android:title="@string/pref_horizontal_margin_title" android:summary="%sdp" android:defaultValue="3" min="0" max="20"/>
-    <juloo.common.SlideBarPreference android:key="character_size" android:title="@string/pref_character_size_title" android:summary="@string/pref_character_size_summary" android:defaultValue="1.0" min="0.8" max="1.2"/>
+    <juloo.common.SlideBarPreference android:key="character_size" android:title="@string/pref_character_size_title" android:summary="@string/pref_character_size_summary" android:defaultValue="1.0" min="0.8" max="2.2"/>
     <juloo.common.IntSlideBarPreference android:key="key_vertical_space" android:title="@string/pref_key_vertical_space" android:summary="%sdp" android:defaultValue="2" min="0" max="8"/>
     <juloo.common.IntSlideBarPreference android:key="key_horizontal_space" android:title="@string/pref_key_horizontal_space" android:summary="%sdp" android:defaultValue="2" min="0" max="8"/>
   </PreferenceCategory>


### PR DESCRIPTION
This fix issue #83

Also issue #78 may or may not benefit from this.

Increasing the max allowed char label size. The current max is too small for tablet resolutions.

I also added a description, so if user goes overboard with the label size setting in a small screen and it ends up looking weird, there is the reason why.

![image](https://user-images.githubusercontent.com/25059996/155811723-46bc0762-fd56-4e0b-8e15-5bdd6edba540.png)

