### PR TITLE
Resolve layout warnings in neo2

### DIFF
--- a/res/xml/latn_neo2.xml
+++ b/res/xml/latn_neo2.xml
@@ -7,8 +7,8 @@
     <key key0="l" key2="3" key4="["/>
     <key key0="c" key2="4" key4="]"/>
     <key key0="w" key2="5" key4="^"/>
-    <key key0="k" key1="$" key2="6" key4="!"/>
-    <key key0="h" key1="€" key2="7" key4="&lt;"/>
+    <key key0="k" key2="6" key4="!"/>
+    <key key0="h" key2="7" key4="&lt;"/>
     <key key0="g" key2="8" key4="&gt;"/>
     <key key0="f" key2="9" key3="f11_placeholder" key4="="/>
     <key key0="q" key2="0" key3="f12_placeholder" key4="&amp;"/>

--- a/res/xml/latn_neo2.xml
+++ b/res/xml/latn_neo2.xml
@@ -7,12 +7,12 @@
     <key key0="l" key2="3" key4="["/>
     <key key0="c" key2="4" key4="]"/>
     <key key0="w" key2="5" key4="^"/>
-    <key key0="k" key2="6" key4="!"/>
-    <key key0="h" key2="7" key4="&lt;"/>
+    <key key0="k" key1="$" key2="6" key4="!"/>
+    <key key0="h" key1="€" key2="7" key4="&lt;"/>
     <key key0="g" key2="8" key4="&gt;"/>
     <key key0="f" key2="9" key3="f11_placeholder" key4="="/>
     <key key0="q" key2="0" key3="f12_placeholder" key4="&amp;"/>
-    <key key0="ß" key1="-"/>
+    <key key0="ß" key1="—"/>
   </row>
   <row>
     <key key0="u" key1="tab" key4="\\"/>
@@ -40,11 +40,11 @@
     <key width="1.5" key0="backspace" key2="delete"/>
   </row>
   <row height="0.95">
-	  <key width="1.8" key0="ctrl" key2="loc meta" key4="switch_numeric"/>
+	  <key width="1.8" key0="ctrl" key1="loc switch_greekmath" key2="loc meta" key4="switch_numeric"/>
 	  <key width="1.2" key0="fn" key1="loc alt" key2="change_method" key3="switch_emoji" key4="config"/>
-	  <key width="4.0" key0="space" key7="switch_second" key8="switch_backward"/>
+	  <key width="4.0" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right" slider="true"/>
 	  <key width="1.2" key7="up" key6="right" key5="left" key8="down"/>
 	  <key key0="j" key4=";"/>
-	  <key width="1.8" key0="enter" key2="action"/>
+	  <key width="1.8" key0="enter" key1="loc voice_typing" key2="action"/>
 	</row>
 </keyboard>


### PR DESCRIPTION
The update to the bottom row did not get into neo2. This resolves the warnings found by check_layout.py:
- Replace "-" with "—" on the "ß" key
   "-" should be U+2011 (non-breaking hyphen), but this mostly is not recognized by apps, —" (U+2014, EM Dash) is in the second layer of the same key and was not available before.
- ~"$" and "€" are available again ("$" is not available from the additional key menu, is this intentional)~
  edit: $ was already present, I reverted this point
- Update bottom row special keys

https://github.com/Julow/Unexpected-Keyboard/blob/5b4345088d419ab2b26df11fbc80bc265181df93/check_layout.output#L65-L68