### PR TITLE
Add modifier key to swap '.' <=> ','

### DIFF
--- a/res/xml/numeric.xml
+++ b/res/xml/numeric.xml
@@ -29,7 +29,7 @@
   <row height="0.95">
     <key width="1.5" key0="switch_text" key2="ctrl"/>
     <key width="1.5" key0="0" key3="f11_placeholder" key4="f12_placeholder"/>
-    <key width="0.75" key0="." key1=":" key2="," key3=";"/>
+    <key width="0.75" key0="decimal_separator" key1=":" key2="group_separator" key3=";" key4="loc swap_separator"/>
     <key width="0.75" key0="space" key1="&quot;" key2="'" key4="_"/>
     <key width="1.5" key0="enter" key1="±" key2="action" key3="="/>
   </row>

--- a/res/xml/numpad.xml
+++ b/res/xml/numpad.xml
@@ -20,7 +20,7 @@
     </row>
     <row height="0.95">
         <key key0="0"/>
-        <key key0="."/>
+        <key key0="decimal_separator" key1="loc group_separator" key2="loc swap_separator"/>
         <key key0="="/>
         <key key0="+"/>
     </row>

--- a/srcs/juloo.keyboard2/ExtraKeyCheckBoxPreference.java
+++ b/srcs/juloo.keyboard2/ExtraKeyCheckBoxPreference.java
@@ -36,6 +36,8 @@ public class ExtraKeyCheckBoxPreference extends CheckBoxPreference
     "£",
     "switch_greekmath",
     "capslock",
+    "group_separator",
+    "swap_separator",
     "copy",
     "paste",
     "cut",

--- a/srcs/juloo.keyboard2/KeyEventHandler.java
+++ b/srcs/juloo.keyboard2/KeyEventHandler.java
@@ -180,6 +180,7 @@ class KeyEventHandler implements Config.IKeyEventHandler
     public void switch_layout(int layout_id);
 
     public void set_shift_state(boolean state, boolean lock);
+    public void set_swap_separator_state(boolean state, boolean lock);
 
     public InputConnection getCurrentInputConnection();
   }

--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -21,6 +21,8 @@ class KeyModifier
     if (r == null)
     {
       r = k;
+      if (KeyValue.Kind.Separator == r.getKind())
+        r = apply_separator_replacement(r, mods);
       /* Order: Fn, Shift, accents */
       for (int i = 0; i < n_mods; i++)
         r = modify(r, mods.get(i));
@@ -135,6 +137,17 @@ class KeyModifier
         break;
     }
     return (name == null) ? k : KeyValue.getKeyByName(name);
+  }
+
+  private static KeyValue apply_separator_replacement(KeyValue k, Pointers.Modifiers mods) {
+    boolean swap_separator = mods.contains(KeyValue.Modifier.SWAP_SEPARATOR);
+    if ("decimal_separator".equals(k.getString())) {
+      return k.withString(swap_separator ? "," : ".");
+    }
+    if ("group_separator".equals(k.getString())) {
+      return k.withString(swap_separator ? "." : ",");
+    }
+    return k;
   }
 
   private static String apply_fn_keyevent(int code)

--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -24,6 +24,7 @@ final class KeyValue
   // Must be evaluated in the reverse order of their values.
   public static enum Modifier
   {
+    SWAP_SEPARATOR,
     SHIFT,
     CTRL,
     ALT,
@@ -70,7 +71,7 @@ final class KeyValue
 
   public static enum Kind
   {
-    Char, String, Keyevent, Event, Modifier, Editing
+    Char, String, Keyevent, Event, Modifier, Editing, Separator
   }
 
   // Behavior flags.
@@ -275,6 +276,12 @@ final class KeyValue
         FLAG_SPECIAL | FLAG_SECONDARY | FLAG_SMALLER_FONT);
   }
 
+  private static void addSeparatorKey(String name)
+  {
+    addKey(name, name, Kind.Separator, 0, 0);
+  }
+
+
   // Within VALUE_BITS
   private static int placeholder_unique_id = 0;
 
@@ -325,6 +332,10 @@ final class KeyValue
     addEventKey("change_method", 0x09, Event.CHANGE_METHOD, FLAG_SMALLER_FONT);
     addEventKey("action", "Action", Event.ACTION, FLAG_SMALLER_FONT); // Will always be replaced
     addEventKey("capslock", 0x12, Event.CAPS_LOCK, 0);
+
+    addModifierKey("swap_separator", 0x15, Modifier.SWAP_SEPARATOR, FLAG_LOCKED);
+    addSeparatorKey("decimal_separator");
+    addSeparatorKey("group_separator");
 
     addKeyeventKey("esc", "Esc", KeyEvent.KEYCODE_ESCAPE, FLAG_SMALLER_FONT);
     addKeyeventKey("enter", 0x0E, KeyEvent.KEYCODE_ENTER, 0);
@@ -391,6 +402,8 @@ final class KeyValue
     /* Keys description is shown in the settings. */
     addKeyDescr("capslock", "Caps lock");
     addKeyDescr("switch_greekmath", "Greek & math symbols");
+    addKeyDescr("group_separator", "',' on Numpad");
+    addKeyDescr("swap_separator", "swap '.' and ',' on Numpad");
   }
 
   // Substitute for [assert], which has no effect on Android.

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -10,7 +10,6 @@ import android.text.InputType;
 import android.util.Log;
 import android.util.LogPrinter;
 import android.view.ContextThemeWrapper;
-import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
@@ -317,6 +316,11 @@ public class Keyboard2 extends InputMethodService
     public void set_shift_state(boolean state, boolean lock)
     {
       _keyboardView.set_shift_state(state, lock);
+    }
+
+    public void set_swap_separator_state(boolean state, boolean lock)
+    {
+      _keyboardView.set_swap_separator_state(state, lock);
     }
 
     public void switch_text()

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -22,6 +22,8 @@ public class Keyboard2View extends View
   private KeyboardData _keyboard;
   private KeyValue _shift_kv;
   private KeyboardData.Key _shift_key;
+  private KeyValue _swap_separator_kv;
+  private KeyboardData.Key _swap_separator_key;
 
   private Pointers _pointers;
 
@@ -89,6 +91,15 @@ public class Keyboard2View extends View
       _shift_kv = _shift_kv.withFlags(_shift_kv.getFlags() | KeyValue.FLAG_LOCK);
       _shift_key = _keyboard.findKeyWithValue(_shift_kv);
     }
+
+    _swap_separator_kv = KeyValue.getKeyByName("swap_separator");
+    _swap_separator_key = _keyboard.findKeyWithValue(_swap_separator_kv);
+
+    if (_swap_separator_key == null)
+    {
+      _swap_separator_kv = _swap_separator_kv.withFlags(_swap_separator_kv.getFlags() | KeyValue.FLAG_LOCK);
+      _swap_separator_key = _keyboard.findKeyWithValue(_swap_separator_kv);
+    }
     reset();
   }
 
@@ -109,6 +120,17 @@ public class Keyboard2View extends View
       _pointers.add_fake_pointer(_shift_kv, _shift_key, lock);
     else
       _pointers.remove_fake_pointer(_shift_kv, _shift_key);
+    invalidate();
+  }
+
+  public void set_swap_separator_state(boolean state, boolean lock)
+  {
+    if (_keyboard == null || _swap_separator_key == null)
+      return;
+    if (state)
+      _pointers.add_fake_pointer(_swap_separator_kv, _swap_separator_key, lock);
+    else
+      _pointers.remove_fake_pointer(_swap_separator_kv, _swap_separator_key);
     invalidate();
   }
 

--- a/srcs/juloo.keyboard2/Pointers.java
+++ b/srcs/juloo.keyboard2/Pointers.java
@@ -445,6 +445,14 @@ public final class Pointers implements Handler.Callback
 
     public KeyValue.Modifier get(int i) { return _mods[_size - 1 - i]; }
     public int size() { return _size; }
+    public boolean contains(KeyValue.Modifier mod)
+    {
+      for (int i = 0; i < _mods.length; i++)
+      {
+        if (_mods[i] == mod) return true;
+      }
+      return false;
+    }
 
     @Override
     public int hashCode() { return Arrays.hashCode(_mods); }

--- a/srcs/special_font/15.svg
+++ b/srcs/special_font/15.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="28" height="24" viewBox="0 0 28 24">
+<circle fill="black" stroke="none" cx="2" cy="18" r="2"/>
+<path fill="black" stroke="none" d="M17 5h-8v-3l-5 5l5 5v-3h8z"/>
+<path fill="black" stroke="none" d="M11 11h8v-3l5 5l-5 5v-3h-8z"/>
+<path fill="black" stroke="none" d="M24 17.5c0 -0.7, 0.3 -1, 1 -1h1c0.7 0,1 0.3,1 1v3l-2 4h-2l1 -4z"/>
+</svg>


### PR DESCRIPTION
Add modifier key to swap decimal separator and group separator ('.' <=> ',') on numeric keyboard. The key can be selected in the extra key preferences.

__NOTE:__ the new version of `./srcs/special_font/result.ttf` isn't submitted here, because the creation of this file by `make rebuild_special_font`
fails on my installation (ubuntu) with
```
Import: Wrong number of arguments
Called from...
 build.pe: line 10
make: *** [Makefile:26: rebuild_special_font] Fehler 1
```
So, rebuild `result.ttf` it on your system, or take the version from my `makeshift-resources` branch, which is built by adding glyph 0x15 (`./srcs/special_font/15.svg`) to `master` version with fontforge manually.