### PR TITLE
Change Greek math koppa to lowercase

### DIFF
--- a/res/xml/greekmath.xml
+++ b/res/xml/greekmath.xml
@@ -31,7 +31,7 @@
     <key key0="ϡ" key4="∩"/>
     <key key0="υ" key3="∇" key4="ℵ"/>
     <key key0="ζ" key1="≤" key3="ℤ" key4="1"/>
-    <key key0="Ϟ" key1="≠" key3="ℚ" key4="2"/>
+    <key key0="ϟ" key1="≠" key3="ℚ" key4="2"/>
     <key key0="κ" key1="≥" key3="×" key4="3"/>
     <key width="1.5" key0="backspace" key3="delete"/>
   </row>


### PR DESCRIPTION
Uppercase koppa can still be entered as shift+koppa.