### PR TITLE
Add `<queries>` element in AndroidManifest to fix voice IME detection in modern Android

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -21,4 +21,11 @@
   </application>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+
+  <!-- To query enabled input methods for voice IME detection -->
+  <queries>
+    <intent>
+      <action android:name="android.view.InputMethod" />
+    </intent>
+  </queries>
 </manifest>


### PR DESCRIPTION
To detect voice IMEs, Unexpected Keyboard calls `InputMethodManager.getEnabledInputMethodList`

https://github.com/Julow/Unexpected-Keyboard/blob/95bd9312a7714e1fbee2a792a12d2b9ced36b708/srcs/juloo.keyboard2/VoiceImeSwitcher.java#L108

Internally, this method eventually calls a method that returns a [filtered list of packages](https://developer.android.com/training/package-visibility) that may not include the installed voice IME, and thus Unexpected Keyboard unexpectedly claims no voice input is installed because it can't see it.

The fix is to explicitly state in the manifest that we want to query for other IMEs, based on https://developer.android.com/training/package-visibility/declaring

This is not an issue with Google's voice input or other preinstalled voice inputs because they usually have android:forceQueryable=true, but this is an issue with third-party voice inputs such as FUTO Voice Input. Launching the voice input app after activating the keyboard also usually makes the package visible, so a consistent way to replicate this issue on modern Android is to reboot the device and try triggering voice input from the keyboard