### PR TITLE
Upgrade CI workflow

### DIFF
--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   Build-Apk:
-    runs-on: ubuntu-20.04 # That is the latest OS version available today
+    runs-on: ubuntu-latest
     steps:
     - name: Cache fontforge and extra dependencies
       id: cache_localbin

--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -7,17 +7,23 @@ on:
 
 jobs:
   Build-Apk:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04 # That is the latest OS version available today
     steps:
-    - name: Tweaks to get more recent version of fontforge
-      run: |
-        # Dirty: Get a more recent version of fontforge
-        sudo sed -i 's/focal/impish/g' /etc/apt/sources.list
-        sudo apt-get update -y
+    # Dirty OS upgrade to get newer version of FontForge
+    # - name: Tweaks to get more recent version of fontforge
+    #   run: |
+    #     # Dirty: Get a more recent version of fontforge
+    #     sudo sed -i 's/focal/impish/g' /etc/apt/sources.list
+    #     sudo apt-get update -y
+    # - name: Install external dependencies and cache them
+    #   uses: awalsh128/cache-apt-pkgs-action@v1
+    #   with:
+    #     packages: fontforge fontforge-common libfontforge4 libpython3.9 libgtk-3-0
+    #     version: 1.0
     - name: Install external dependencies and cache them
       uses: awalsh128/cache-apt-pkgs-action@v1
       with:
-        packages: fontforge fontforge-common libfontforge4 libpython3.9 libgtk-3-0
+        packages: fontforge fontforge-common libfontforge3 libgdraw6 libc6 libpython3.8 libuninameslist1 libgtk-3-0
         version: 1.0
     - name: Try to install fontforge again to get any missing non cached dependency
       run: sudo apt-get install -y fontforge

--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -10,17 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Cache fontforge and extra dependencies
-      id: cache_localbin
       uses: actions/cache@v2
       with:
         path: /usr/local/bin
         key: usr-local-bin
     - name: Install latest FontForge version (using AppImage)
-      if: steps.cache_localbin.outputs.cache-hit != 'true'
       run: |
         # Get most recent version of FontForge
         # Using AppImage there is no dependecy problem, it is the latest version and it's easier to cache
-        # -------
         cd /usr/local/bin
         sudo wget -c -N https://github.com/fontforge/fontforge/releases/download/20220308/FontForge-2022-03-08-582bd41-x86_64.AppImage
         sudo chmod +x ./FontForge-2022-03-08-582bd41-x86_64.AppImage

--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -10,17 +10,19 @@ jobs:
     runs-on: ubuntu-20.04 # That is the latest OS version available today
     steps:
     - name: Cache fontforge and extra dependencies
+      id: cache_localbin
       uses: actions/cache@v2
       with:
         path: /usr/local/bin
         key: usr-local-bin
     - name: Install latest FontForge version (using AppImage)
+      if: steps.cache_localbin.outputs.cache-hit != 'true'
       run: |
         # Get most recent version of FontForge
         # Using AppImage there is no dependecy problem, it is the latest version and it's easier to cache
         # -------
         cd /usr/local/bin
-        sudo wget https://github.com/fontforge/fontforge/releases/download/20220308/FontForge-2022-03-08-582bd41-x86_64.AppImage
+        sudo wget -c -N https://github.com/fontforge/fontforge/releases/download/20220308/FontForge-2022-03-08-582bd41-x86_64.AppImage
         sudo chmod +x ./FontForge-2022-03-08-582bd41-x86_64.AppImage
         sudo ln --symbolic --force /usr/local/bin/FontForge-2022-03-08-582bd41-x86_64.AppImage /usr/local/bin/fontforge
     - uses: actions/setup-java@v2

--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -9,24 +9,20 @@ jobs:
   Build-Apk:
     runs-on: ubuntu-20.04 # That is the latest OS version available today
     steps:
-    # Dirty OS upgrade to get newer version of FontForge
-    # - name: Tweaks to get more recent version of fontforge
-    #   run: |
-    #     # Dirty: Get a more recent version of fontforge
-    #     sudo sed -i 's/focal/impish/g' /etc/apt/sources.list
-    #     sudo apt-get update -y
-    # - name: Install external dependencies and cache them
-    #   uses: awalsh128/cache-apt-pkgs-action@v1
-    #   with:
-    #     packages: fontforge fontforge-common libfontforge4 libpython3.9 libgtk-3-0
-    #     version: 1.0
-    - name: Install external dependencies and cache them
-      uses: awalsh128/cache-apt-pkgs-action@v1
+    - name: Cache fontforge and extra dependencies
+      uses: actions/cache@v2
       with:
-        packages: fontforge fontforge-common libfontforge3 libgdraw6 libc6 libpython3.8 libuninameslist1 libgtk-3-0
-        version: 1.0
-    - name: Try to install fontforge again to get any missing non cached dependency
-      run: sudo apt-get install -y fontforge
+        path: /usr/local/bin
+        key: usr-local-bin
+    - name: Install latest FontForge version (using AppImage)
+      run: |
+        # Get most recent version of FontForge
+        # Using AppImage there is no dependecy problem, it is the latest version and it's easier to cache
+        # -------
+        cd /usr/local/bin
+        sudo wget https://github.com/fontforge/fontforge/releases/download/20220308/FontForge-2022-03-08-582bd41-x86_64.AppImage
+        sudo chmod +x ./FontForge-2022-03-08-582bd41-x86_64.AppImage
+        sudo ln -s /usr/local/bin/FontForge-2022-03-08-582bd41-x86_64.AppImage /usr/local/bin/fontforge
     - uses: actions/setup-java@v2
       with:
         distribution: 'zulu' # See 'Supported distributions' for available options

--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -22,7 +22,7 @@ jobs:
         cd /usr/local/bin
         sudo wget https://github.com/fontforge/fontforge/releases/download/20220308/FontForge-2022-03-08-582bd41-x86_64.AppImage
         sudo chmod +x ./FontForge-2022-03-08-582bd41-x86_64.AppImage
-        sudo ln -s /usr/local/bin/FontForge-2022-03-08-582bd41-x86_64.AppImage /usr/local/bin/fontforge
+        sudo ln --symbolic --force /usr/local/bin/FontForge-2022-03-08-582bd41-x86_64.AppImage /usr/local/bin/fontforge
     - uses: actions/setup-java@v2
       with:
         distribution: 'zulu' # See 'Supported distributions' for available options

--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -17,8 +17,10 @@ jobs:
     - name: Install external dependencies and cache them
       uses: awalsh128/cache-apt-pkgs-action@v1
       with:
-        packages: fontforge
+        packages: fontforge fontforge-common libfontforge4 libpython3.9 libgtk-3-0
         version: 1.0
+    - name: Try to install fontforge again to get any missing non cached dependency
+      run: sudo apt-get install -y fontforge
     - uses: actions/setup-java@v2
       with:
         distribution: 'zulu' # See 'Supported distributions' for available options

--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -36,6 +36,18 @@ jobs:
       with:
         path: _build/debug.keystore
         key: debug-keystore
+    - name: Restore debug keystore from github Secrets 
+      run: |
+        echo `pwd`
+        echo "$GITHUB_WORKSPACE"
+        mkdir -p _build
+        cd "$GITHUB_WORKSPACE/_build"
+        if [[ ! "${{ secrets.DEBUG_KEYSTORE }}" == "" ]]; then
+            echo "${{ secrets.DEBUG_KEYSTORE }}" > "debug.keystore.asc"
+            if [[ -s "debug.keystore.asc" ]]; then
+                gpg -d --passphrase "debug0" --batch "debug.keystore.asc" > "debug.keystore"
+            fi
+        fi
     - name: Build
       run: make
     - name: Save debug apk

--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -9,12 +9,16 @@ jobs:
   Build-Apk:
     runs-on: ubuntu-20.04
     steps:
-    - name: Install external dependencies
+    - name: Tweaks to get more recent version of fontforge
       run: |
         # Dirty: Get a more recent version of fontforge
         sudo sed -i 's/focal/impish/g' /etc/apt/sources.list
         sudo apt-get update -y
-        sudo apt-get install -y fontforge
+    - name: Install external dependencies and cache them
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: fontforge
+        version: 1.0
     - uses: actions/setup-java@v2
       with:
         distribution: 'zulu' # See 'Supported distributions' for available options

--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -38,10 +38,11 @@ jobs:
         key: debug-keystore
     - name: Restore debug keystore from github Secrets 
       run: |
-        echo `pwd`
-        echo "$GITHUB_WORKSPACE"
         mkdir -p _build
         cd "$GITHUB_WORKSPACE/_build"
+        # Check if exist and use the secret named DEBUG_KEYSTORE
+        # The contents of the secret can be obtained -
+        #    from the debug.keystore.asc from you local _build folder
         if [[ ! "${{ secrets.DEBUG_KEYSTORE }}" == "" ]]; then
             echo "${{ secrets.DEBUG_KEYSTORE }}" > "debug.keystore.asc"
             if [[ -s "debug.keystore.asc" ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.keystore
+*.keystore.asc
 _build
 /*-keystore.conf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,24 @@ make
 If the build succeed, the debug apk is located in
 `_build/juloo.keyboard2.debug.apk`.
 
+## Using the local debug.keystore on the Github CI actions
+
+It's possible to save the local debug.keystore into a github secret, so the same keystore is utilized to build the debug apk in the CI github actions.
+Doing this, they wil have the same signature, thus the debug apk can be updated without having to uninstall it first.
+
+After you sucessfully run `make`, (thus a debug.keystore exists) you can use this second command to generate a base64 stringified version of it
+
+```sh
+cd _build
+gpg -c --armor --pinentry-mode loopback --passphrase debug0 --yes "debug.keystore"
+```
+
+A file will be generated inside the local `_build/` folder, called `debug.keystore.asc`
+
+You can copy the content of this file, and with that, paste it into a new github secret in your repo settings. 
+
+The secret must be named `DEBUG_KEYSTORE`
+
 ## Debugging on your phone
 
 First [Enable adb debugging on your device](https://developer.android.com/studio/command-line/adb#Enabling).

--- a/Makefile
+++ b/Makefile
@@ -97,12 +97,13 @@ $(R_FILE): $(RES_FILES) $(MANIFEST_FILE)
 
 # Special font
 
-SPECIAL_FONT_GLYPHS = $(wildcard srcs/special_font/*.svg)
-SPECIAL_FONT_SCRIPT = srcs/special_font/build.pe
+CURRENT_DIRECTORY := $(shell pwd)
+SPECIAL_FONT_GLYPHS = $(wildcard $(CURRENT_DIRECTORY)/srcs/special_font/*.svg)
+SPECIAL_FONT_SCRIPT = $(CURRENT_DIRECTORY)/srcs/special_font/build.pe
 
 _build/assets/special_font.ttf: $(SPECIAL_FONT_SCRIPT) $(SPECIAL_FONT_GLYPHS)
 	mkdir -p $(@D)
-	fontforge -lang=ff -script $(SPECIAL_FONT_SCRIPT) $@ $(SPECIAL_FONT_GLYPHS)
+	fontforge -lang=ff -script $(SPECIAL_FONT_SCRIPT) $(CURRENT_DIRECTORY)/$@ $(SPECIAL_FONT_GLYPHS)
 
 # Compile java classes and build classes.dex
 

--- a/Makefile
+++ b/Makefile
@@ -97,13 +97,12 @@ $(R_FILE): $(RES_FILES) $(MANIFEST_FILE)
 
 # Special font
 
-CURRENT_DIRECTORY := $(shell pwd)
-SPECIAL_FONT_GLYPHS = $(wildcard $(CURRENT_DIRECTORY)/srcs/special_font/*.svg)
-SPECIAL_FONT_SCRIPT = $(CURRENT_DIRECTORY)/srcs/special_font/build.pe
+SPECIAL_FONT_GLYPHS = $(wildcard $(CURDIR)/srcs/special_font/*.svg)
+SPECIAL_FONT_SCRIPT = $(CURDIR)/srcs/special_font/build.pe
 
 _build/assets/special_font.ttf: $(SPECIAL_FONT_SCRIPT) $(SPECIAL_FONT_GLYPHS)
 	mkdir -p $(@D)
-	fontforge -lang=ff -script $(SPECIAL_FONT_SCRIPT) $(CURRENT_DIRECTORY)/$@ $(SPECIAL_FONT_GLYPHS)
+	fontforge -lang=ff -script $(SPECIAL_FONT_SCRIPT) $(CURDIR)/$@ $(SPECIAL_FONT_GLYPHS)
 
 # Compile java classes and build classes.dex
 

--- a/Makefile
+++ b/Makefile
@@ -49,14 +49,18 @@ RES_FILES = $(shell find $(RES_DIR) -type f)
 # Debug signing
 
 DEBUG_KEYSTORE = _build/debug.keystore
+DEBUG_KEYSTORE_ASC = _build/debug.keystore.asc
 DEBUG_PASSWD = debug0
+
+$(DEBUG_KEYSTORE_ASC):
+	gpg -c --armor --output "$@" --pinentry-mode loopback --passphrase debug0 --yes $(DEBUG_KEYSTORE)
 
 $(DEBUG_KEYSTORE):
 	echo y | keytool -genkeypair -dname "cn=d, ou=e, o=b, c=ug" \
 		-alias debug -keypass $(DEBUG_PASSWD) -keystore "$@" \
 		-keyalg rsa -storepass $(DEBUG_PASSWD) -validity 10000
 
-_build/%.debug.apk: _build/%.debug.unsigned-apk $(DEBUG_KEYSTORE)
+_build/%.debug.apk: _build/%.debug.unsigned-apk $(DEBUG_KEYSTORE) $(DEBUG_KEYSTORE_ASC)
 	$(ANDROID_BUILD_TOOLS)/apksigner sign --in "$<" --out "$@" \
 		--ks $(DEBUG_KEYSTORE) --ks-key-alias debug --ks-pass "pass:$(DEBUG_PASSWD)"
 

--- a/Makefile
+++ b/Makefile
@@ -49,18 +49,14 @@ RES_FILES = $(shell find $(RES_DIR) -type f)
 # Debug signing
 
 DEBUG_KEYSTORE = _build/debug.keystore
-DEBUG_KEYSTORE_ASC = _build/debug.keystore.asc
 DEBUG_PASSWD = debug0
-
-$(DEBUG_KEYSTORE_ASC):
-	gpg -c --armor --output "$@" --pinentry-mode loopback --passphrase debug0 --yes $(DEBUG_KEYSTORE)
 
 $(DEBUG_KEYSTORE):
 	echo y | keytool -genkeypair -dname "cn=d, ou=e, o=b, c=ug" \
 		-alias debug -keypass $(DEBUG_PASSWD) -keystore "$@" \
 		-keyalg rsa -storepass $(DEBUG_PASSWD) -validity 10000
 
-_build/%.debug.apk: _build/%.debug.unsigned-apk $(DEBUG_KEYSTORE) $(DEBUG_KEYSTORE_ASC)
+_build/%.debug.apk: _build/%.debug.unsigned-apk $(DEBUG_KEYSTORE)
 	$(ANDROID_BUILD_TOOLS)/apksigner sign --in "$<" --out "$@" \
 		--ks $(DEBUG_KEYSTORE) --ks-key-alias debug --ks-pass "pass:$(DEBUG_PASSWD)"
 


### PR DESCRIPTION
I got in this rabbit hole, and spent my night without sleeping, but I ended with a working CI flow, which utilizes caches and runs in 40sec after the first cache is done.
The steps are simplified, and there is no dirty OS upgrade anymore in order to get a newer version of FontForge. The new FontForge is self-contained and has no dependency.

Only doubt I have is if its a good thing to cache the whole folder /usr/local/bin, but it's working well so far.