### PR TITLE
Select the closest key on swipe

### DIFF
--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -108,9 +108,11 @@ public class Keyboard2View extends View
   public KeyValue onPointerSwipe(KeyValue k, int flags)
   {
     k = KeyModifier.handleFlags(k, flags);
-    invalidate();
     if (k != null)
+    {
+      invalidate();
       vibrate();
+    }
     return k;
   }
 

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -96,24 +96,15 @@ public class Keyboard2View extends View
     invalidate();
   }
 
-  public KeyValue onPointerDown(KeyValue k, int flags)
+  public KeyValue modifyKey(KeyValue k, int flags)
   {
-    k = KeyModifier.handleFlags(k, flags);
-    invalidate();
-    if (k != null)
-      vibrate();
-    return k;
+    return KeyModifier.handleFlags(k, flags);
   }
 
-  public KeyValue onPointerSwipe(KeyValue k, int flags)
+  public void onPointerDown(boolean isSwipe)
   {
-    k = KeyModifier.handleFlags(k, flags);
-    if (k != null)
-    {
-      invalidate();
-      vibrate();
-    }
-    return k;
+    invalidate();
+    vibrate();
   }
 
   public void onPointerUp(KeyValue k, int flags)

--- a/srcs/juloo.keyboard2/KeyboardData.java
+++ b/srcs/juloo.keyboard2/KeyboardData.java
@@ -195,7 +195,10 @@ class KeyboardData
       return new Key(key0, key1, key2, key3, key4, width * s, shift, edgekeys);
     }
 
-    private KeyValue getAtDirectionExact(int direction)
+    /*
+     * See Pointers.onTouchMove() for the represented direction.
+     */
+    public KeyValue getAtDirection(int direction)
     {
       if (edgekeys)
       {
@@ -226,25 +229,6 @@ class KeyboardData
           case 5: case 6: return key4;
           case 7: case 8: return key3;
         }
-      }
-      return null;
-    }
-
-    /*
-     * Get the KeyValue at the given direction. In case of swipe (!= 0), get the
-     * nearest KeyValue that is not key0. See Pointers.onTouchMove() for the
-     * represented direction.
-     */
-    public KeyValue getAtDirection(int direction)
-    {
-      if (direction == 0)
-        return key0;
-      KeyValue k;
-      for (int i = 0; i > -2; i = (~i>>31) - i)
-      {
-        k = getAtDirectionExact(Math.floorMod(direction + i - 1, 8) + 1);
-        if (k != null)
-          return k;
       }
       return null;
     }

--- a/srcs/juloo.keyboard2/KeyboardData.java
+++ b/srcs/juloo.keyboard2/KeyboardData.java
@@ -195,102 +195,58 @@ class KeyboardData
       return new Key(key0, key1, key2, key3, key4, width * s, shift, edgekeys);
     }
 
-    
-    /* Get the KeyValue at the given direction. See Pointers.onTouchMove() for the represented direction */
-    public KeyValue getAtDirection(int direction)
+    private KeyValue getAtDirectionExact(int direction)
     {
-      if (direction == 0 || direction > 8) return key0;
-      KeyValue key = null;
-      if (edgekeys) {
+      if (edgekeys)
+      {
         // \ 1 /
         //  \ /
         // 3 0 2
         //  / \
         // / 4 \
-        
-        // first closer
         switch (direction)
         {
-          case 2: case 3: key = key1; break;
-          case 4: case 8: key = key2; break;
-          case 1: case 5: key = key3; break;
-          case 6: case 7: key = key4; break;
+          case 2: case 3: return key1;
+          case 4: case 5: return key2;
+          case 6: case 7: return key4;
+          case 8: case 1: return key3;
         }
-        if (key != null) return key;
-        // second closer
-        switch (direction)
-        {
-          case 1: case 4: key = key1; break;
-          case 3: case 7: key = key2; break;
-          case 2: case 6: key = key3; break;
-          case 5: case 8: key = key4; break;
-        }
-        if (key != null) return key;
-        // third closer
-        switch (direction)
-        {
-          case 5: case 8: key = key1; break;
-          case 2: case 6: key = key2; break;
-          case 3: case 7: key = key3; break;
-          case 1: case 4: key = key4; break;
-        }
-        if (key != null) return key;
-        // fourth closer
-        switch (direction)
-        {
-          case 6: case 7: key = key1; break;
-          case 1: case 5: key = key2; break;
-          case 4: case 8: key = key3; break;
-          case 2: case 3: key = key4; break;
-        }
-        if (key != null) return key;
       }
       else
       {
         // 1 | 2
         //   |
         // --0--
-        //   |  
+        //   |
         // 3 | 4
-        // first closer
         switch (direction)
         {
-          case 1: case 2: key = key1; break;
-          case 3: case 4: key = key2; break;
-          case 5: case 6: key = key3; break;
-          case 7: case 8: key = key4; break;
+          case 1: case 2: return key1;
+          case 3: case 4: return key2;
+          case 5: case 6: return key4;
+          case 7: case 8: return key3;
         }
-        if (key != null) return key;
-        // second closer
-        switch (direction)
-        {
-          case 3: case 5: key = key1; break;
-          case 2: case 8: key = key2; break;
-          case 1: case 7: key = key3; break;
-          case 4: case 6: key = key4; break;
-        }
-        if (key != null) return key;
-        // third closer
-        switch (direction)
-        {
-          case 4: case 6: key = key1; break;
-          case 1: case 7: key = key2; break;
-          case 2: case 8: key = key3; break;
-          case 3: case 5: key = key4; break;
-        }
-        if (key != null) return key;
-        // fourth closer
-        switch (direction)
-        {
-          case 7: case 8: key = key1; break;
-          case 3: case 4: key = key2; break;
-          case 5: case 6: key = key3; break;
-          case 1: case 2: key = key4; break;
-        }
-        if (key != null) return key;
       }
-      
-      return key0;
+      return null;
+    }
+
+    /*
+     * Get the KeyValue at the given direction. In case of swipe (!= 0), get the
+     * nearest KeyValue that is not key0. See Pointers.onTouchMove() for the
+     * represented direction.
+     */
+    public KeyValue getAtDirection(int direction)
+    {
+      if (direction == 0)
+        return key0;
+      KeyValue k;
+      for (int i = 0; i > -2; i = (~i>>31) - i)
+      {
+        k = getAtDirectionExact(Math.floorMod(direction + i - 1, 8) + 1);
+        if (k != null)
+          return k;
+      }
+      return null;
     }
   }
 

--- a/srcs/juloo.keyboard2/KeyboardData.java
+++ b/srcs/juloo.keyboard2/KeyboardData.java
@@ -197,14 +197,98 @@ class KeyboardData
 
     public KeyValue getValue(int index)
     {
-      switch (index)
-      {
-        case 1: return key1;
-        case 2: return key2;
-        case 3: return key3;
-        case 4: return key4;
-        default: case 0: return key0;
+      if (index == 0 || index > 8) return key0;
+      KeyValue key = null;
+      if (edgekeys) {
+        // \ 1 /
+        //  \ /
+        // 3 0 2
+        //  / \
+        // / 4 \
+        
+        // first closer
+        switch (index)
+        {
+          case 2: case 3: key = key1; break;
+          case 4: case 8: key = key2; break;
+          case 1: case 5: key = key3; break;
+          case 6: case 7: key = key4; break;
+        }
+        if (key != null) return key;
+        // second closer
+        switch (index)
+        {
+          case 1: case 4: key = key1; break;
+          case 3: case 7: key = key2; break;
+          case 2: case 6: key = key3; break;
+          case 5: case 8: key = key4; break;
+        }
+        if (key != null) return key;
+        // third closer
+        switch (index)
+        {
+          case 5: case 8: key = key1; break;
+          case 2: case 6: key = key2; break;
+          case 3: case 7: key = key3; break;
+          case 1: case 4: key = key4; break;
+        }
+        if (key != null) return key;
+        // fourth closer
+        switch (index)
+        {
+          case 6: case 7: key = key1; break;
+          case 1: case 5: key = key2; break;
+          case 4: case 8: key = key3; break;
+          case 2: case 3: key = key4; break;
+        }
+        if (key != null) return key;
       }
+      else
+      {
+        // 1 | 2
+        //   |
+        // --0--
+        //   |  
+        // 3 | 4
+        // first closer
+        switch (index)
+        {
+          case 1: case 2: key = key1; break;
+          case 3: case 4: key = key2; break;
+          case 5: case 6: key = key3; break;
+          case 7: case 8: key = key4; break;
+        }
+        if (key != null) return key;
+        // second closer
+        switch (index)
+        {
+          case 3: case 5: key = key1; break;
+          case 2: case 8: key = key2; break;
+          case 1: case 7: key = key3; break;
+          case 4: case 6: key = key4; break;
+        }
+        if (key != null) return key;
+        // third closer
+        switch (index)
+        {
+          case 4: case 6: key = key1; break;
+          case 1: case 7: key = key2; break;
+          case 2: case 8: key = key3; break;
+          case 3: case 5: key = key4; break;
+        }
+        if (key != null) return key;
+        // fourth closer
+        switch (index)
+        {
+          case 7: case 8: key = key1; break;
+          case 3: case 4: key = key2; break;
+          case 5: case 6: key = key3; break;
+          case 1: case 2: key = key4; break;
+        }
+        if (key != null) return key;
+      }
+      
+      return key0;
     }
   }
 

--- a/srcs/juloo.keyboard2/KeyboardData.java
+++ b/srcs/juloo.keyboard2/KeyboardData.java
@@ -195,9 +195,11 @@ class KeyboardData
       return new Key(key0, key1, key2, key3, key4, width * s, shift, edgekeys);
     }
 
-    public KeyValue getValue(int index)
+    
+    /* Get the KeyValue at the given direction. See Pointers.onTouchMove() for the represented direction */
+    public KeyValue getAtDirection(int direction)
     {
-      if (index == 0 || index > 8) return key0;
+      if (direction == 0 || direction > 8) return key0;
       KeyValue key = null;
       if (edgekeys) {
         // \ 1 /
@@ -207,7 +209,7 @@ class KeyboardData
         // / 4 \
         
         // first closer
-        switch (index)
+        switch (direction)
         {
           case 2: case 3: key = key1; break;
           case 4: case 8: key = key2; break;
@@ -216,7 +218,7 @@ class KeyboardData
         }
         if (key != null) return key;
         // second closer
-        switch (index)
+        switch (direction)
         {
           case 1: case 4: key = key1; break;
           case 3: case 7: key = key2; break;
@@ -225,7 +227,7 @@ class KeyboardData
         }
         if (key != null) return key;
         // third closer
-        switch (index)
+        switch (direction)
         {
           case 5: case 8: key = key1; break;
           case 2: case 6: key = key2; break;
@@ -234,7 +236,7 @@ class KeyboardData
         }
         if (key != null) return key;
         // fourth closer
-        switch (index)
+        switch (direction)
         {
           case 6: case 7: key = key1; break;
           case 1: case 5: key = key2; break;
@@ -251,7 +253,7 @@ class KeyboardData
         //   |  
         // 3 | 4
         // first closer
-        switch (index)
+        switch (direction)
         {
           case 1: case 2: key = key1; break;
           case 3: case 4: key = key2; break;
@@ -260,7 +262,7 @@ class KeyboardData
         }
         if (key != null) return key;
         // second closer
-        switch (index)
+        switch (direction)
         {
           case 3: case 5: key = key1; break;
           case 2: case 8: key = key2; break;
@@ -269,7 +271,7 @@ class KeyboardData
         }
         if (key != null) return key;
         // third closer
-        switch (index)
+        switch (direction)
         {
           case 4: case 6: key = key1; break;
           case 1: case 7: key = key2; break;
@@ -278,7 +280,7 @@ class KeyboardData
         }
         if (key != null) return key;
         // fourth closer
-        switch (index)
+        switch (direction)
         {
           case 7: case 8: key = key1; break;
           case 3: case 4: key = key2; break;

--- a/srcs/juloo.keyboard2/Pointers.java
+++ b/srcs/juloo.keyboard2/Pointers.java
@@ -146,6 +146,11 @@ public final class Pointers implements Handler.Callback
     Pointer ptr = getPtr(pointerId);
     if (ptr == null)
       return;
+
+    // The position in a IME windows is clampled to view.
+    // For a better up swipe behaviour, set the y position to a negative value when clamped.
+    if (y == 0.0) y = -400;
+
     float dx = x - ptr.downX;
     float dy = y - ptr.downY;
     float dist = Math.abs(dx) + Math.abs(dy);
@@ -155,19 +160,17 @@ public final class Pointers implements Handler.Callback
     {
       newIndex = 0;
     }
-    else if (ptr.key.edgekeys)
-    {
-      if (Math.abs(dy) > Math.abs(dx)) // vertical swipe
-        newIndex = (dy < 0) ? 1 : 4;
-      else // horizontal swipe
-        newIndex = (dx < 0) ? 3 : 2;
-    }
-    else
-    {
-      if (dx < 0) // left side
-        newIndex = (dy < 0) ? 1 : 3;
-      else // right side
-        newIndex = (dy < 0) ? 2 : 4;
+    else {
+        // One of the 8 directions:
+        // |\2|3/|
+        // |1\|/4|
+        // |-----|
+        // |5/|\8|
+        // |/6|7\|
+        newIndex = 1;
+        if (dy > 0) newIndex += 4;
+        if (dx > 0) newIndex += 2;
+        if (dx > Math.abs(dy) || (dx < 0 && dx > -Math.abs(dy))) newIndex += 1;
     }
     if (newIndex != ptr.value_index)
     {

--- a/srcs/juloo.keyboard2/Pointers.java
+++ b/srcs/juloo.keyboard2/Pointers.java
@@ -167,12 +167,12 @@ public final class Pointers implements Handler.Callback
       // |\2|3/|
       // |1\|/4|
       // |-----|
-      // |5/|\8|
-      // |/6|7\|
+      // |8/|\5|
+      // |/7|6\|
       direction = 1;
-      if (dy > 0) direction += 4;
       if (dx > 0) direction += 2;
       if (dx > Math.abs(dy) || (dx < 0 && dx > -Math.abs(dy))) direction += 1;
+      if (dy > 0) direction = 9 - direction;
     }
 
     KeyValue newSelectedValue = ptr.key.getAtDirection(direction);


### PR DESCRIPTION
I have seen a [Google Play review (in Portuguese)](https://play.google.com/store/apps/details?id=juloo.keyboard2&hl=pt_BR&gl=US&reviewId=gp%3AAOqpTOEjFVJva0Z97IWxFpGxBGCbGh3Dzpo4BGEqO0xC0v5uJTtZGegDXELaXkt7NbwBjQ8hQ9GZH-OV0OAw4g) suggesting (among others) that 0 could be recognized with an up swipe, regardless of the direction (since the 0 has a different direction from the other numbers, probably).

So I decided to solve this by always choosing the closest key to the swipe direction. So instead of computing the index of the key in `onTouchMove`, I compute the direction of the swipe (from 1 to 8, 0 is no swipe) and I replaced `Key.getValue` by `Key.getAtDirection`, which finds the closest key and handles `edgekeys`. Now `Pointer` keeps track of `selected_value` instead of `value_index`.