### PR TITLE
Move 'ъ' where it belongs and increase the width of the keys

### DIFF
--- a/res/xml/local_ru_jcuken.xml
+++ b/res/xml/local_ru_jcuken.xml
@@ -10,12 +10,12 @@
     <key key0="г" key2="7" key3="&amp;"/>
     <key key0="ш" key2="8" key3="*"/>
     <key key0="щ" key2="9" key3="(" key4=")"/>
-    <key key0="з" key2="0"/>
-    <key key0="х" key1="{" key2="}" key4="f11_placeholder"/>
-    <key key0="ъ" key1="[" key2="]" key4="f12_placeholder"/>
+    <key key0="з" key2="0" key3="{" key4="}" />
+    <key key0="х" key3="[" key4="]" key1="f11_placeholder" key2="f12_placeholder"/>
+
   </row>
   <row>
-    <key shift="0.5" key0="ф" key1="tab" key2="`"/>
+    <key key0="ф" key1="tab" key2="`"/>
     <key key0="ы"/>
     <key key0="в"/>
     <key key0="а"/>
@@ -28,16 +28,16 @@
     <key key0="э" key2="|" key3="\\"/>
   </row>
   <row>
-    <key width="1.5" key0="shift"/>
-    <key key0="я"/>
-    <key key0="ч"/>
-    <key key0="с"/>
-    <key key0="м"/>
-    <key key0="и" key2="&lt;" key3="."/>
-    <key key0="т" key2="&gt;" key3=","/>
-    <key key0="ь" key2="\?" key3="/"/>
-    <key key0="б" key2=":" key3=";"/>
-    <key key0="ю" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.18" key0="shift"/>
+    <key width="0.96" key0="я"/>
+    <key width="0.96" key0="ч"/>
+    <key width="0.96" key0="с"/>
+    <key width="0.96" key0="м"/>
+    <key width="0.96" key0="и" key2="&lt;" key3="."/>
+    <key width="0.96" key0="т" key2="&gt;" key3=","/>
+    <key width="0.96" key0="ь" key1="ъ" key2="\?" key3="/"/>
+    <key width="0.96" key0="б" key2=":" key3=";"/>
+    <key width="0.96" key0="ю" key2="&quot;" key3="'"/>
+    <key width="1.18" key0="backspace" key2="delete"/>
   </row>
 </keyboard>


### PR DESCRIPTION
The 'ъ' key is rarely used, and therefore we may move it to 'ь', as usual, and then increase the width of the keys.
![ru](https://user-images.githubusercontent.com/107509683/173685202-4fa256f0-8da0-44d3-b637-e5cba7408c12.png)
