### PR TITLE
Add white e-ink oriented theme

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -31,6 +31,7 @@
   <string name="pref_theme_e_dark">Sombre</string>
   <string name="pref_theme_e_light">Clair</string>
   <string name="pref_theme_e_black">Noir</string>
+  <string name="pref_theme_e_white">Blanc</string>
   <string name="pref_swipe_dist_e_very_short">Très courte</string>
   <string name="pref_swipe_dist_e_short">Courte</string>
   <string name="pref_swipe_dist_e_default">Normale</string>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -67,12 +67,14 @@
     <item>@string/pref_theme_e_dark</item>
     <item>@string/pref_theme_e_light</item>
     <item>@string/pref_theme_e_black</item>
+    <item>@string/pref_theme_e_white</item>
   </string-array>
   <string-array name="pref_theme_values">
     <item>system</item>
     <item>dark</item>
     <item>light</item>
     <item>black</item>
+    <item>white</item>
   </string-array>
   <string-array name="pref_swipe_dist_entries">
     <item>@string/pref_swipe_dist_e_very_short</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -39,6 +39,7 @@
   <string name="pref_theme_e_dark">Dark</string>
   <string name="pref_theme_e_light">Light</string>
   <string name="pref_theme_e_black">Black</string>
+  <string name="pref_theme_e_white">White</string>
   <string name="pref_swipe_dist_e_very_short">Very short</string>
   <string name="pref_swipe_dist_e_short">Short</string>
   <string name="pref_swipe_dist_e_default">Normal</string>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -69,4 +69,16 @@
     <item name="emoji_button_bg">#000000</item>
     <item name="emoji_color">#ffffff</item>
   </style>
+  <style name="White" parent="BaseTheme">
+    <item name="android:isLightTheme">true</item>
+    <item name="colorKeyboard">#ffffff</item>
+    <item name="colorKey">#ffffff</item>
+    <item name="colorKeyActivated">#cccccc</item>
+    <item name="colorLabel">#000000</item>
+    <item name="colorLabelActivated">#0066cc</item>
+    <item name="colorLabelLocked">#33cc33</item>
+    <item name="colorSubLabel">#333333</item>
+    <item name="emoji_button_bg">#ffffff</item>
+    <item name="emoji_color">#000000</item>
+  </style>
 </resources>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -224,6 +224,7 @@ final class Config
       case "light": return R.style.Light;
       case "black": return R.style.Black;
       case "dark": return R.style.Dark;
+      case "white": return R.style.White;
       default:
       case "system":
         if (Build.VERSION.SDK_INT >= 8)
@@ -258,16 +259,6 @@ final class Config
       case "ru_jcuken": return R.xml.local_ru_jcuken;
       case "jcuken_ua": return R.xml.jcuken_ua;
       default: return R.xml.qwerty; // The config might store an invalid layout, don't crash
-    }
-  }
-
-  public static int themeId_of_string(String name)
-  {
-    switch (name)
-    {
-      case "light": return R.style.Light;
-      case "black": return R.style.Black;
-      default: case "dark": return R.style.Dark;
     }
   }
 


### PR DESCRIPTION
Hi, just discovered this keyboard on my android ereader (color eink Boox Nova Air C), and blindly edited a theme that would be least artifacty on the eink screen. Based on the Light one.

That's just an untested idea (browser-edited with a typo in the commit message ;) ). I simply would be glad if anything eink-oriented landed in a future release :)