### PR TITLE
Add Shaw Imperial layout

### DIFF
--- a/check_layout.output
+++ b/check_layout.output
@@ -133,6 +133,8 @@ Layout doesn't define some important keys, missing: f11_placeholder, f12_placeho
 Layout includes some ASCII punctuation but not all, missing: `
 Layout doesn't define some important keys, missing: f11_placeholder, f12_placeholder
 2 warnings
+# shaw_imperial_en
+0 warnings
 # urdu_phonetic_ur
 Duplicate keys:  
 Layout includes some ASCII punctuation but not all, missing: <, >, ?, `, |, ~

--- a/res/values/layouts.xml
+++ b/res/values/layouts.xml
@@ -51,6 +51,7 @@
     <item>latn_qwertz_fr_ch</item>
     <item>latn_qwertz_hu</item>
     <item>latn_qwertz_sk</item>
+    <item>shaw_imperial_en</item>
     <item>urdu_phonetic_ur</item>
     <item>custom</item>
   </string-array>
@@ -104,6 +105,7 @@
     <item>QWERTZ (Swiss French)</item>
     <item>QWERTZ (Magyar)</item>
     <item>QWERTZ (Slovak)</item>
+    <item>Shaw Imperial</item>
     <item>Urdu Phonetic</item>
     <item>@string/pref_layout_e_custom</item>
   </string-array>
@@ -157,6 +159,7 @@
     <item>@xml/latn_qwertz_fr_ch</item>
     <item>@xml/latn_qwertz_hu</item>
     <item>@xml/latn_qwertz_sk</item>
+    <item>@xml/shaw_imperial_en</item>
     <item>@xml/urdu_phonetic_ur</item>
     <item>-1</item>
   </integer-array>

--- a/srcs/layouts/shaw_imperial_en.xml
+++ b/srcs/layouts/shaw_imperial_en.xml
@@ -41,12 +41,12 @@
     <key key0="𐑲"/>
     <key key0="𐑴"/>
     <key key0="𐑰"/>
-    <key key0="𐑚" key2="&lt;" key3="."/>
-    <key key0="𐑝" key2="&gt;" key3=","/>
-    <key key0="𐑟" key2="\?" key3="/"/>
-    <key key0="𐑒" key2=":" key3=";"/>
-    <key key0="𐑢" key2="&quot;" key3="'"/>
-    <key key0="𐑛"/>
+    <key key0="𐑚"/>
+    <key key0="𐑝" key2="&lt;" key3="."/>
+    <key key0="𐑟" key2="&gt;" key3=","/>
+    <key key0="𐑒" key2="\?" key3="/"/>
+    <key key0="𐑢" key2=":" key3=";"/>
+    <key key0="𐑛" key2="&quot;" key3="'"/>
     <key key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/shaw_imperial_en.xml
+++ b/srcs/layouts/shaw_imperial_en.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Shaw Imperial layout for shavian alphabet, see https://www.shavian.info/keyboards/ -->
+<keyboard name="Shaw Imperial" script="shavian">
+  <row>
+    <key key0="𐑶" key2="1" key4="esc"/>
+    <key key0="𐑬" key1="~" key2="2" key3="\@"/>
+    <key key0="𐑫" key1="!" key2="3" key3="\#"/>
+    <key key0="𐑜" key2="4" key3="$"/>
+    <key key0="𐑖" key1="𐑠" key2="5" key3="%"/>
+    <key key0="𐑗" key2="6" key3="^"/>
+    <key key0="𐑙" key2="7" key3="&amp;"/>
+    <key key0="𐑘" key2="8" key3="*"/>
+    <key key0="𐑡" key2="9" key3="(" key4=")"/>
+    <key key0="𐑔" key2="0" key3="f11_placeholder" key4="f12_placeholder"/>
+  </row>
+  <row>
+    <key shift="0.5" key0="𐑭" key1="tab" key2="𐑸" key3="`"/>
+    <key key0="𐑷" key2="𐑹"/>
+    <key key0="𐑵" key2="𐑿"/>
+    <key key0="𐑱" key2="𐑺"/>
+    <key key0="𐑳" key2="𐑻"/>
+    <key key0="𐑓" key2="-" key3="_"/>
+    <key key0="𐑞" key2="=" key3="+"/>
+    <key key0="𐑤" key4="}" key3="{"/>
+    <key key0="𐑥" key3="[" key4="]"/>
+    <key key0="𐑣" key2="|" key3="\\"/>
+  </row>
+  <row>
+    <key key0="𐑪"/>
+    <key key0="𐑨"/>
+    <key key0="𐑦" key1="𐑾" key2="𐑽"/>
+    <key key0="𐑩" key2="𐑼"/>
+    <key key0="𐑧"/>
+    <key key0="𐑐"/>
+    <key key0="𐑯"/>
+    <key key0="𐑑"/>
+    <key key0="𐑮"/>
+    <key key0="𐑕"/>
+  </row>
+  <row>
+    <key shift="0.5" key0="𐑲"/>
+    <key key0="𐑴"/>
+    <key key0="𐑰"/>
+    <key key0="𐑚" key2="&lt;" key3="."/>
+    <key key0="𐑝" key2="&gt;" key3=","/>
+    <key key0="𐑟" key2="\?" key3="/"/>
+    <key key0="𐑒" key2=":" key3=";"/>
+    <key key0="𐑢" key2="&quot;" key3="'"/>
+    <key key0="𐑛"/>
+    <key key0="backspace" key2="delete"/>
+  </row>
+</keyboard>

--- a/srcs/layouts/shaw_imperial_en.xml
+++ b/srcs/layouts/shaw_imperial_en.xml
@@ -14,7 +14,7 @@
     <key key0="𐑔" key2="0" key3="f11_placeholder" key4="f12_placeholder"/>
   </row>
   <row>
-    <key shift="0.5" key0="𐑭" key1="tab" key2="𐑸" key3="`"/>
+    <key key0="𐑭" key1="tab" key2="𐑸" key3="`"/>
     <key key0="𐑷" key2="𐑹"/>
     <key key0="𐑵" key2="𐑿"/>
     <key key0="𐑱" key2="𐑺"/>
@@ -38,7 +38,7 @@
     <key key0="𐑕"/>
   </row>
   <row>
-    <key shift="0.5" key0="𐑲"/>
+    <key key0="𐑲"/>
     <key key0="𐑴"/>
     <key key0="𐑰"/>
     <key key0="𐑚" key2="&lt;" key3="."/>


### PR DESCRIPTION
I see that there are no options for typing in shavian on android besides the keyman app. It is okay, but somewhat slow and it's not great switching back and forth between keyboard apps all the time. After I learned that one can add a custom layout to Unexpected keyboard, I immediately thought about finally unifying all my layouts in one app, so i don't have to switch all the time.

Hope it will be useful for somebody.

And thanks for this great project!