### PR TITLE
Circle and round trip gestures

### DIFF
--- a/srcs/juloo.keyboard2/Gesture.java
+++ b/srcs/juloo.keyboard2/Gesture.java
@@ -43,13 +43,14 @@ public final class Gesture
       case Ended_swipe:
         return selected_val;
       case Ended_center:
-        return KeyModifier.modify_round_trip(selected_val);
+        return KeyModifier.modify_gesture(selected_val);
       case Rotating_clockwise:
       case Ended_clockwise:
-        return KeyModifier.modify_circle(key.keys[0], true);
+        return KeyModifier.modify_gesture(key.keys[0]);
       case Rotating_anticlockwise:
       case Ended_anticlockwise:
-        return KeyModifier.modify_circle(key.keys[0], false);
+        // Unimplemented for now.
+        return key.keys[0];
     }
     return null; // Unreachable
   }

--- a/srcs/juloo.keyboard2/Gesture.java
+++ b/srcs/juloo.keyboard2/Gesture.java
@@ -1,0 +1,126 @@
+package juloo.keyboard2;
+
+public final class Gesture
+{
+  /** The pointer direction that caused the last state change.
+      Integer from 0 to 15 (included). */
+  int current_dir;
+
+  State state;
+
+  public Gesture(int starting_direction)
+  {
+    current_dir = starting_direction;
+    state = State.Swiped;
+  }
+
+  enum State
+  {
+    Cancelled,
+    Swiped,
+    Rotating_clockwise,
+    Rotating_anticlockwise,
+    Ended_swipe,
+    Ended_center,
+    Ended_clockwise,
+    Ended_anticlockwise
+  }
+
+  /** Angle to travel before a rotation gesture starts. A threshold too low
+      would be too easy to reach while doing back and forth gestures, as the
+      quadrants are very small. In the same unit as [current_dir] */
+  static final int ROTATION_THRESHOLD = 2;
+
+  /** Modify the key depending on the current gesture. Return [null] if the
+      gesture is invalid or if [KeyModifier] returned [null]. */
+  public KeyValue modify_key(KeyValue selected_val, KeyboardData.Key key)
+  {
+    switch (state)
+    {
+      case Cancelled:
+        return null;
+      case Swiped:
+      case Ended_swipe:
+        return selected_val;
+      case Ended_center:
+        return KeyModifier.modify_round_trip(selected_val);
+      case Rotating_clockwise:
+      case Ended_clockwise:
+        return KeyModifier.modify_circle(key.keys[0], true);
+      case Rotating_anticlockwise:
+      case Ended_anticlockwise:
+        return KeyModifier.modify_circle(key.keys[0], false);
+    }
+    return null; // Unreachable
+  }
+
+  public boolean is_in_progress()
+  {
+    switch (state)
+    {
+      case Swiped:
+      case Rotating_clockwise:
+      case Rotating_anticlockwise:
+        return true;
+    }
+    return false;
+  }
+
+  /** The pointer changed direction. Return [true] if the gesture changed state. */
+  public boolean changed_direction(int direction)
+  {
+    int d = dir_diff(current_dir, direction);
+    boolean clockwise = d > 0;
+    switch (state)
+    {
+      case Swiped:
+        if (Math.abs(d) < ROTATION_THRESHOLD)
+          return false;
+        // Start a rotation
+        state = (clockwise) ?
+          State.Rotating_clockwise : State.Rotating_anticlockwise;
+        current_dir = direction;
+        return true;
+      // Check that rotation is not reversing
+      case Rotating_clockwise:
+      case Rotating_anticlockwise:
+        current_dir = direction;
+        if ((state == State.Rotating_clockwise) == clockwise)
+          return false;
+        state = State.Cancelled;
+        return true;
+    }
+    return false;
+  }
+
+  public void moved_to_center()
+  {
+    switch (state)
+    {
+      case Swiped: state = State.Ended_center; break;
+      case Rotating_clockwise: state = State.Ended_clockwise; break;
+      case Rotating_anticlockwise: state = State.Ended_anticlockwise; break;
+    }
+  }
+
+  public void pointer_up()
+  {
+    switch (state)
+    {
+      case Swiped: state = State.Ended_swipe; break;
+      case Rotating_clockwise: state = State.Ended_clockwise; break;
+      case Rotating_anticlockwise: state = State.Ended_anticlockwise; break;
+    }
+  }
+
+  static int dir_diff(int d1, int d2)
+  {
+    final int n = 16;
+    // Shortest-path in modulo arithmetic
+    if (d1 == d2)
+      return 0;
+    int left = (d1 - d2 + n) % n;
+    int right = (d2 - d1 + n) % n;
+    return (left < right) ? -left : right;
+  }
+}

--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -33,7 +33,6 @@ public final class KeyModifier
     if (r == null)
     {
       r = k;
-      /* Order: Fn, Shift, accents */
       for (int i = 0; i < n_mods; i++)
         r = modify(r, mods.get(i));
       ks.put(mods, r);
@@ -70,6 +69,7 @@ public final class KeyModifier
       case ALT:
       case META: return turn_into_keyevent(k);
       case FN: return apply_fn(k);
+      case GESTURE: return apply_gesture(k);
       case SHIFT: return apply_shift(k);
       case GRAVE: return apply_map_char(k, map_char_grave);
       case AIGU: return apply_map_char(k, map_char_aigu);
@@ -115,15 +115,6 @@ public final class KeyModifier
         break;
     }
     return k;
-  }
-
-  /** Modify a key affected by a round-trip or a clockwise circle gesture. */
-  public static KeyValue modify_gesture(KeyValue k)
-  {
-    KeyValue shifted = apply_shift(k);
-    if (shifted == null || shifted.equals(k))
-      return apply_fn(k);
-    return shifted;
   }
 
   public static Map_char modify_numpad_script(String numpad_script)
@@ -488,6 +479,15 @@ public final class KeyModifier
       default: return k;
     }
     return k.withKeyevent(e);
+  }
+
+  /** Modify a key affected by a round-trip or a clockwise circle gesture. */
+  private static KeyValue apply_gesture(KeyValue k)
+  {
+    KeyValue shifted = apply_shift(k);
+    if (shifted == null || shifted.equals(k))
+      return apply_fn(k);
+    return shifted;
   }
 
   /* Lookup the cache entry for a key. Create it needed. */

--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -117,17 +117,13 @@ public final class KeyModifier
     return k;
   }
 
-  public static KeyValue modify_round_trip(KeyValue k)
+  /** Modify a key affected by a round-trip or a clockwise circle gesture. */
+  public static KeyValue modify_gesture(KeyValue k)
   {
-    return apply_fn(k);
-  }
-
-  public static KeyValue modify_circle(KeyValue k, boolean clockwise)
-  {
-    if (clockwise)
-      return apply_shift(k);
-    else
+    KeyValue shifted = apply_shift(k);
+    if (shifted == null || shifted.equals(k))
       return apply_fn(k);
+    return shifted;
   }
 
   public static Map_char modify_numpad_script(String numpad_script)

--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -117,6 +117,19 @@ public final class KeyModifier
     return k;
   }
 
+  public static KeyValue modify_round_trip(KeyValue k)
+  {
+    return apply_fn(k);
+  }
+
+  public static KeyValue modify_circle(KeyValue k, boolean clockwise)
+  {
+    if (clockwise)
+      return apply_shift(k);
+    else
+      return apply_fn(k);
+  }
+
   public static Map_char modify_numpad_script(String numpad_script)
   {
     if (numpad_script == null)
@@ -139,11 +152,10 @@ public final class KeyModifier
       case Char:
         char kc = k.getChar();
         String modified = map.apply(kc);
-        if (modified == null)
-          return k;
-        return KeyValue.makeStringKey(modified, k.getFlags());
-      default: return k;
+        if (modified != null)
+          return KeyValue.makeStringKey(modified, k.getFlags());
     }
+    return k;
   }
 
   private static KeyValue apply_shift(KeyValue k)

--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -27,6 +27,7 @@ public final class KeyValue implements Comparable<KeyValue>
   public static enum Modifier
   {
     SHIFT,
+    GESTURE,
     CTRL,
     ALT,
     META,
@@ -54,8 +55,8 @@ public final class KeyValue implements Comparable<KeyValue>
     ARROW_RIGHT,
     BREVE,
     BAR,
-    FN, // Must be placed last to be applied first
-  }
+    FN,
+  } // Last is be applied first
 
   public static enum Editing
   {
@@ -402,6 +403,12 @@ public final class KeyValue implements Comparable<KeyValue>
       return new KeyValue(str, Kind.Char, str.charAt(0), flags);
     else
       return new KeyValue(str, Kind.String, 0, flags | FLAG_SMALLER_FONT);
+  }
+
+  /** Make a modifier key for passing to [KeyModifier]. */
+  public static KeyValue makeInternalModifier(Modifier mod)
+  {
+    return new KeyValue("", Kind.Modifier, mod.ordinal(), 0);
   }
 
   public static KeyValue getKeyByName(String name)


### PR DESCRIPTION
This implements clockwise/anticlockwise circle and round trip gestures inspired by Messagease.

The circle gestures start after a small threshold to avoid making the regular swipe too hard to aim.

The gestures do:

- clockwise circle: Shift variant of the center symbol
- anticlockwise circle: Fn variant of the center symbol
- round trip: Fn variant of the targetted side symbol