### PR TITLE
neo2: Update bottom row

### DIFF
--- a/srcs/layouts/latn_neo2.xml
+++ b/srcs/layouts/latn_neo2.xml
@@ -40,11 +40,11 @@
     <key width="1.5" key0="backspace" key2="delete"/>
   </row>
   <row height="0.95">
-	  <key width="1.8" key0="ctrl" key1="loc switch_greekmath" key2="loc meta" key4="switch_numeric"/>
-	  <key width="1.2" key0="fn" key1="loc alt" key2="loc change_method" key3="switch_emoji" key4="config"/>
-	  <key width="4.0" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right" slider="true"/>
-	  <key width="1.2" key7="up" key6="right" key5="left" key8="down"/>
-	  <key key0="j" key4=";"/>
-	  <key width="1.8" key0="enter" key1="loc voice_typing" key2="action"/>
-	</row>
+    <key width="1.7" key0="ctrl" key1="loc switch_greekmath" key2="loc meta" key4="switch_numeric"/>
+    <key width="1.1" key0="fn" key1="loc alt" key2="loc change_method" key3="switch_emoji" key4="config"/>
+    <key width="4.4" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right" slider="true"/>
+    <key width="1.1" key0="loc compose" key7="up" key6="right" key5="left" key8="down" key1="loc home" key2="loc page_up" key3="loc end" key4="loc page_down"/>
+    <key key0="j" key4=";"/>
+    <key width="1.7" key0="enter" key1="loc voice_typing" key2="action"/>
+  </row>
 </keyboard>


### PR DESCRIPTION
Update bottom row in neo2 layout to match default and added new keys.
Resolves layout warnings.