### PR TITLE
Rename resulting CI artifact

### DIFF
--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -9,14 +9,14 @@ jobs:
   Build-Apk:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v3
       with:
         distribution: 'zulu' # See 'Supported distributions' for available options
         java-version: '11'
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Cache debug certificate
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: _build/debug.keystore
         key: debug-keystore
@@ -35,8 +35,13 @@ jobs:
         fi
     - name: Build
       run: make
+    - name: Artifact naming
+      run: |
+        artifact="${{github.repository_owner}} ${{github.ref_name}}"
+        artifact="${artifact//\//-}" # replace slashes
+        echo "artifact=${artifact}" >> $GITHUB_ENV
     - name: Save debug apk
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
-        name: "${{github.repository_owner}} ${{github.ref_name}} debug_apk"
+        name: "${{env.artifact}} debug_apk"
         path: _build/*.apk

--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -38,5 +38,5 @@ jobs:
     - name: Save debug apk
       uses: actions/upload-artifact@v2
       with:
-        name: debug apk
+        name: "${{github.repository_owner}} ${{github.ref_name}} debug_apk"
         path: _build/*.apk


### PR DESCRIPTION
Add details to the name of the artifact, to distiguish downloads of it between multiple branches while testing

for example:
the resulting zip file will look like this:

![Screenshot_20220718-010502_Brave](https://user-images.githubusercontent.com/25059996/179448370-7d110669-7696-4787-846c-537144a72c78.jpg)

the unique name for each branch helps a lot while testing/debuging diferent versions
