### PR TITLE
`Arrows` and `Box` system

### DIFF
--- a/res/xml/numeric.xml
+++ b/res/xml/numeric.xml
@@ -3,26 +3,26 @@
   <row>
     <key width="0.75" key0="esc" key2="~" key4="!"/>
     <key width="0.75" key0="(" key2="[" key4="{"/>
-    <key key0="7" key1="&lt;" key2="&gt;" key4="↖"/>
-    <key key0="8" key2="∞" key4="↑"/>
-    <key key0="9" key2="π" key4="↗"/>
+    <key key0="7" key1="&lt;" key2="&gt;"/>
+    <key key0="8" key2="∞"/>
+    <key key0="9" key2="π"/>
     <key width="0.75" key0="*" key1="√" key2="×"/>
     <key width="0.75" key0="/" key1="%" key3="÷"/>
   </row>
   <row>
     <key width="0.75" key0="tab" key1=";" key2="|" key4="\\"/>
     <key width="0.75" key0=")" key2="]" key4="}"/>
-    <key key0="4" key1="box" key3="arrows" key4="←"/>
+    <key key0="4" key1="box" key3="arrows"/>
     <key key0="5" key1="up" key2="right" key3="left" key4="down" edgekeys="true"/>
-    <key key0="6" key4="→"/>
+    <key key0="6"/>
     <key width="0.75" key0="+" key1="Σ" key2="$"/>
     <key width="0.75" key0="-" key2="^"/>
   </row>
   <row>
     <key shift="0.35" width="1.15" key0="shift" key2="fn" key4="alt"/>
-    <key key0="1" key1="superscript" key2="ordinal" key3="subscript" key4="↙"/>
-    <key key0="2" key4="↓"/>
-    <key key0="3" key4="↘"/>
+    <key key0="1" key1="superscript" key2="ordinal" key3="subscript"/>
+    <key key0="2"/>
+    <key key0="3"/>
     <key width="1.15" key0="backspace" key2="delete"/>
   </row>
   <row height="0.95">

--- a/res/xml/numeric.xml
+++ b/res/xml/numeric.xml
@@ -12,7 +12,7 @@
   <row>
     <key width="0.75" key0="tab" key1=";" key2="|" key4="\\"/>
     <key width="0.75" key0=")" key2="]" key4="}"/>
-    <key key0="4"/>
+    <key key0="4" key1="box" key3="arrows"/>
     <key key0="5" key1="up" key2="right" key3="left" key4="down" edgekeys="true"/>
     <key key0="6"/>
     <key width="0.75" key0="+" key1="Σ" key2="$"/>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -17,6 +17,7 @@
       <CheckBoxPreference android:key="lockable_meta" android:title="Meta" android:defaultValue="false"/>
       <CheckBoxPreference android:key="lockable_sup" android:title="Sup" android:defaultValue="false"/>
       <CheckBoxPreference android:key="lockable_sub" android:title="Sub" android:defaultValue="false"/>
+      <CheckBoxPreference android:key="lockable_box" android:title="Box" android:defaultValue="false"/>
     </PreferenceScreen>
   </PreferenceCategory>
   <PreferenceCategory android:title="@string/pref_category_vibrate">

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -124,7 +124,8 @@ final class Config
       | (prefs.getBoolean("lockable_fn", false) ? KeyValue.FLAG_FN : 0)
       | (prefs.getBoolean("lockable_meta", false) ? KeyValue.FLAG_META : 0)
       | (prefs.getBoolean("lockable_sup", false) ? KeyValue.FLAG_ACCENT_SUPERSCRIPT : 0)
-      | (prefs.getBoolean("lockable_sub", false) ? KeyValue.FLAG_ACCENT_SUBSCRIPT : 0);
+      | (prefs.getBoolean("lockable_sub", false) ? KeyValue.FLAG_ACCENT_SUBSCRIPT : 0)
+      | (prefs.getBoolean("lockable_box", false) ? KeyValue.FLAG_ACCENT_BOX : 0);
     characterSize = prefs.getFloat("character_size", characterSize);
     accents = Integer.valueOf(prefs.getString("accents", "1"));
     theme = getThemeId(res, prefs.getString("theme", ""));

--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -204,6 +204,7 @@ class KeyModifier
       case "!": name = "¡"; break;
       case "?": name = "¿"; break;
       case "tab": name = "\\t"; break;
+      case "space": name = "nbsp"; break;
       case "€": case "£": return removed_key; // Avoid showing these twice
       default: return k;
     }

--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -145,6 +145,74 @@ class KeyModifier
           case 'o': return 'ₒ';
           default: return c;
         }
+      case KeyValue.FLAG_ACCENT_ARROWS:
+        if ((flags & KeyValue.FLAG_SHIFT) == 0)
+        {
+          switch (c)
+          {
+            case '1': return '↙';
+            case '2': return '↓';
+            case '3': return '↘';
+            case '4': return '←';
+            case '6': return '→';
+            case '7': return '↖';
+            case '8': return '↑';
+            case '9': return '↗';
+            default: return c;
+          }
+        }
+        else
+        {
+          switch (c)
+          {
+            case '1': return '⇙';
+            case '2': return '⇓';
+            case '3': return '⇘';
+            case '4': return '⇐';
+            case '6': return '⇒';
+            case '7': return '⇖';
+            case '8': return '⇑';
+            case '9': return '⇗';
+            default: return c;
+          }
+        }
+      case KeyValue.FLAG_ACCENT_BOX:
+        if ((flags & KeyValue.FLAG_SHIFT) == 0)
+        {
+          switch (c)
+          {
+            case '1': return '└';
+            case '2': return '┴';
+            case '3': return '┘';
+            case '4': return '├';
+            case '5': return '┼';
+            case '6': return '┤';
+            case '7': return '┌';
+            case '8': return '┬';
+            case '9': return '┐';
+            case '0': return '─';
+            case '.': return '│';
+            default: return c;
+          }
+        }
+        else
+        {
+          switch (c)
+          {
+            case '1': return '╚';
+            case '2': return '╩';
+            case '3': return '╝';
+            case '4': return '╠';
+            case '5': return '╬';
+            case '6': return '╣';
+            case '7': return '╔';
+            case '8': return '╦';
+            case '9': return '╗';
+            case '0': return '═';
+            case '.': return '║';
+            default: return c;
+          }
+        }
       default: return c; // Can't happen
     }
   }

--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -49,16 +49,8 @@ class KeyModifier
     char c = k.char_;
     if (k.char_ != KeyValue.CHAR_NONE)
       c = Character.toUpperCase(c);
-    if (c == k.char_) // More rules if toUpperCase() did nothing
-      switch (k.symbol)
-      {
-        case "→": c = '⇒'; break;
-        case "←": c = '⇐'; break;
-        case "<": c = '«'; break;
-        case ">": c = '»'; break;
-        case "“": c = '”'; break;
-        default: return k;
-      }
+    if (c == k.char_) // Used to have more rules if toUpperCase() did nothing
+      return k;
     return k.withCharAndSymbol(c);
   }
 
@@ -69,54 +61,27 @@ class KeyModifier
       case KeyValue.FLAG_ACCENT1:
         return (char)KeyCharacterMap.getDeadChar('\u02CB', c);
       case KeyValue.FLAG_ACCENT2:
-        switch (c)
-        {
-          case '`': return '´';
-          case '<': return '‘';
-          case '>': return '‘';
-          default: return (char)KeyCharacterMap.getDeadChar('\u00B4', c);
-        }
+        return (char)KeyCharacterMap.getDeadChar('\u00B4', c);
       case KeyValue.FLAG_ACCENT3:
         return (char)KeyCharacterMap.getDeadChar('\u02C6', c);
       case KeyValue.FLAG_ACCENT4:
-        switch (c)
-        {
-          case '?': return '¿';
-          case '!': return '¡';
-          default: return (char)KeyCharacterMap.getDeadChar('\u02DC', c);
-        }
+        return (char)KeyCharacterMap.getDeadChar('\u02DC', c);
       case KeyValue.FLAG_ACCENT5:
         switch (c)
         {
           case 'u': return 'µ';
-          case '"': return '„';
-          case '\'': return '’';
-          case '-': return '¬';
           case 'a': return 'æ';
           case 'o': return 'œ';
           default: return (char)KeyCharacterMap.getDeadChar('\u00B8', c);
         }
       case KeyValue.FLAG_ACCENT6:
-        switch (c)
-        {
-          case '-': return '÷';
-          default: return (char)KeyCharacterMap.getDeadChar('\u00A8', c);
-        }
+        return (char)KeyCharacterMap.getDeadChar('\u00A8', c);
       case KeyValue.FLAG_ACCENT_CARON:
-        switch (c)
-        {
-          default: return (char)KeyCharacterMap.getDeadChar('\u02C7', c);
-        }
+        return (char)KeyCharacterMap.getDeadChar('\u02C7', c);
       case KeyValue.FLAG_ACCENT_RING:
-        switch (c)
-        {
-          default: return (char)KeyCharacterMap.getDeadChar('\u02DA', c);
-        }
+        return (char)KeyCharacterMap.getDeadChar('\u02DA', c);
       case KeyValue.FLAG_ACCENT_MACRON:
-        switch (c)
-        {
-          default: return (char)KeyCharacterMap.getDeadChar('\u00AF', c);
-        }
+        return (char)KeyCharacterMap.getDeadChar('\u00AF', c);
       case KeyValue.FLAG_ACCENT_ORDINAL:
         switch (c)
         {
@@ -215,15 +180,29 @@ class KeyModifier
       case "down": name = "page_down"; break;
       case "left": name = "home"; break;
       case "right": name = "end"; break;
-      case ">": name = "→"; break;
-      case "<": name = "←"; break;
-      case "\"": name = "“"; break;
+      case "<": name = "«"; break;
+      case ">": name = "»"; break;
+      case "{": name = "‹"; break;
+      case "}": name = "›"; break;
+      case "[": name = "‘"; break;
+      case "]": name = "’"; break;
+      case "(": name = "“"; break;
+      case ")": name = "”"; break;
+      case "'": name = "‚"; break;
+      case "\"": name = "„"; break;
       case "-": name = "–"; break;
       case "_": name = "—"; break;
+      case "^": name = "¬"; break;
+      case "%": name = "‰"; break;
+      case "=": name = "≈"; break;
       case "esc": name = "insert"; break;
       case "$": name = "€"; break;
       case "#": name = "£"; break;
       case "*": name = "°"; break;
+      case ".": name = "…"; break;
+      case ",": name = "·"; break;
+      case "!": name = "¡"; break;
+      case "?": name = "¿"; break;
       case "tab": name = "\\t"; break;
       case "€": case "£": return removed_key; // Avoid showing these twice
       default: return k;

--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -265,5 +265,6 @@ class KeyValue
 
     addKey("\\t", "\\t", '\t', EVENT_NONE, 0); // Send the tab character
     addKey("space", "\r", ' ', KeyEvent.KEYCODE_SPACE, FLAG_KEY_FONT | FLAG_SMALLER_FONT);
+    addKey("nbsp", "\u237d", '\u00a0', EVENT_NONE, FLAG_KEY_FONT | FLAG_SMALLER_FONT);
   }
 }

--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -50,11 +50,14 @@ class KeyValue
   public static final int FLAG_ACCENT_CARON = (1 << 26);
   public static final int FLAG_ACCENT_MACRON = (1 << 27);
   public static final int FLAG_ACCENT_ORDINAL = (1 << 28);
+  public static final int FLAG_ACCENT_ARROWS = (1 << 29);
+  public static final int FLAG_ACCENT_BOX = (1 << 30);
 
   public static final int FLAGS_ACCENTS = FLAG_ACCENT1 | FLAG_ACCENT2 |
     FLAG_ACCENT3 | FLAG_ACCENT4 | FLAG_ACCENT5 | FLAG_ACCENT6 |
     FLAG_ACCENT_CARON | FLAG_ACCENT_MACRON | FLAG_ACCENT_SUPERSCRIPT |
-    FLAG_ACCENT_SUBSCRIPT | FLAG_ACCENT_ORDINAL | FLAG_ACCENT_RING;
+    FLAG_ACCENT_SUBSCRIPT | FLAG_ACCENT_ORDINAL | FLAG_ACCENT_ARROWS | 
+    FLAG_ACCENT_BOX | FLAG_ACCENT_RING;
 
   // Language specific keys that are removed from the keyboard by default
   public static final int FLAG_LOCALIZED = (1 << 25);
@@ -168,6 +171,8 @@ class KeyValue
     addModifierKey("superscript", "Sup", FLAG_ACCENT_SUPERSCRIPT | FLAG_SMALLER_FONT);
     addModifierKey("subscript", "Sub", FLAG_ACCENT_SUBSCRIPT | FLAG_SMALLER_FONT);
     addModifierKey("ordinal", "Ord", FLAG_ACCENT_ORDINAL | FLAG_SMALLER_FONT);
+    addModifierKey("arrows", "Arr", FLAG_ACCENT_ARROWS | FLAG_SMALLER_FONT);
+    addModifierKey("box", "Box", FLAG_ACCENT_BOX | FLAG_SMALLER_FONT);
     addModifierKey("fn", "Fn", FLAG_FN | FLAG_SMALLER_FONT);
     addModifierKey("meta", "◆", FLAG_META);
 


### PR DESCRIPTION
I liked the streamlining of the symbols with FN keys from PR #112,
but I disliked the arrows taking room on all keys on the numeric keyboard. Some of that conflicting with some of my layouts.
So I cherry picked @ArenaL5 commits from his PR, and worked on top of it. Instead of allocating the arrows directly to the keyboard on all keys, I created a Single key for Arrows, using the accent system, and once I was doing that, I also created one for Box frames. Both Arrows and Box can have variations if paired with Shift or Alt in the Box case. The Box key can also be configurable to be Lockable.


![arrows and box](https://user-images.githubusercontent.com/25059996/160286880-497b95dc-b57b-41a7-ab60-1023e67055b2.gif)

