### PR TITLE
Add dagger, double dagger, section mark, and pilcrow as extra keys on QWERTY-like layouts

### DIFF
--- a/res/xml/latn_azerty_fr.xml
+++ b/res/xml/latn_azerty_fr.xml
@@ -29,7 +29,7 @@
   <row>
     <key width="2.0" key0="shift" key2="loc capslock"/>
     <key key0="w" key3="&lt;" key4="&gt;"/>
-    <key key0="x"/>
+    <key key0="x" key1="loc †"/>
     <key key0="c" key1="accent_cedille" key3="," key4="\?"/>
     <key key0="v" key3=";" key4="."/>
     <key key0="b" key3=":" key4="/"/>

--- a/res/xml/latn_qwerty_br.xml
+++ b/res/xml/latn_qwerty_br.xml
@@ -28,7 +28,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x"/>
+    <key key0="x" key2="loc †"/>
     <key key0="c"/>
     <key key0="v"/>
     <key key0="b"/>

--- a/res/xml/latn_qwerty_br.xml
+++ b/res/xml/latn_qwerty_br.xml
@@ -15,7 +15,7 @@
   </row>
   <row>
     <key key0="a" key2="tab" key4="`"/>
-    <key key0="s" key1="'" key3="loc ß" key4="accent_cedille"/>
+    <key key0="s" key1="'" key2="loc §" key3="loc ß" key4="accent_cedille"/>
     <key key0="d" key1="&quot;"/>
     <key key0="f"/>
     <key key0="g"/>

--- a/res/xml/latn_qwerty_es.xml
+++ b/res/xml/latn_qwerty_es.xml
@@ -14,7 +14,7 @@
   </row>
   <row>
     <key key0="a" key2="tab" key4="`"/>
-    <key key0="s" key2="¡" key3="loc ß"/>
+    <key key0="s" key1="loc §" key2="¡" key3="loc ß"/>
     <key key0="d" key1="accent_grave" key3="accent_aigu"/>
     <key key0="f"/>
     <key key0="g" key2="-" key3="_"/>

--- a/res/xml/latn_qwerty_es.xml
+++ b/res/xml/latn_qwerty_es.xml
@@ -27,7 +27,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x"/>
+    <key key0="x" key1="loc †"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="."/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/" key4="¿"/>

--- a/res/xml/latn_qwerty_hu.xml
+++ b/res/xml/latn_qwerty_hu.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z" key3="&lt;" key4="&gt;"/>
-    <key key0="x" key4="\#"/>
+    <key key0="x" key1="loc †" key4="\#"/>
     <key key0="c" key4="&amp;"/>
     <key key0="v" key4="\@"/>
     <key key0="b" key1="\?" key3="," key4=";"/>

--- a/res/xml/latn_qwerty_lv.xml
+++ b/res/xml/latn_qwerty_lv.xml
@@ -14,7 +14,7 @@
   </row>
   <row>
     <key shift="0.5" key0="a" key1="ā" key2="tab"/>
-    <key key0="s" key1="š" key3="loc ß" key4="loc accent_ogonek"/>
+    <key key0="s" key1="š" key2="loc §" key3="loc ß" key4="loc accent_ogonek"/>
     <key key0="d"/>
     <key key0="f" key1="loc accent_dot_above"/>
     <key key0="g" key1="ģ"/>

--- a/res/xml/latn_qwerty_lv.xml
+++ b/res/xml/latn_qwerty_lv.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z" key1="ž"/>
-    <key key0="x"/>
+    <key key0="x" key2="loc †"/>
     <key key0="c" key1="č"/>
     <key key0="v"/>
     <key key0="b" key2="\?" key3="&lt;" key4="&gt;"/>

--- a/res/xml/latn_qwerty_no.xml
+++ b/res/xml/latn_qwerty_no.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x"/>
+    <key key0="x" key2="loc †"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="."/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/"/>

--- a/res/xml/latn_qwerty_no.xml
+++ b/res/xml/latn_qwerty_no.xml
@@ -14,7 +14,7 @@
   </row>
   <row>
     <key shift="0.5" key0="a" key1="tab" key2="`" key3="æ" key4="å"/>
-    <key key0="s" key1="loc accent_ring" key3="loc ß" key4="loc accent_ogonek"/>
+    <key key0="s" key1="loc accent_ring" key2="loc §" key3="loc ß" key4="loc accent_ogonek"/>
     <key key0="d" key1="loc accent_grave" key2="loc £" key3="loc accent_aigu"/>
     <key key0="f" key1="loc accent_dot_above"/>
     <key key0="g" key1="loc accent_caron" key2="-" key3="_"/>

--- a/res/xml/latn_qwerty_pl.xml
+++ b/res/xml/latn_qwerty_pl.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z" key4="ż"/>
-    <key key0="x" key4="ź"/>
+    <key key0="x" key2="loc †" key4="ź"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="." key4="ć"/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/"/>

--- a/res/xml/latn_qwerty_pl.xml
+++ b/res/xml/latn_qwerty_pl.xml
@@ -14,7 +14,7 @@
   </row>
   <row>
     <key shift="0.5" key0="a" key1="tab" key2="`" key4="ą"/>
-    <key key0="s" key1="loc accent_ring" key3="loc ß" key4="ś"/>
+    <key key0="s" key1="loc accent_ring" key2="loc §" key3="loc ß" key4="ś"/>
     <key key0="d" key1="loc accent_grave" key2="loc £" key3="loc accent_aigu"/>
     <key key0="f" key1="loc accent_dot_above" key4="loc accent_ogonek"/>
     <key key0="g" key1="loc accent_caron" key2="-" key3="_"/>

--- a/res/xml/latn_qwerty_ro.xml
+++ b/res/xml/latn_qwerty_ro.xml
@@ -14,7 +14,7 @@
   </row>
   <row>
     <key shift="0.5" key0="a" key1="â" key2="ă" key3="`" key4="tab"/>
-    <key key0="s" key1="ș" key3="loc ß" key4="loc accent_ogonek"/>
+    <key key0="s" key1="ș" key2="loc §" key3="loc ß" key4="loc accent_ogonek"/>
     <key key0="d" key1="loc accent_grave" key2="loc £" key3="loc accent_aigu"/>
     <key key0="f" key1="loc accent_dot_above"/>
     <key key0="g" key1="loc accent_caron" key2="-" key3="_"/>

--- a/res/xml/latn_qwerty_ro.xml
+++ b/res/xml/latn_qwerty_ro.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x"/>
+    <key key0="x" key2="loc †"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="."/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/"/>

--- a/res/xml/latn_qwerty_se.xml
+++ b/res/xml/latn_qwerty_se.xml
@@ -15,7 +15,7 @@
   </row>
   <row>
     <key key0="a" key2="tab"/>
-    <key key0="s" key1="accent_ring" key3="loc ß"/>
+    <key key0="s" key1="accent_ring" key2="loc §" key3="loc ß"/>
     <key key0="d" key3="accent_aigu"/>
     <key key0="f" key1="accent_trema"/>
     <key key0="g"/>

--- a/res/xml/latn_qwerty_se.xml
+++ b/res/xml/latn_qwerty_se.xml
@@ -29,7 +29,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x"/>
+    <key key0="x" key2="loc †"/>
     <key key0="c"/>
     <key key0="v"/>
     <key key0="b" key2=";" key4=","/>

--- a/res/xml/latn_qwerty_tr.xml
+++ b/res/xml/latn_qwerty_tr.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x"/>
+    <key key0="x" key2="loc †"/>
     <key key0="c" key1="ç" key2="&lt;" key3="."/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/"/>

--- a/res/xml/latn_qwerty_tr.xml
+++ b/res/xml/latn_qwerty_tr.xml
@@ -14,7 +14,7 @@
   </row>
   <row>
     <key shift="0.5" key0="a" key1="tab" key2="`"/>
-    <key key0="s" key1="ş"/>
+    <key key0="s" key1="ş" key2="loc §"/>
     <key key0="d"/>
     <key key0="f"/>
     <key key0="g" key1="ğ" key2="-" key3="_"/>

--- a/res/xml/latn_qwerty_us.xml
+++ b/res/xml/latn_qwerty_us.xml
@@ -35,7 +35,7 @@ See srcs/juloo.keyboard2/KeyValue.java for the keys that have a special meaning.
   </row>
   <row>
     <key shift="0.5" key0="a" key1="tab" key2="`"/>
-    <key key0="s" key1="loc accent_ring" key3="loc ß" key4="loc accent_ogonek"/>
+    <key key0="s" key1="loc accent_ring" key2="loc §" key3="loc ß" key4="loc accent_ogonek"/>
     <key key0="d" key1="loc accent_grave" key2="loc £" key3="loc accent_aigu"/>
     <key key0="f" key1="loc accent_dot_above"/>
     <key key0="g" key1="loc accent_caron" key2="-" key3="_"/>

--- a/res/xml/latn_qwerty_us.xml
+++ b/res/xml/latn_qwerty_us.xml
@@ -47,7 +47,7 @@ See srcs/juloo.keyboard2/KeyValue.java for the keys that have a special meaning.
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x"/>
+    <key key0="x" key2="loc †"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="."/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/"/>

--- a/res/xml/latn_qwerty_vi.xml
+++ b/res/xml/latn_qwerty_vi.xml
@@ -27,7 +27,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
-    <key key0="x" key1="accent_tilde"/>
+    <key key0="x" key1="accent_tilde" key2="loc †"/>
     <key key0="c" key2="&lt;" key3="."/>
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="b" key2="\?" key3="/"/>

--- a/res/xml/latn_qwerty_vi.xml
+++ b/res/xml/latn_qwerty_vi.xml
@@ -15,7 +15,7 @@
   </row>
   <row>
     <key shift="0.5" key0="a" key1="tab" key2="ă" key3="â"/>
-    <key key0="s" key1="accent_aigu"/>
+    <key key0="s" key1="accent_aigu" key2="loc §"/>
     <key key0="d" key1="accent_bar" key2="₫" key3="đ"/>
     <key key0="f" key1="accent_grave"/>
     <key key0="g" key2="-" key3="_"/>

--- a/res/xml/latn_qwertz.xml
+++ b/res/xml/latn_qwertz.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="y" key1="&gt;" key2="|" key3="&lt;"/>
-    <key key0="x"/>
+    <key key0="x" key1="loc †"/>
     <key key0="c"/>
     <key key0="v" />
     <key key0="b" key1=";" key3=","/>

--- a/res/xml/latn_qwertz_cz.xml
+++ b/res/xml/latn_qwertz_cz.xml
@@ -14,7 +14,7 @@
   </row>
   <row>
     <key shift="0.5" key0="a" key1="tab" key2="á" key3=";"/>
-    <key key0="s" key4="š"/>
+    <key key0="s" key1="loc §" key4="š"/>
     <key key0="d" key4="ď"/>
     <key key0="f" key3="["/>
     <key key0="g" key3="]"/>

--- a/res/xml/latn_qwertz_cz.xml
+++ b/res/xml/latn_qwertz_cz.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="y" key2="ý"/>
-    <key key0="x" key3="\#"/>
+    <key key0="x" key1="loc †" key3="\#"/>
     <key key0="c" key3="&amp;" key4="č"/>
     <key key0="v" key3="\@"/>
     <key key0="b" key1="&lt;" key2="&gt;" key3="{" key4="}"/>

--- a/res/xml/latn_qwertz_cz_multifunctional.xml
+++ b/res/xml/latn_qwertz_cz_multifunctional.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="y" key1="÷" key2="ý"/>
-    <key key0="x" key1="∙" key3="×"/>
+    <key key0="x" key1="∙" key3="×" key4="loc †"/>
     <key key0="c" key1="\#" key2="γ" key3="&amp;" key4="č"/>
     <key key0="v" key1="|" key3="\@"/>
     <key key0="b" key1=";" key2="♭" key3=":" key4="β"/>

--- a/res/xml/latn_qwertz_de.xml
+++ b/res/xml/latn_qwertz_de.xml
@@ -30,7 +30,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key shift="0.5" key0="y" key1="&gt;" key2="|" key3="&lt;"/>
-    <key key0="x"/>
+    <key key0="x" key1="loc †"/>
     <key key0="c"/>
     <key key0="v"/>
     <key key0="b" key1=";" key3=","/>

--- a/res/xml/latn_qwertz_hu.xml
+++ b/res/xml/latn_qwertz_hu.xml
@@ -26,7 +26,7 @@
   <row>
     <key width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="y" key3="&lt;" key4="&gt;"/>
-    <key key0="x" key4="\#"/>
+    <key key0="x" key1="loc †" key4="\#"/>
     <key key0="c" key4="&amp;"/>
     <key key0="v" key4="\@"/>
     <key key0="b" key1="\?" key3="," key4=";"/>

--- a/res/xml/latn_qwertz_sk.xml
+++ b/res/xml/latn_qwertz_sk.xml
@@ -27,7 +27,7 @@
   <row>
     <key key0="shift" key2="loc capslock"/>
     <key key0="y" key1="$" key3="ý"/>
-    <key key0="x"/>
+    <key key0="x" key1="loc †"/>
     <key key0="c" key4="č"/>
     <key key0="v" key4="\@"/>
     <key key0="b" key1="\#" key2="&amp;" key3="-" key4="_"/>

--- a/res/xml/latn_qwertz_sk.xml
+++ b/res/xml/latn_qwertz_sk.xml
@@ -14,7 +14,7 @@
   </row>
   <row>
     <key key0="a" key1="tab" key3="á" key4="ä"/>
-    <key key0="s" key3="ś" key4="š"/>
+    <key key0="s" key1="loc §" key3="ś" key4="š"/>
     <key key0="d" key4="ď"/>
     <key key0="f" key1="%" key2="*"/>
     <key key0="g" key2="^"/>

--- a/srcs/juloo.keyboard2/ExtraKeysPreference.java
+++ b/srcs/juloo.keyboard2/ExtraKeysPreference.java
@@ -42,6 +42,7 @@ public class ExtraKeysPreference extends PreferenceCategory
     "ß",
     "£",
     "§",
+    "†",
     "switch_greekmath",
     "capslock",
     "copy",

--- a/srcs/juloo.keyboard2/ExtraKeysPreference.java
+++ b/srcs/juloo.keyboard2/ExtraKeysPreference.java
@@ -41,6 +41,7 @@ public class ExtraKeysPreference extends PreferenceCategory
     "€",
     "ß",
     "£",
+    "§",
     "switch_greekmath",
     "capslock",
     "copy",

--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -238,6 +238,7 @@ class KeyModifier
       case '?': return "¿";
       case '|': return "¦";
       case '§': return "¶";
+      case '†': return "‡";
       case '×': return "∙";
       // arrows
       case '↖': return "⇖";


### PR DESCRIPTION
I use the QWERTY (US) layout and I miss these punctuation marks, which can be found in other Android keyboards including the LineageOS stock keyboard US layout. So I added section mark and dagger as user-selectable extras on the S and X keys (except for the layouts that already had the section mark). Double dagger can be entered as a modified dagger.