### PR TITLE
Add dagger, double dagger, section mark, and pilcrow to all QWERTY-like layouts

### DIFF
--- a/res/xml/cyrl_yaverti.xml
+++ b/res/xml/cyrl_yaverti.xml
@@ -8,7 +8,7 @@
     <key key0="т" key2="5" key3="%"/>
     <key key0="ъ" key2="6" key3="^" key4="€"/>
     <key key0="у" key2="7" key3="&amp;" key4="§"/>
-    <key key0="и" key2="8" key3="*"/>
+    <key key0="и" key2="8" key3="*" key4="†"/>
     <key key0="о" key2="9" key3="(" key4=")"/>
     <key key0="п" key2="0" key3="f11_placeholder" key4="f12_placeholder"/>
   </row>

--- a/res/xml/latn_azerty_fr.xml
+++ b/res/xml/latn_azerty_fr.xml
@@ -32,7 +32,7 @@
     <key key0="x"/>
     <key key0="c" key1="accent_cedille" key3="," key4="\?"/>
     <key key0="v" key3=";" key4="."/>
-    <key key0="b" key3=":" key4="/"/>
+    <key key0="b" key2="†" key3=":" key4="/"/>
     <key key0="n" key1="loc accent_tilde" key2="§" key4="!"/>
     <key width="2.0" key0="backspace" key2="delete"/>
   </row>

--- a/res/xml/latn_qwerty_br.xml
+++ b/res/xml/latn_qwerty_br.xml
@@ -15,8 +15,8 @@
   </row>
   <row>
     <key key0="a" key2="tab" key4="`"/>
-    <key key0="s" key1="'" key3="loc ß" key4="accent_cedille"/>
-    <key key0="d" key1="&quot;"/>
+    <key key0="s" key1="'" key2="§" key3="loc ß" key4="accent_cedille"/>
+    <key key0="d" key1="&quot;" key2="†"/>
     <key key0="f"/>
     <key key0="g"/>
     <key key0="h"/>

--- a/res/xml/latn_qwerty_es.xml
+++ b/res/xml/latn_qwerty_es.xml
@@ -27,7 +27,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x"/>
+    <key key0="x" key2="†" key3="§"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="."/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/" key4="¿"/>

--- a/res/xml/latn_qwerty_hu.xml
+++ b/res/xml/latn_qwerty_hu.xml
@@ -15,7 +15,7 @@
   <row>
     <key shift="0.5" key0="a" key1="tab" key4="á"/>
     <key key0="s" key1="§" key2="\\" key3="[" key4="]"/>
-    <key key0="d" key3="{" key4="}"/>
+    <key key0="d" key1="†" key3="{" key4="}"/>
     <key key0="f" key3="+"/>
     <key key0="g" key3="*"/>
     <key key0="h"/>

--- a/res/xml/latn_qwerty_lv.xml
+++ b/res/xml/latn_qwerty_lv.xml
@@ -14,8 +14,8 @@
   </row>
   <row>
     <key shift="0.5" key0="a" key1="ā" key2="tab"/>
-    <key key0="s" key1="š" key3="loc ß" key4="loc accent_ogonek"/>
-    <key key0="d"/>
+    <key key0="s" key1="š" key2="§" key3="loc ß" key4="loc accent_ogonek"/>
+    <key key0="d" key2="†"/>
     <key key0="f" key1="loc accent_dot_above"/>
     <key key0="g" key1="ģ"/>
     <key key0="h" key2="accent_macron" key3="accent_caron" key4="accent_cedille"/>

--- a/res/xml/latn_qwerty_no.xml
+++ b/res/xml/latn_qwerty_no.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x"/>
+    <key key0="x" key2="†" key3="§"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="."/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/"/>

--- a/res/xml/latn_qwerty_pl.xml
+++ b/res/xml/latn_qwerty_pl.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z" key4="ż"/>
-    <key key0="x" key4="ź"/>
+    <key key0="x" key2="†" key3="§" key4="ź"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="." key4="ć"/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/"/>

--- a/res/xml/latn_qwerty_ro.xml
+++ b/res/xml/latn_qwerty_ro.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x"/>
+    <key key0="x" key2="†" key3="§"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="."/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/"/>

--- a/res/xml/latn_qwerty_se.xml
+++ b/res/xml/latn_qwerty_se.xml
@@ -15,8 +15,8 @@
   </row>
   <row>
     <key key0="a" key2="tab"/>
-    <key key0="s" key1="accent_ring" key3="loc ß"/>
-    <key key0="d" key3="accent_aigu"/>
+    <key key0="s" key1="accent_ring" key2="§" key3="loc ß"/>
+    <key key0="d" key2="†" key3="accent_aigu"/>
     <key key0="f" key1="accent_trema"/>
     <key key0="g"/>
     <key key0="h"/>

--- a/res/xml/latn_qwerty_tr.xml
+++ b/res/xml/latn_qwerty_tr.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x"/>
+    <key key0="x" key2="†" key3="§"/>
     <key key0="c" key1="ç" key2="&lt;" key3="."/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/"/>

--- a/res/xml/latn_qwerty_us.xml
+++ b/res/xml/latn_qwerty_us.xml
@@ -47,7 +47,7 @@ See srcs/juloo.keyboard2/KeyValue.java for the keys that have a special meaning.
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x"/>
+    <key key0="x" key2="†" key3="§"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="."/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/"/>

--- a/res/xml/latn_qwerty_vi.xml
+++ b/res/xml/latn_qwerty_vi.xml
@@ -27,7 +27,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x" key1="accent_tilde"/>
+    <key key0="x" key1="accent_tilde" key2="†" key3="§"/>
     <key key0="c" key2="&lt;" key3="."/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/"/>

--- a/res/xml/latn_qwertz.xml
+++ b/res/xml/latn_qwertz.xml
@@ -15,7 +15,7 @@
   <row>
     <key shift="0.5" key0="a" key1="tab" key2="`" key3="ä"/>
     <key key0="s" key3="ß"/>
-    <key key0="d"/>
+    <key key0="d" key1="†"/>
     <key key0="f" key1="~"/>
     <key key0="g" key3="-"/>
     <key key0="h" key3="+"/>

--- a/res/xml/latn_qwertz_cz.xml
+++ b/res/xml/latn_qwertz_cz.xml
@@ -14,8 +14,8 @@
   </row>
   <row>
     <key shift="0.5" key0="a" key1="tab" key2="á" key3=";"/>
-    <key key0="s" key4="š"/>
-    <key key0="d" key4="ď"/>
+    <key key0="s" key1="§" key4="š"/>
+    <key key0="d" key1="†" key4="ď"/>
     <key key0="f" key3="["/>
     <key key0="g" key3="]"/>
     <key key0="h"/>

--- a/res/xml/latn_qwertz_cz_multifunctional.xml
+++ b/res/xml/latn_qwertz_cz_multifunctional.xml
@@ -25,7 +25,7 @@
   </row>
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
-    <key key0="y" key1="÷" key2="ý"/>
+    <key key0="y" key1="÷" key2="ý" key3="†"/>
     <key key0="x" key1="∙" key3="×"/>
     <key key0="c" key1="\#" key2="γ" key3="&amp;" key4="č"/>
     <key key0="v" key1="|" key3="\@"/>

--- a/res/xml/latn_qwertz_de.xml
+++ b/res/xml/latn_qwertz_de.xml
@@ -17,7 +17,7 @@
   <row>
     <key key0="a" key2="tab"/>
     <key key0="s" key1="`" key3="ß"/>
-    <key key0="d"/>
+    <key key0="d" key1="†"/>
     <key key0="f" key1="~"/>
     <key key0="g" key3="-"/>
     <key key0="h" key3="+"/>

--- a/res/xml/latn_qwertz_hu.xml
+++ b/res/xml/latn_qwertz_hu.xml
@@ -15,7 +15,7 @@
   <row>
     <key shift="0.5" key0="a" key1="tab" key4="á"/>
     <key key0="s" key1="§" key2="\\" key3="[" key4="]"/>
-    <key key0="d" key3="{" key4="}"/>
+    <key key0="d" key1="†" key3="{" key4="}"/>
     <key key0="f" key3="+"/>
     <key key0="g" key3="*"/>
     <key key0="h"/>

--- a/res/xml/latn_qwertz_sk.xml
+++ b/res/xml/latn_qwertz_sk.xml
@@ -14,8 +14,8 @@
   </row>
   <row>
     <key key0="a" key1="tab" key3="á" key4="ä"/>
-    <key key0="s" key3="ś" key4="š"/>
-    <key key0="d" key4="ď"/>
+    <key key0="s" key1="§" key3="ś" key4="š"/>
+    <key key0="d" key1="†" key4="ď"/>
     <key key0="f" key1="%" key2="*"/>
     <key key0="g" key2="^"/>
     <key key0="h" key1="~" key2="÷"/>

--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -238,6 +238,7 @@ class KeyModifier
       case '?': return "¿";
       case '|': return "¦";
       case '§': return "¶";
+      case '†': return "‡";
       case '×': return "∙";
       // arrows
       case '↖': return "⇖";


### PR DESCRIPTION
I use the QWERTY (US) layout and I miss these punctuation marks, which can be found in other Android keyboards including the LineageOS stock keyboard US layout. So I've added them to all QWERTY-like keyboard layouts, according to the following rules:

1. If § was already in the layout, then I added † next to it in the same position. Usually this put † on the D key.
2. If < and . were already in the 2nd and 3rd position on the C key, as in the US layout, then I put § and † in the 2nd and 3rd position on the X key.
3. Otherwise, I put § and † on the S and D keys, in the same position.

The result is about as consistent as I think is possible, without moving any existing characters, in that § and † are in almost the same place on almost all of the QWERTY-like layouts (except AZERTY and ЯВЕРТИ).