### PR TITLE
Adds the ability for users to invoke the soft keyboard anywhere, at any time, even on screens that do not normally allow keyboards. This approach works even on Android 13 (API 33)

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -18,7 +18,13 @@
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity>
+    <service
+        android:name=".OverlayService"
+        android:enabled="true"
+        android:exported="false"/>
   </application>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 </manifest>

--- a/res/layout/launcher_activity.xml
+++ b/res/layout/launcher_activity.xml
@@ -6,4 +6,5 @@
   <TextView style="@style/paragraph" android:text="https://github.com/Julow/Unexpected-Keyboard" android:autoLink="web" android:linksClickable="true"/>
   <TextView android:id="@+id/launcher_tryhere_text" style="@style/paragraph" android:text="@string/launcher_tryhere"/>
   <EditText android:id="@+id/launcher_tryhere_area" style="@style/paragraph" android:inputType="text"/>
+  <Button style="@style/paragraph" android:text="Show Persistent Keyboard" android:onClick="startOverlayService" android:layout_width="wrap_content"/>
 </LinearLayout>

--- a/res/layout/overlay_button.xml
+++ b/res/layout/overlay_button.xml
@@ -2,18 +2,23 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:padding="10dp"
     android:orientation="horizontal">
 
-    <Button
-        android:id="@+id/invokeKeyboardButton"
-        android:layout_width="72dp"
-        android:layout_height="wrap_content"
-        android:text="Show" />
 
-    <Button
+    <ImageView
+        android:id="@+id/invokeKeyboardButton"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:background="@android:color/darker_gray"
+        android:gravity="center"
+        android:scaleType="fitCenter"
+        android:src="@drawable/ic_launcher_foreground" />
+
+    <ImageView
         android:id="@+id/closeOverlayButton"
-        android:layout_width="32dp"
-        android:layout_height="32dp"
+        android:layout_width="25dp"
+        android:layout_height="25dp"
         android:background="#FF8282"
-        android:text="x" />
+        android:src="@android:drawable/ic_menu_close_clear_cancel" />
 </LinearLayout>

--- a/res/layout/overlay_button.xml
+++ b/res/layout/overlay_button.xml
@@ -1,0 +1,19 @@
+<!-- overlay_button.xml -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <Button
+        android:id="@+id/invokeKeyboardButton"
+        android:layout_width="72dp"
+        android:layout_height="wrap_content"
+        android:text="Show" />
+
+    <Button
+        android:id="@+id/closeOverlayButton"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:background="#FF8282"
+        android:text="x" />
+</LinearLayout>

--- a/srcs/juloo.keyboard2/LauncherActivity.java
+++ b/srcs/juloo.keyboard2/LauncherActivity.java
@@ -35,7 +35,7 @@ public class LauncherActivity extends Activity
   private static final int REQUEST_CODE_OVERLAY_PERMISSION = 1601;
   private void requestOverlayPermission() {
     // Request the permission using an Intent
-    Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, Uri.parse("package:" + getPackageName()));
+    Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, Uri.fromParts("package", getPackageName(), ""));
     startActivityForResult(intent, REQUEST_CODE_OVERLAY_PERMISSION);
   }
 
@@ -58,6 +58,7 @@ public class LauncherActivity extends Activity
       // Check if the permission was granted
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Settings.canDrawOverlays(this)) {
         Toast.makeText(this, "Overlay permissions are granted. You can now launch persistent keyboards.", Toast.LENGTH_SHORT).show();
+        startService(new Intent(this, OverlayService.class));
       } else {
         Toast.makeText(this, "Overlay permissions are required for launching persistent keyboard.", Toast.LENGTH_SHORT).show();
       }

--- a/srcs/juloo.keyboard2/LauncherActivity.java
+++ b/srcs/juloo.keyboard2/LauncherActivity.java
@@ -2,6 +2,8 @@ package juloo.keyboard2;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Bundle;
 import android.provider.Settings;
@@ -9,6 +11,7 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
+import android.widget.Toast;
 
 public class LauncherActivity extends Activity
 {
@@ -26,6 +29,39 @@ public class LauncherActivity extends Activity
     if (VERSION.SDK_INT > 28)
       _tryhere_area.addOnUnhandledKeyEventListener(
           this.new Tryhere_OnUnhandledKeyEventListener());
+
+  }
+
+  private static final int REQUEST_CODE_OVERLAY_PERMISSION = 1601;
+  private void requestOverlayPermission() {
+    // Request the permission using an Intent
+    Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, Uri.parse("package:" + getPackageName()));
+    startActivityForResult(intent, REQUEST_CODE_OVERLAY_PERMISSION);
+  }
+
+  public void startOverlayService(View _btn) {
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(this)) {
+      // If not, request the permission
+      requestOverlayPermission();
+    } else {
+      startService(new Intent(this, OverlayService.class));
+    }
+  }
+
+  @Override
+  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
+
+    //handle response for overlay permission request
+    if (requestCode == REQUEST_CODE_OVERLAY_PERMISSION) {
+      // Check if the permission was granted
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Settings.canDrawOverlays(this)) {
+        Toast.makeText(this, "Overlay permissions are granted. You can now launch persistent keyboards.", Toast.LENGTH_SHORT).show();
+      } else {
+        Toast.makeText(this, "Overlay permissions are required for launching persistent keyboard.", Toast.LENGTH_SHORT).show();
+      }
+    }
   }
 
   public void launch_imesettings(View _btn)

--- a/srcs/juloo.keyboard2/OverlayService.java
+++ b/srcs/juloo.keyboard2/OverlayService.java
@@ -1,0 +1,90 @@
+package juloo.keyboard2;
+
+import android.app.Service;
+import android.content.Intent;
+import android.graphics.PixelFormat;
+import android.os.Build;
+import android.os.IBinder;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+
+public class OverlayService extends Service {
+
+    private WindowManager windowManager;
+    private View overlayView;
+
+    public OverlayService() {
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        WindowManager.LayoutParams layoutParams = new WindowManager.LayoutParams(
+        WindowManager.LayoutParams.WRAP_CONTENT,
+        WindowManager.LayoutParams.WRAP_CONTENT,
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                ? WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+                : WindowManager.LayoutParams.TYPE_PHONE,
+        WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL,
+        PixelFormat.TRANSLUCENT);
+
+        //setup the temporary button that the user can use to launch the soft keyboard
+        overlayView = LayoutInflater.from(this).inflate(R.layout.overlay_button, null);
+        layoutParams.gravity =  Gravity.TOP | Gravity.START;
+        windowManager = (WindowManager) getSystemService(WINDOW_SERVICE);
+        overlayView.requestFocus();
+        windowManager.addView(overlayView, layoutParams);
+
+        //handle the show keyboard button
+        overlayView.findViewById(R.id.invokeKeyboardButton).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                //force the keyboard to display. this approach is confirmed to work on API 33.
+                InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
+                inputMethodManager.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
+
+                //we must dismiss the UI to prevent it from interfering with key input
+                new Timer().schedule(new TimerTask() {
+                    @Override
+                    public void run() {
+                        stopSelf();
+                    }
+                }, 200);
+            }
+        });
+
+        //handle the X button to close overlay and keyboard
+        overlayView.findViewById(R.id.closeOverlayButton).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+
+                //if the keyboard is currently show, dismiss it
+                InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
+                inputMethodManager.hideSoftInputFromWindow(overlayView.getWindowToken(), 0);
+
+                stopSelf(); //kill the overlay so it doesn't c continue interfering with key input
+            }
+        });
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (overlayView != null) {
+            windowManager.removeView(overlayView);
+        }
+    }
+}


### PR DESCRIPTION
I went ahead and did it myself, because I really needed the functionality. I am quite certain no other FOSS keyboard has this ability working in Android 13.

This PR adds the ability for users to invoke the soft keyboard anywhere, at any time, even on screens that do not normally allow keyboards. This approach works even on Android 13 (API 33), and is an essential replacement for the now-defunct Hacker Keyboard's Permanent Notification, which had a similar capability but stopped functioning after API 30 (https://github.com/klausw/hackerskeyboard/issues/897).

Closes https://github.com/Julow/Unexpected-Keyboard/issues/496, Closes https://github.com/Julow/Unexpected-Keyboard/issues/71, Closes https://github.com/Julow/Unexpected-Keyboard/issues/392 and Closes https://github.com/Julow/Unexpected-Keyboard/issues/69 

How to use:
1. Launch Unexpected Keyboard, and click `Show Persistent Keyboard`
2. Grant the `Draw Over Other Apps` permission, allowing overlays to be displayed.
3. Now, whenever you require a keyboard, launch the app and press `Show Persistent Keyboard`
4. A button overlay will appear in the top left corner
5. Navigate back to the app you want to use that does not support keyboards.
6. Click the `Show` button in the top left corner. The overlay will be closed, and at the same time the soft keyboard will be invoked.
7. Enjoy your ability to use a keyboard anywhere, like Richard Stallman intended.

![demo](https://github.com/Julow/Unexpected-Keyboard/assets/39025047/8c1df984-98b0-430e-974d-f5f64b00c10b)

