### PR TITLE
Separate emoji display from system fonts

### DIFF
--- a/srcs/juloo.keyboard2/EmojiGridView.java
+++ b/srcs/juloo.keyboard2/EmojiGridView.java
@@ -2,6 +2,7 @@ package juloo.keyboard2;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.graphics.Typeface;
 import android.util.AttributeSet;
 import android.view.ContextThemeWrapper;
 import android.view.View;
@@ -146,6 +147,8 @@ public class EmojiGridView extends GridView
     public EmojiView(Context context)
     {
       super(context);
+      Typeface typeface = context.getResources().getFont(R.font.notocoloremoji);
+      this.setTypeface(typeface);
     }
 
     public void setEmoji(Emoji emoji)


### PR DESCRIPTION
### Purpose
Use an independent font asset to render emojis within the keyboard.

### Why?
My Oneplus 7 Pro does not have the full set of emojis within its system font leading to invalid characters to be displayed within the emoji selection of the keyboard. Due to this being a system font, it is not replaceable without root access. The actual emojis rendered within any text display are still unfortunately missing, however with this patch you can at least see what emoji you are selecting now.