### PR TITLE
Added Czech translation and layout

### DIFF
--- a/metadata/android/cs-CZ/full_description.txt
+++ b/metadata/android/cs-CZ/full_description.txt
@@ -1,0 +1,18 @@
+Tato aplikace je virtuální aplikací pro Android. Mezi její hlavní výhody patří jednoduché psaní libovolného ASCII znaku pomocí gest, mrtvé klávesy pro diakritická znaménka a modifikační klávesy, obohacena o speciální klávesy (tab, esc, šipky, atd..).
+
+Klávesnice zobrazuje až 4 další znaky v rozích každé klávesy. Tyto znaky jsou vyvolány přejetím prstu do vybraného rohu.
+
+Mezi další výhody patří:
+
+- Obsahuje každý znak a speciální klávesu, která je běžnou součástí počítačové klávesnice. To přijde vhod obzvláště při používání aplikací jako např. Termux
+
+- To zahrnuje Tab, Esc, šipky, F klávesy, ale také Ctrl nebo Alt !
+
+- Diakritická znaménka mohou být vyvolána za pomocí mrtvých kláves. Nejdříve zvolte diakritické znaménko, pak znak, který chcete obohatit o toto znaménko.
+
+- Vysoce nenáročná a rychlá. Zabere 500x méně místa než klávesnice od Googlu (Gboard) a 15x méně než výchozí klávesnice systému. Bez reklam, bez sledování.
+
+- Vícero rozložení: QWERTY, QWERTZ, AZERTY. Motivy: Bílá, Tmavá, OLED Černá. A mnoho dalších možností.
+
+Jako jiné virtuální klávesnice, musí být aktivována v nastavení systému. Otevřte (Systémové) Nastavení a přejděte na:
+(Další nastavení) > Jazyk & způsob zadávání > Spravovat klávesnice.

--- a/metadata/android/cs-CZ/full_description.txt
+++ b/metadata/android/cs-CZ/full_description.txt
@@ -1,18 +1,18 @@
-Tato aplikace je virtuální aplikací pro Android. Mezi její hlavní výhody patří jednoduché psaní libovolného ASCII znaku pomocí gest, mrtvé klávesy pro diakritická znaménka a modifikační klávesy, obohacena o speciální klávesy (tab, esc, šipky, atd..).
+Tato aplikace je virtuální klávesnící pro Android. Umožňuje rychlejší a plynulejší psaní písmen i symbolů (vč. diakritiky), a to ve vícero jazycích a vlastních rozloženích. To vše zdarma, bez reklam a bez plýtvání vašeho uložiště. Můžete psát libovolné znaky pomocí gest (ASCII i Unicode), používat mrtvé (univerzální) klávesy pro diakritická znaménka a mnohem více.
 
 Klávesnice zobrazuje až 4 další znaky v rozích každé klávesy. Tyto znaky jsou vyvolány přejetím prstu do vybraného rohu.
 
-Mezi další výhody patří:
+No zkrátka...:
 
 - Obsahuje každý znak a speciální klávesu, která je běžnou součástí počítačové klávesnice. To přijde vhod obzvláště při používání aplikací jako např. Termux
 
-- To zahrnuje Tab, Esc, šipky, F klávesy, ale také Ctrl nebo Alt !
+- Můžete používat modifikační klávesy, obohaceny o speciální klávesy (např. Tab, Esc, šipky, F klávesy, ale také Ctrl nebo Alt !)
 
-- Diakritická znaménka mohou být vyvolána za pomocí mrtvých kláves. Nejdříve zvolte diakritické znaménko, pak znak, který chcete obohatit o toto znaménko.
+- Můžete psát vícero jazyky rychleji a bez chyb. Diakritická znaménka mohou být vyvolána i za pomocí mrtvých kláves. Nejdříve zvolte diakritické znaménko a pak znak, který chcete obohatit o toto znaménko.
 
-- Vysoce nenáročná a rychlá. Zabere 500x méně místa než klávesnice od Googlu (Gboard) a 15x méně než výchozí klávesnice systému. Bez reklam, bez sledování.
+- Je vysoce nenáročná a rychlá. Zabere 500x méně místa než klávesnice od Googlu (Gboard) a 15x méně než výchozí klávesnice systému. Bez reklam, bez sledování.
 
-- Vícero rozložení: QWERTY, QWERTZ, AZERTY. Motivy: Bílá, Tmavá, OLED Černá. A mnoho dalších možností.
+- Má vícero rozložení: QWERTY, QWERTZ, AZERTY. Motivy: Bílá, Tmavá, OLED Černá. A mnoho dalších které si s drobnou znalostí programování můžete upravovat dle libosti.
 
-Jako jiné virtuální klávesnice, musí být aktivována v nastavení systému. Otevřte (Systémové) Nastavení a přejděte na:
-(Další nastavení) > Jazyk & způsob zadávání > Spravovat klávesnice.
+Nezapomeňte... Jako každá virtuální klávesnice, i tato musí být aktivována v nastavení systému (zařízení). Otevřte (Systémové) Nastavení a přejděte na:
+(Další nastavení NEBO Nastavení systému) > Jazyk & způsob zadávání > Spravovat klávesnice.

--- a/metadata/android/cs-CZ/short_description.txt
+++ b/metadata/android/cs-CZ/short_description.txt
@@ -1,0 +1,1 @@
+Nenáročná virtuální klávesnice pro vývojáře.

--- a/metadata/android/cs-CZ/title.txt
+++ b/metadata/android/cs-CZ/title.txt
@@ -1,0 +1,1 @@
+Klávesnice Unexpected

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="app_name" product="debug">Klávesnice Unexpected (pro ladění)</string>
+  <string name="app_name" product="default">Klávesnice Unexpected</string>
+  <string name="settings_activity_label">Nastavení Klávesnice Unexpected</string>
+  <string name="pref_category_layout">Rozvržení</string>
+  <string name="pref_layout_title">Změnit rozvržení klávesnice</string>
+  <string name="pref_layout_e_system">V nastavení systému</string>
+  <string name="pref_accents_title">(Univerzální) Diakritická znaménka</string>
+  <string name="pref_accents_e_all_installed">Zobrazovat znaménka pro všechny instalované systémové jazyky</string>
+  <string name="pref_accents_e_selected">Zobrazovat znaménka pouze pro současně zvolený jazyk</string>
+  <string name="pref_accents_e_none">Skrýt (univerzální) diakritická znaménka</string>
+  <string name="pref_autocapitalisation_title">Automatická kapitalizace</string>
+  <string name="pref_autocapitalisation_summary">Stiskne Shift na začátku věty</string>
+  <string name="pref_programming_layout_title">Rozložení klávesnice pro programování</string>
+  <string name="pref_programming_layout_none">Žádné</string>
+  <string name="pref_category_typing">Psaní</string>
+  <string name="pref_swipe_dist_title">Vzdálenost posunutí prstem</string>
+  <string name="pref_swipe_dist_summary">Jak daleko je třeba posunout prst pro napsaní znaku/diakritiky v rozích klávey (%s)</string>
+  <string name="pref_long_timeout_title">Časová prodleva opakování znaků</string>
+  <string name="pref_long_interval_title">Interval opakování znaků</string>
+  <string name="pref_vibrate_title">Vibrace</string>
+  <string name="pref_vibrate_summary">Zapnout/Vypnout vibrace při stisku klávesy</string>
+  <string name="pref_precise_repeat_title">Precizní posun kurzoru</string>
+  <string name="pref_precise_repeat_summary">Zda-li posun prstem ovlivňuje rychlost kurzoru</string>
+  <string name="pref_lockable_keys_title">Zastaralé: Zamykatelné modifikační klávesy</string>
+  <string name="pref_lockable_keys_summary">Tato možnost bude v budoucnu odebrána</string>
+  <string name="pref_lock_double_tap_title">Dvojklik pro aktivaci caps lock(u)</string>
+  <string name="pref_lock_double_tap_summary">Dvojklik namísto držení modifikačních kláves po nějakou dobu</string>
+  <string name="pref_category_style">Styl</string>
+  <string name="pref_margin_bottom_title">Spodní odsazení</string>
+  <string name="pref_keyboard_height_title">Výška klávesnice</string>
+  <string name="pref_keyboard_height_landscape_title">Výška klávesnice v režimu na šířku</string>
+  <string name="pref_horizontal_margin_title">Boční odsazení</string>
+  <string name="pref_character_size_title">Velikost znaků</string>
+  <string name="pref_character_size_summary">Velikost znaků zobrazených na klávesnici (%.2fx)</string>
+  <string name="pref_theme">Motiv</string>
+  <string name="pref_theme_e_system">Dle systému</string>
+  <string name="pref_theme_e_dark">Tmavý</string>
+  <string name="pref_theme_e_light">Světlý</string>
+  <string name="pref_theme_e_black">Černý</string>
+  <string name="pref_swipe_dist_e_very_short">Velmi krátká</string>
+  <string name="pref_swipe_dist_e_short">Krátká</string>
+  <string name="pref_swipe_dist_e_default">Běžná</string>
+  <string name="pref_swipe_dist_e_far">Dlouhá</string>
+  <string name="pref_swipe_dist_e_very_far">Velmi dlouhá</string>
+  <string name="pref_key_horizontal_space">Horizontální mezery mezi klávesami</string>
+  <string name="pref_key_vertical_space">Vertikální mezery mezi klávesami</string>
+  <string name="key_action_next">Další</string>
+  <string name="key_action_done">Dokončit</string>
+  <string name="key_action_go">Spustit</string>
+  <string name="key_action_prev">Předchozí</string>
+  <string name="key_action_search">Hledat</string>
+  <string name="key_action_send">Odeslat</string>
+</resources>

--- a/res/xml/method.xml
+++ b/res/xml/method.xml
@@ -17,4 +17,5 @@
   <subtype android:label="%s" android:languageTag="sv" android:imeSubtypeLocale="sv_SE" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwerty_sv_se,extra_keys=accent_aigu|accent_trema|accent_ring|€"/>
   <subtype android:label="%s" android:languageTag="tr" android:imeSubtypeLocale="tr_TR" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwerty_tr,extra_keys=accent_cedille|accent_trema|₺|ı|ğ"/>
   <subtype android:label="%s" android:languageTag="uk" android:imeSubtypeLocale="uk_UA" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=jcuken_ua"/>
+  <subtype android:label="%s" android:languageTag="cs" android:imeSubtypeLocale="cs_CZ" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwertz_cs,extra_keys=a|accent_cedille|accent_circonflexe"/>
 </input-method>

--- a/res/xml/qwertz_cs.xml
+++ b/res/xml/qwertz_cs.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<keyboard>
+  <row>
+    <key key0="q" key1="1" key4="esc"/>
+    <key key0="w" key1="2" key3="~"/>
+    <key key0="e" key1="3" key2="é" key3="ë" key4="ě"/>
+    <key key0="r" key1="4" key2="ŕ" key3="°" key4="ř"/>
+    <key key0="t" key1="5" key3="%" key4="ť"/>
+    <key key0="z" key1="6" key3="^" key4="ž"/>
+    <key key0="u" key1="7" key2="ú" key3="ü" key4="ů"/>
+    <key key0="i" key1="8" key2="í" key3="ï" key4="*"/>
+    <key key0="o" key1="9" key2="ó" key3="ö" key4="ô"/>
+    <key key0="p" key1="0" key2="=" key3="/" key4="π"/>
+  </row>
+  <row>
+    <key shift="0.5" key0="a" key1="tab" key2="á" key3="ä" key4="α"/>
+    <key key0="s" key1="{" key2="&lt;" key3="§" key4="š"/>
+    <key key0="d" key1="$" key2="δ" key3="Δ" key4="ď"/>
+    <key key0="f" key1="&gt;" key2="}" key3="ѳ" key4="φ"/>
+    <key key0="g" key1="»" key2="«" key3="–" key4="_"/>
+    <key key0="h" key1="[" key2="("/>
+    <key key0="j" key1="+" key2="\?" key3="!" key4="-"/>
+    <key key0="k" key1=")" key2="]"/>
+    <key key0="l" key2="ľ" key3="\\" key4="ĺ"/>
+  </row>
+  <row>
+    <key width="1.5" key0="shift"/>
+    <key key0="y" key1="÷" key2="ý"/>
+    <key key0="x" key1="∙" key3="×"/>
+    <key key0="c" key1="\#" key2="γ" key3="&amp;" key4="č"/>
+    <key key0="v" key1="|" key3="\@"/>
+    <key key0="b" key1=";" key2="♭" key3=":" key4="β"/>
+    <key key0="n" key1="," key3="." key4="ň"/>
+    <key key0="m" key1="&quot;" key3="\'"/>
+    <key width="1.5" key0="backspace" key2="delete"/>
+  </row>
+</keyboard>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -254,6 +254,7 @@ final class Config
       case "qwerty": return R.xml.qwerty;
       case "qwerty_sv_se": return R.xml.qwerty_sv_se;
       case "qwertz_hu": return R.xml.qwertz_hu;
+      case "qwertz_cs": return R.xml.qwertz_cs;
       case "qwertz": return R.xml.qwertz;
       case "ru_jcuken": return R.xml.local_ru_jcuken;
       case "jcuken_ua": return R.xml.jcuken_ua;


### PR DESCRIPTION
Translated keyboard and created Czech multilingual "practical" layout for faster typing and typing in commonly used languages (German, Slovak + French w/accents)

_I've designed the layout to be more useful and practical in typing while preserving QWERTZ and certain alphanumeric symbols (PC keyboard) where change wasn't needed/available_

I've tested it (and made changes) for a week. I plan on using it for a long time so feel free to modify or ask for help or changing commits.
_Thank you for this amazing gift of a keyboard to us all. Hope you're doing well._