### PR TITLE
Make the keyboard transparent

### DIFF
--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -5,6 +5,9 @@
   <string name="settings_activity_label">Nastavení Klávesnice Unexpected</string>
   <string name="pref_category_layout">Rozvržení</string>
   <!-- <string name="pref_label_brightness">Adjust label brightness</string> -->
+  <!-- <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string> -->
+  <!-- <string name="pref_key_opacity">Adjust key opacity</string> -->
+  <!-- <string name="pref_key_activated_opacity">Adjust pressed key opacity</string> -->
   <string name="pref_layout_title">Změnit rozvržení klávesnice</string>
   <string name="pref_layout_e_system">V nastavení systému</string>
   <!-- <string name="pref_layout_e_custom">Custom layout</string> -->

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -5,6 +5,9 @@
   <string name="settings_activity_label">Unexpected Keyboard - Einstellungen</string>
   <string name="pref_category_layout">Layout</string>
   <!-- <string name="pref_label_brightness">Adjust label brightness</string> -->
+  <!-- <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string> -->
+  <!-- <string name="pref_key_opacity">Adjust key opacity</string> -->
+  <!-- <string name="pref_key_activated_opacity">Adjust pressed key opacity</string> -->
   <string name="pref_layout_title">Tastaturlayout ändern</string>
   <string name="pref_layout_e_system">Systemeinstellung</string>
   <!-- <string name="pref_layout_e_custom">Custom layout</string> -->

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -5,6 +5,9 @@
   <string name="settings_activity_label">Ajustes de Unexpected Keyboard</string>
   <string name="pref_category_layout">Formato</string>
   <!-- <string name="pref_label_brightness">Adjust label brightness</string> -->
+  <!-- <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string> -->
+  <!-- <string name="pref_key_opacity">Adjust key opacity</string> -->
+  <!-- <string name="pref_key_activated_opacity">Adjust pressed key opacity</string> -->
   <string name="pref_layout_title">Cambiar formato de teclado</string>
   <string name="pref_layout_e_system">Ajustes del sistema</string>
   <!-- <string name="pref_layout_e_custom">Custom layout</string> -->

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -5,6 +5,9 @@
   <string name="settings_activity_label">Unexpected Keyboard Paramètres</string>
   <string name="pref_category_layout">Disposition</string>
   <string name="pref_label_brightness">Luminosité des symboles</string>
+  <!-- <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string> -->
+  <!-- <string name="pref_key_opacity">Adjust key opacity</string> -->
+  <!-- <string name="pref_key_activated_opacity">Adjust pressed key opacity</string> -->
   <string name="pref_layout_title">Disposition des touches</string>
   <string name="pref_layout_e_system">Paramètre système</string>
   <string name="pref_layout_e_custom">Disposition personnalisée</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -5,6 +5,9 @@
   <string name="settings_activity_label">Impostazioni di Unexpected Keyboard</string>
   <string name="pref_category_layout">Layout</string>
   <!-- <string name="pref_label_brightness">Adjust label brightness</string> -->
+  <!-- <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string> -->
+  <!-- <string name="pref_key_opacity">Adjust key opacity</string> -->
+  <!-- <string name="pref_key_activated_opacity">Adjust pressed key opacity</string> -->
   <string name="pref_layout_title">Cambia layout tastiera</string>
   <string name="pref_layout_e_system">Impostazioni di sistema</string>
   <!-- <string name="pref_layout_e_custom">Custom layout</string> -->

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -5,6 +5,9 @@
   <string name="settings_activity_label">Unexpected Keyboard 설정</string>
   <string name="pref_category_layout">레이아웃</string>
   <!-- <string name="pref_label_brightness">Adjust label brightness</string> -->
+  <!-- <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string> -->
+  <!-- <string name="pref_key_opacity">Adjust key opacity</string> -->
+  <!-- <string name="pref_key_activated_opacity">Adjust pressed key opacity</string> -->
   <string name="pref_layout_title">키보드 레이아웃 변경</string>
   <string name="pref_layout_e_system">시스템 세팅</string>
   <!-- <string name="pref_layout_e_custom">Custom layout</string> -->

--- a/res/values-lv/strings.xml
+++ b/res/values-lv/strings.xml
@@ -5,6 +5,9 @@
   <string name="settings_activity_label">Unexpected Keyboard iestatījumi</string>
   <string name="pref_category_layout">Izkārtojums</string>
   <!-- <string name="pref_label_brightness">Adjust label brightness</string> -->
+  <!-- <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string> -->
+  <!-- <string name="pref_key_opacity">Adjust key opacity</string> -->
+  <!-- <string name="pref_key_activated_opacity">Adjust pressed key opacity</string> -->
   <string name="pref_layout_title">Mainīt tastatūras izkārtojumu</string>
   <string name="pref_layout_e_system">Ierīces iestatījumi</string>
   <!-- <string name="pref_layout_e_custom">Custom layout</string> -->

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -5,6 +5,9 @@
   <string name="settings_activity_label">Ustawienia Unexpected Keyboard</string>
   <string name="pref_category_layout">Układ</string>
   <string name="pref_label_brightness">Dostosuj jasność znaków</string>
+  <string name="pref_keyboard_opacity">Nieprzezroczystość tła klawiatury</string>
+  <string name="pref_key_opacity">Nieprzezroczystość klawisza</string>
+  <string name="pref_key_activated_opacity">Nieprzezroczystość naciśniętego klawisza</string>
   <string name="pref_layout_title">Zmień układ klawiatury</string>
   <string name="pref_layout_e_system">Systemowy</string>
   <string name="pref_layout_e_custom">Własny układ</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -5,6 +5,9 @@
   <string name="settings_activity_label">Configurar Teclado Unexpected</string>
   <string name="pref_category_layout">Layout</string>
   <!-- <string name="pref_label_brightness">Adjust label brightness</string> -->
+  <!-- <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string> -->
+  <!-- <string name="pref_key_opacity">Adjust key opacity</string> -->
+  <!-- <string name="pref_key_activated_opacity">Adjust pressed key opacity</string> -->
   <string name="pref_layout_title">Mudar layout do teclado</string>
   <string name="pref_layout_e_system">Mesmo do sistema</string>
   <!-- <string name="pref_layout_e_custom">Custom layout</string> -->

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -5,6 +5,9 @@
   <string name="settings_activity_label">Unexpected Keyboard Настройки</string>
   <string name="pref_category_layout">Расположение</string>
   <!-- <string name="pref_label_brightness">Adjust label brightness</string> -->
+  <!-- <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string> -->
+  <!-- <string name="pref_key_opacity">Adjust key opacity</string> -->
+  <!-- <string name="pref_key_activated_opacity">Adjust pressed key opacity</string> -->
   <string name="pref_layout_title">Изменить раскладку клавиатуры</string>
   <string name="pref_layout_e_system">Системные настройки</string>
   <!-- <string name="pref_layout_e_custom">Custom layout</string> -->

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -5,6 +5,9 @@
   <string name="settings_activity_label">Unexpected Keyboard Ayarları</string>
   <string name="pref_category_layout">Düzen</string>
   <!-- <string name="pref_label_brightness">Adjust label brightness</string> -->
+  <!-- <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string> -->
+  <!-- <string name="pref_key_opacity">Adjust key opacity</string> -->
+  <!-- <string name="pref_key_activated_opacity">Adjust pressed key opacity</string> -->
   <string name="pref_layout_title">Klavye Düzenini Değiştir</string>
   <string name="pref_layout_e_system">Sistem Ayarları</string>
   <!-- <string name="pref_layout_e_custom">Custom layout</string> -->

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -5,6 +5,9 @@
   <string name="settings_activity_label">Unexpected Keyboard 设置</string>
   <string name="pref_category_layout">布局</string>
   <string name="pref_label_brightness">调整字母亮度</string>
+  <!-- <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string> -->
+  <!-- <string name="pref_key_opacity">Adjust key opacity</string> -->
+  <!-- <string name="pref_key_activated_opacity">Adjust pressed key opacity</string> -->
   <string name="pref_layout_title">改变键盘布局</string>
   <string name="pref_layout_e_system">系统设置</string>
   <!-- <string name="pref_layout_e_custom">Custom layout</string> -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -5,6 +5,9 @@
   <string name="settings_activity_label">Unexpected Keyboard Settings</string>
   <string name="pref_category_layout">Layout</string>
   <string name="pref_label_brightness">Adjust label brightness</string>
+  <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string>
+  <string name="pref_key_opacity">Adjust key opacity</string>
+  <string name="pref_key_activated_opacity">Adjust pressed key opacity</string>
   <string name="pref_layout_title">Change keyboard layout</string>
   <string name="pref_layout_e_system">System settings</string>
   <string name="pref_layout_e_custom">Custom layout</string>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -47,6 +47,9 @@
   <PreferenceCategory android:title="@string/pref_category_style">
     <ListPreference android:key="theme" android:title="@string/pref_theme" android:summary="%s" android:defaultValue="system" android:entries="@array/pref_theme_entries" android:entryValues="@array/pref_theme_values"/>
     <juloo.common.IntSlideBarPreference android:key="label_brightness" android:title="@string/pref_label_brightness" android:summary="%s%%" android:defaultValue="100" min="50" max="100"/>
+    <juloo.common.IntSlideBarPreference android:key="keyboard_opacity" android:title="@string/pref_keyboard_opacity" android:summary="%s%%" android:defaultValue="100" min="30" max="100"/>
+    <juloo.common.IntSlideBarPreference android:key="key_opacity" android:title="@string/pref_key_opacity" android:summary="%s%%" android:defaultValue="100" min="30" max="100"/>
+    <juloo.common.IntSlideBarPreference android:key="key_activated_opacity" android:title="@string/pref_key_activated_opacity" android:summary="%s%%" android:defaultValue="100" min="30" max="100"/>
     <juloo.common.IntSlideBarPreference android:key="margin_bottom" android:title="@string/pref_margin_bottom_title" android:summary="%sdp" android:defaultValue="5" min="0" max="100"/>
     <juloo.common.IntSlideBarPreference android:key="keyboard_height" android:title="@string/pref_keyboard_height_title" android:summary="%s%%" android:defaultValue="35" min="10" max="50"/>
     <juloo.common.IntSlideBarPreference android:key="keyboard_height_landscape" android:title="@string/pref_keyboard_height_landscape_title" android:summary="%s%%" android:defaultValue="50" min="20" max="65"/>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -1,6 +1,5 @@
 package juloo.keyboard2;
 
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -9,7 +8,6 @@ import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.KeyEvent;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 final class Config
@@ -40,6 +38,9 @@ final class Config
   public float keyVerticalInterval;
   public float keyHorizontalInterval;
   public int labelBrightness; // 0 - 255
+  public int keyboardOpacity; // 0 - 255
+  public int keyOpacity; // 0 - 255
+  public int keyActivatedOpacity; // 0 - 255
   public boolean preciseRepeat;
   public boolean double_tap_lock_shift;
   public float characterSize; // Ratio
@@ -141,6 +142,10 @@ final class Config
       * horizontalIntervalScale;
     // Label brightness is used as the alpha channel
     labelBrightness = _prefs.getInt("label_brightness", 100) * 255 / 100;
+    // Keyboard opacity
+    keyboardOpacity = _prefs.getInt("keyboard_opacity", 100) * 255 / 100;
+    keyOpacity = _prefs.getInt("key_opacity", 100) * 255 / 100;
+    keyActivatedOpacity = _prefs.getInt("key_activated_opacity", 100) * 255 / 100;
     // Do not substract keyVerticalInterval from keyHeight because this is done
     // during rendered.
     keyHeight = dm.heightPixels * keyboardHeightPercent / 100 / 4;

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -312,6 +312,7 @@ public class Keyboard2View extends View
     // Set keys opacity
     _theme.keyBgPaint.setAlpha(_config.keyOpacity);
     _theme.keyDownBgPaint.setAlpha(_config.keyActivatedOpacity);
+    _theme.keyBorderPaint.setAlpha(_config.keyOpacity);
     canvas.drawRoundRect(_tmpRect, r, r,
         isKeyDown ? _theme.keyDownBgPaint : _theme.keyBgPaint);
     if (w > 0.f)

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -258,6 +258,10 @@ public class Keyboard2View extends View
     updateFlags();
     // Set keyboard background opacity
     getBackground().setAlpha(_config.keyboardOpacity);
+    // Set keys opacity
+    _theme.keyBgPaint.setAlpha(_config.keyOpacity);
+    _theme.keyDownBgPaint.setAlpha(_config.keyActivatedOpacity);
+    _theme.keyBorderPaint.setAlpha(_config.keyOpacity);
     float y = _config.marginTop + _config.keyVerticalInterval / 2;
     for (KeyboardData.Row row : _keyboard.rows)
     {
@@ -309,10 +313,6 @@ public class Keyboard2View extends View
     float w = isKeyDown ? _theme.keyBorderWidthActivated : _theme.keyBorderWidth;
     float w2 = _theme.keyBorderWidth / 2.f;
     _tmpRect.set(x + w2, y + w2, x + keyW - w2, y + keyH - w2);
-    // Set keys opacity
-    _theme.keyBgPaint.setAlpha(_config.keyOpacity);
-    _theme.keyDownBgPaint.setAlpha(_config.keyActivatedOpacity);
-    _theme.keyBorderPaint.setAlpha(_config.keyOpacity);
     canvas.drawRoundRect(_tmpRect, r, r,
         isKeyDown ? _theme.keyDownBgPaint : _theme.keyBgPaint);
     if (w > 0.f)

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -3,7 +3,6 @@ package juloo.keyboard2;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.RectF;
@@ -12,7 +11,6 @@ import android.os.Build.VERSION;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.view.HapticFeedbackConstants;
-import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.Window;
@@ -258,6 +256,8 @@ public class Keyboard2View extends View
   protected void onDraw(Canvas canvas)
   {
     updateFlags();
+    // Set keyboard background opacity
+    getBackground().setAlpha(_config.keyboardOpacity);
     float y = _config.marginTop + _config.keyVerticalInterval / 2;
     for (KeyboardData.Row row : _keyboard.rows)
     {
@@ -309,6 +309,9 @@ public class Keyboard2View extends View
     float w = isKeyDown ? _theme.keyBorderWidthActivated : _theme.keyBorderWidth;
     float w2 = _theme.keyBorderWidth / 2.f;
     _tmpRect.set(x + w2, y + w2, x + keyW - w2, y + keyH - w2);
+    // Set keys opacity
+    _theme.keyBgPaint.setAlpha(_config.keyOpacity);
+    _theme.keyDownBgPaint.setAlpha(_config.keyActivatedOpacity);
     canvas.drawRoundRect(_tmpRect, r, r,
         isKeyDown ? _theme.keyDownBgPaint : _theme.keyBgPaint);
     if (w > 0.f)


### PR DESCRIPTION
Quite missed this feature from the other keyboard I used in the past along with remote desktop viewers and emulators, so I decided to add it here. This setting is split into 3 options.

This are a few examples what it looks like with the following values:
background opacity: 70%
key opacity: 30%
key pressed opacity: 30%

Settings screen:
![settings](https://user-images.githubusercontent.com/46286197/206917194-51e290db-196d-4bd2-8d65-f6f1961a7a09.png)

Remote desktop app:
![remote_desktop](https://user-images.githubusercontent.com/46286197/206917214-947876ae-fb12-4b39-bf56-239a763b0d56.png)
