### PR TITLE
Add Arabic layout

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -31,6 +31,7 @@
     <item>hindi</item>
     <item>he_il_1452_1</item>
     <item>he_il_1452_2</item>
+    <item>ar_pc</item>
     <item>custom</item>
   </string-array>
   <string-array name="pref_layout_entries">
@@ -64,6 +65,7 @@
     <item>हिन्दी</item>
     <item>Hebrew SI-1452-1</item>
     <item>Hebrew SI-1452-2</item>
+    <item>Arabic PC</item>
     <item>@string/pref_layout_e_custom</item>
   </string-array>
   <string-array name="pref_accents_entries">

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -32,6 +32,7 @@
     <item>he_il_1452_1</item>
     <item>he_il_1452_2</item>
     <item>ar_pc</item>
+    <item>ar_alt</item>
     <item>custom</item>
   </string-array>
   <string-array name="pref_layout_entries">
@@ -66,6 +67,7 @@
     <item>Hebrew SI-1452-1</item>
     <item>Hebrew SI-1452-2</item>
     <item>Arabic PC</item>
+    <item>Arabic ALT</item>
     <item>@string/pref_layout_e_custom</item>
   </string-array>
   <string-array name="pref_accents_entries">

--- a/res/xml/ar_alt.xml
+++ b/res/xml/ar_alt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <keyboard>
   <row>
-    <key key0="ض" key2="`" key4="esc"/>
+    <key key0="ض" key2="1" key3="`" key4="esc"/>
     <key key0="ص" key2="2" key3="\@"/>
     <key key0="ث" key2="3" key3="\#"/>
     <key key0="ق" key2="4" key3="$"/>

--- a/res/xml/ar_alt.xml
+++ b/res/xml/ar_alt.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <keyboard>
   <row>
-    <key key0="ض" key2="1" key3="`" key4="esc"/>
-    <key key0="ص" key2="2" key3="\@"/>
-    <key key0="ث" key2="3" key3="\#"/>
-    <key key0="ق" key2="4" key3="$"/>
-    <key key0="ف" key2="5" key3="%"/>
-    <key key0="غ" key2="6" key3="^"/>
-    <key key0="ع" key2="7" key3="&amp;"/>
-    <key key0="ه" key2="8" key3="*"/>
-    <key key0="خ" key2="9" key3="("/>
-    <key key0="ح" key2="0" key3=")"/>
+    <key key0="ض" key2="١" key3="`" key4="esc"/>
+    <key key0="ص" key2="٢" key3="\@"/>
+    <key key0="ث" key2="٣" key3="\#"/>
+    <key key0="ق" key2="٤" key3="$"/>
+    <key key0="ف" key2="٥" key3="%"/>
+    <key key0="غ" key2="٦" key3="^"/>
+    <key key0="ع" key2="٧" key3="&amp;"/>
+    <key key0="ه" key2="٨" key3="*"/>
+    <key key0="خ" key2="٩" key3="("/>
+    <key key0="ح" key2="٠" key3=")"/>
     <key key0="ج"/>
   </row>
   <row>

--- a/res/xml/ar_alt.xml
+++ b/res/xml/ar_alt.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<keyboard>
+  <row>
+    <key key0="ض" key2="`" key4="esc"/>
+    <key key0="ص" key2="2" key3="\@"/>
+    <key key0="ث" key2="3" key3="\#"/>
+    <key key0="ق" key2="4" key3="$"/>
+    <key key0="ف" key2="5" key3="%"/>
+    <key key0="غ" key2="6" key3="^"/>
+    <key key0="ع" key2="7" key3="&amp;"/>
+    <key key0="ه" key2="8" key3="*"/>
+    <key key0="خ" key2="9" key3="("/>
+    <key key0="ح" key2="0" key3=")"/>
+    <key key0="ج"/>
+  </row>
+  <row>
+    <key key0="ش" key4="tab"/>
+    <key key0="س"/>
+    <key key0="ي"/>
+    <key key0="ب"/>
+    <key key0="ل"/>
+    <key key0="ا" key1="أ"/>
+    <key key0="ت"/>
+    <key key0="ن"/>
+    <key key0="م"/>
+    <key key0="ك"/>
+    <key key0="ط"/>
+  </row>
+  <row>
+    <key key0="ذ"/>
+    <key key0="ء"/>
+    <key key0="ؤ" key1="{"/>
+    <key key0="ر" key1="}"/>
+    <key key0="ى" key1="ئ"/>
+    <key key0="ة"/>
+    <key key0="و" key3=","/>
+    <key key0="ز" key3="."/>
+    <key key0="ظ" key3="&#1567;"/>
+    <key key0="د"/>
+    <key width="1.0" key0="backspace" key2="delete"/>
+  </row>
+</keyboard>

--- a/res/xml/ar_pc.xml
+++ b/res/xml/ar_pc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <keyboard>
   <row>
-    <key key0="ض" key1="&#1614;" key2="`" key4="esc"/>
+    <key key0="ض" key1="&#1614;" key2="1" key3="`" key4="esc"/>
     <key key0="ص" key1="&#1611;" key2="2" key3="\@"/>
     <key key0="ث" key1="&#1615;" key2="3" key3="\#" key4="loc €"/>
     <key key0="ق" key1="&#1612;" key2="4" key3="$" key4="loc £"/>

--- a/res/xml/ar_pc.xml
+++ b/res/xml/ar_pc.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <keyboard>
   <row>
-    <key key0="ض" key1="&#1614;" key2="1" key3="`" key4="esc"/>
-    <key key0="ص" key1="&#1611;" key2="2" key3="\@"/>
-    <key key0="ث" key1="&#1615;" key2="3" key3="\#" key4="loc €"/>
-    <key key0="ق" key1="&#1612;" key2="4" key3="$" key4="loc £"/>
-    <key key0="ف" key1="&#1604;&#1573;" key2="5" key3="%"/>
-    <key key0="غ" key1="&#1573;" key2="6" key3="^"/>
-    <key key0="ع" key1="&#8216;" key2="7" key3="&amp;"/>
-    <key key0="ه" key1="&#0247;" key2="8" key3="*"/>
-    <key key0="خ" key1="&#0215;" key2="9" key3="("/>
-    <key key0="ح" key1="&#1563;" key2="0" key3=")"/>
+    <key key0="ض" key1="&#1614;" key2="١" key3="`" key4="esc"/>
+    <key key0="ص" key1="&#1611;" key2="٢" key3="\@"/>
+    <key key0="ث" key1="&#1615;" key2="٣" key3="\#" key4="loc €"/>
+    <key key0="ق" key1="&#1612;" key2="٤" key3="$" key4="loc £"/>
+    <key key0="ف" key1="&#1604;&#1573;" key2="٥" key3="%"/>
+    <key key0="غ" key1="&#1573;" key2="٦" key3="^"/>
+    <key key0="ع" key1="&#8216;" key2="٧" key3="&amp;"/>
+    <key key0="ه" key1="&#0247;" key2="٨" key3="*"/>
+    <key key0="خ" key1="&#0215;" key2="٩" key3="("/>
+    <key key0="ح" key1="&#1563;" key2="٠" key3=")"/>
     <key key0="ج" key1="&gt;" key2="-" key3="_"/>
     <key key0="د" key1="&lt;" key2="=" key3="ذ"/>
     <!-- <key key0="ذ" key1="&#1617;" key3="\\" key4="|"/> -->

--- a/res/xml/ar_pc.xml
+++ b/res/xml/ar_pc.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<keyboard>
+  <row>
+    <key key0="ض" key1="َ" key2="`" key4="esc"/>
+    <key key0="ص" key1="ً" key2="2" key3="\@"/>
+    <key key0="ث" key1="ُ" key2="3" key3="\#" key4="loc €"/>
+    <key key0="ق" key1="ٌ" key2="4" key3="$" key4="loc £"/>
+    <key key0="ف" key1="لإ" key2="5" key3="%"/>
+    <key key0="غ" key1="إ" key2="6" key3="^"/>
+    <key key0="ع" key1="‘" key2="7" key3="&amp;"/>
+    <key key0="ه" key1="÷" key2="8" key3="*"/>
+    <key key0="خ" key1="×" key2="9" key3="("/>
+    <key key0="ح" key1="؛" key2="0" key3=")"/>
+    <key key0="ج" key1=">" key2="-" key3="_"/>
+    <key key0="د" key1="&lt;" key2="=" key3="+"/>
+    <key key0="ذ" key1="ّ" key3="\\" key4="|"/>
+  </row>
+  <row>
+    <key shift="1.0" key0="ش" key1="ِ"/>
+    <key key0="س" key1="ٍ"/>
+    <key key0="ي" key1="["/>
+    <key key0="ب" key1="]"/>
+    <key key0="ل" key1="لأ"/>
+    <key key0="ا" key1="أ"/>
+    <key key0="ت" key1="ـ"/>
+    <key key0="ن" key1="،"/>
+    <key key0="م" key1="/"/>
+    <key key0="ك" key1=":"/>
+    <key key0="ط" key1="&quot;"/>
+  </row>
+  <row>
+    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key key0="ئ" key1="~"/>
+    <key key0="ء" key1="ْ"/>
+    <key key0="ؤ" key1="{"/>
+    <key key0="ر" key1="}"/>
+    <key key0="لا" key1="لآ"/>
+    <key key0="ى" key1="آ"/>
+    <key key0="ة" key1="’"/>
+    <key key0="و" key1=","/>
+    <key key0="ز" key1="."/>
+    <key key0="ظ" key1="؟"/>
+    <key width="1.5" key0="backspace" key2="delete"/>
+  </row>
+</keyboard>

--- a/res/xml/ar_pc.xml
+++ b/res/xml/ar_pc.xml
@@ -12,11 +12,11 @@
     <key key0="خ" key1="&#0215;" key2="9" key3="("/>
     <key key0="ح" key1="&#1563;" key2="0" key3=")"/>
     <key key0="ج" key1="&gt;" key2="-" key3="_"/>
-    <key key0="د" key1="&lt;" key2="=" key3="+"/>
-    <key key0="ذ" key1="&#1617;" key3="\\" key4="|"/>
+    <key key0="د" key1="&lt;" key2="=" key3="ذ"/>
+    <!-- <key key0="ذ" key1="&#1617;" key3="\\" key4="|"/> -->
   </row>
   <row>
-    <key shift="1.0" key0="ش" key1="&#1616;"/>
+    <key shift="0.5" key0="ش" key1="&#1616;" key4="tab"/>
     <key key0="س" key1="&#1613;"/>
     <key key0="ي" key1="["/>
     <key key0="ب" key1="]"/>
@@ -29,8 +29,7 @@
     <key key0="ط" key1="&quot;"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
-    <key key0="ئ" key1="~"/>
+    <key shift="0.5" key0="ئ" key1="~"/>
     <key key0="ء" key1="&#1618;"/>
     <key key0="ؤ" key1="{"/>
     <key key0="ر" key1="}"/>

--- a/res/xml/ar_pc.xml
+++ b/res/xml/ar_pc.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <keyboard>
   <row>
-    <key key0="ض" key1="َ" key2="`" key4="esc"/>
-    <key key0="ص" key1="ً" key2="2" key3="\@"/>
-    <key key0="ث" key1="ُ" key2="3" key3="\#" key4="loc €"/>
-    <key key0="ق" key1="ٌ" key2="4" key3="$" key4="loc £"/>
-    <key key0="ف" key1="لإ" key2="5" key3="%"/>
-    <key key0="غ" key1="إ" key2="6" key3="^"/>
-    <key key0="ع" key1="‘" key2="7" key3="&amp;"/>
-    <key key0="ه" key1="÷" key2="8" key3="*"/>
-    <key key0="خ" key1="×" key2="9" key3="("/>
-    <key key0="ح" key1="؛" key2="0" key3=")"/>
-    <key key0="ج" key1=">" key2="-" key3="_"/>
+    <key key0="ض" key1="&#1614;" key2="`" key4="esc"/>
+    <key key0="ص" key1="&#1611;" key2="2" key3="\@"/>
+    <key key0="ث" key1="&#1615;" key2="3" key3="\#" key4="loc €"/>
+    <key key0="ق" key1="&#1612;" key2="4" key3="$" key4="loc £"/>
+    <key key0="ف" key1="&#1604;&#1573;" key2="5" key3="%"/>
+    <key key0="غ" key1="&#1573;" key2="6" key3="^"/>
+    <key key0="ع" key1="&#8216;" key2="7" key3="&amp;"/>
+    <key key0="ه" key1="&#0247;" key2="8" key3="*"/>
+    <key key0="خ" key1="&#0215;" key2="9" key3="("/>
+    <key key0="ح" key1="&#1563;" key2="0" key3=")"/>
+    <key key0="ج" key1="&gt;" key2="-" key3="_"/>
     <key key0="د" key1="&lt;" key2="=" key3="+"/>
-    <key key0="ذ" key1="ّ" key3="\\" key4="|"/>
+    <key key0="ذ" key1="&#1617;" key3="\\" key4="|"/>
   </row>
   <row>
-    <key shift="1.0" key0="ش" key1="ِ"/>
-    <key key0="س" key1="ٍ"/>
+    <key shift="1.0" key0="ش" key1="&#1616;"/>
+    <key key0="س" key1="&#1613;"/>
     <key key0="ي" key1="["/>
     <key key0="ب" key1="]"/>
-    <key key0="ل" key1="لأ"/>
+    <key key0="ل" key1="&#1604;&#1571;"/>
     <key key0="ا" key1="أ"/>
     <key key0="ت" key1="ـ"/>
-    <key key0="ن" key1="،"/>
+    <key key0="ن" key1="&#1548;"/>
     <key key0="م" key1="/"/>
     <key key0="ك" key1=":"/>
     <key key0="ط" key1="&quot;"/>
@@ -31,15 +31,15 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="ئ" key1="~"/>
-    <key key0="ء" key1="ْ"/>
+    <key key0="ء" key1="&#1618;"/>
     <key key0="ؤ" key1="{"/>
     <key key0="ر" key1="}"/>
-    <key key0="لا" key1="لآ"/>
-    <key key0="ى" key1="آ"/>
-    <key key0="ة" key1="’"/>
+    <key key0="لا" key1="&#1604;&#1570;"/>
+    <key key0="ى" key1="&#1570;"/>
+    <key key0="ة" key1="&#8217;"/>
     <key key0="و" key1=","/>
     <key key0="ز" key1="."/>
-    <key key0="ظ" key1="؟"/>
+    <key key0="ظ" key1="&#1567;"/>
     <key width="1.5" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/res/xml/method.xml
+++ b/res/xml/method.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <input-method xmlns:android="http://schemas.android.com/apk/res/android" android:settingsActivity="juloo.keyboard2.SettingsActivity" android:supportsSwitchingToNextInputMethod="true">
+  <subtype android:label="%s" android:languageTag="ar" android:imeSubtypeLocale="ar" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=ar_pc"/>
   <subtype android:label="%s" android:languageTag="be" android:imeSubtypeLocale="be_BY" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=ru_jcuken,extra_keys=ґ|є|і|ї|ў"/>
   <subtype android:label="%s" android:languageTag="bg" android:imeSubtypeLocale="bg_BG" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=bgph1,extra_keys=€"/>
   <subtype android:label="%s" android:languageTag="bn" android:imeSubtypeLocale="bn_BD" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwerty,extra_keys=৳"/>

--- a/res/xml/method.xml
+++ b/res/xml/method.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <input-method xmlns:android="http://schemas.android.com/apk/res/android" android:settingsActivity="juloo.keyboard2.SettingsActivity" android:supportsSwitchingToNextInputMethod="true">
   <subtype android:label="%s" android:languageTag="ar" android:imeSubtypeLocale="ar" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=ar_pc"/>
-  <subtype android:label="%s" android:languageTag="ar" android:imeSubtypeLocale="ar" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=ar_alt"/>
   <subtype android:label="%s" android:languageTag="be" android:imeSubtypeLocale="be_BY" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=ru_jcuken,extra_keys=ґ|є|і|ї|ў"/>
   <subtype android:label="%s" android:languageTag="bg" android:imeSubtypeLocale="bg_BG" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=bgph1,extra_keys=€"/>
   <subtype android:label="%s" android:languageTag="bn" android:imeSubtypeLocale="bn_BD" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwerty,extra_keys=৳"/>

--- a/res/xml/method.xml
+++ b/res/xml/method.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <input-method xmlns:android="http://schemas.android.com/apk/res/android" android:settingsActivity="juloo.keyboard2.SettingsActivity" android:supportsSwitchingToNextInputMethod="true">
   <subtype android:label="%s" android:languageTag="ar" android:imeSubtypeLocale="ar" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=ar_pc"/>
+  <subtype android:label="%s" android:languageTag="ar" android:imeSubtypeLocale="ar" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=ar_alt"/>
   <subtype android:label="%s" android:languageTag="be" android:imeSubtypeLocale="be_BY" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=ru_jcuken,extra_keys=ґ|є|і|ї|ў"/>
   <subtype android:label="%s" android:languageTag="bg" android:imeSubtypeLocale="bg_BG" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=bgph1,extra_keys=€"/>
   <subtype android:label="%s" android:languageTag="bn" android:imeSubtypeLocale="bn_BD" android:imeSubtypeMode="keyboard" android:isAsciiCapable="true" android:imeSubtypeExtraValue="default_layout=qwerty,extra_keys=৳"/>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -371,6 +371,7 @@ final class Config
       case "ru_jcuken": id = R.xml.local_ru_jcuken; break;
       case "he_il_1452_1": id = R.xml.he_il_1452_1; break;
       case "he_il_1452_2": id = R.xml.he_il_1452_2; break;
+      case "ar_pc": id = R.xml.ar_pc; break;
     }
     return KeyboardData.load(res, id);
   }

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -372,6 +372,7 @@ final class Config
       case "he_il_1452_1": id = R.xml.he_il_1452_1; break;
       case "he_il_1452_2": id = R.xml.he_il_1452_2; break;
       case "ar_pc": id = R.xml.ar_pc; break;
+      case "ar_alt": id = R.xml.ar_alt; break;
     }
     return KeyboardData.load(res, id);
   }


### PR DESCRIPTION
This request is to add Arabic Keyboard

The layout follows closely IBM PC (https://en.wikipedia.org/wiki/Arabic_keyboard#IBM_PC_Arabic_Keyboard) 
Only alteration is the letter (ذ) usually in the number row was moved to the end of the first row. This layout is the most common from my experience.

The following are a screenshots of the current layout, suggestions are welcome.

Without number row:
![without_numrow](https://user-images.githubusercontent.com/10065580/223924250-613cd47d-16b7-408f-a250-d221004a3e4e.jpg)

With number row:
![with_numrow](https://user-images.githubusercontent.com/10065580/223924200-e3ca1df9-5ae4-4a6a-bea9-15b9f31b35fd.jpg)

