### PR TITLE
allow to modmap the fn key

### DIFF
--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -158,6 +158,12 @@ public final class KeyModifier
 
   private static KeyValue apply_fn(KeyValue k)
   {
+    if (_modmap != null)
+    {
+      KeyValue mapped = _modmap.fn.get(k);
+      if (mapped != null)
+        return mapped;
+    }
     String name = null;
     switch (k.getKind())
     {

--- a/srcs/juloo.keyboard2/KeyboardData.java
+++ b/srcs/juloo.keyboard2/KeyboardData.java
@@ -515,18 +515,35 @@ public final class KeyboardData
   public static class Modmap
   {
     public final Map<KeyValue, KeyValue> shift;
+    public final Map<KeyValue, KeyValue> fn;
 
-    public Modmap(Map<KeyValue, KeyValue> s)
+    public Modmap(Map<KeyValue, KeyValue> s, Map<KeyValue, KeyValue> f)
     {
       shift = s;
+      fn = f;
     }
 
     public static Modmap parse(XmlPullParser parser) throws Exception
     {
       HashMap<KeyValue, KeyValue> shift = new HashMap<KeyValue, KeyValue>();
-      while (expect_tag(parser, "shift"))
-        parse_mapping(parser, shift);
-      return new Modmap(shift);
+      HashMap<KeyValue, KeyValue> fn = new HashMap<KeyValue, KeyValue>();
+
+      while (next_tag(parser))
+      {
+        switch (parser.getName())
+        {
+          case "shift":
+            parse_mapping(parser, shift);
+            break;
+          case "fn":
+            parse_mapping(parser, fn);
+            break;
+          default:
+            throw error(parser, "Expecting tag <shift> or <fn>, got <" + parser.getName() + ">");
+        }
+      }
+
+      return new Modmap(shift, fn);
     }
 
     private static void parse_mapping(XmlPullParser parser, Map<KeyValue, KeyValue> dst) throws Exception


### PR DESCRIPTION
introduce `<fn ...>` the same way as `<shift ...>` inside of `<modmap>` to map keys for the fn-key via xml without changing the source code.

seems to work straight forward. but maybe [this commit](https://github.com/Julow/Unexpected-Keyboard/commit/3f6b6fd23253e5326d9ba29cac10be36305b3019) broke something even without this pull request:

when building with all current commits in Julow/Unexpected-Keyboard/master, the modmap is only read once on startup of the app. after editing the layout and the modmap xml you have to force quit the app and restart. then everything is up to date. so that is not due to this pull request.