### PR TITLE
Do not lock modifiers if sliding a key

### DIFF
--- a/srcs/juloo.keyboard2/Pointers.java
+++ b/srcs/juloo.keyboard2/Pointers.java
@@ -113,6 +113,7 @@ public final class Pointers implements Handler.Callback
       return;
     if (ptr.sliding)
     {
+      clearLatched();
       onTouchUp_sliding(ptr);
       return;
     }


### PR DESCRIPTION
This unconditionally removes all pointers (touches) pressing modifiers which are not already locked, avoiding that the (currently) latched modifier will be locked aventually.

This can be verfified while sliding the space bar to move the cursor left or right.

Closes #319.