### PR TITLE
"loc" prefix not valid in modmap

### DIFF
--- a/doc/Custom-layouts.md
+++ b/doc/Custom-layouts.md
@@ -1,3 +1,4 @@
+
 # Custom layouts
 You select a key layout for Unexpected Keyboard by calling up the Settings page (swipe the gear icon) and, at the top of the page, either tapping an existing layout or tapping _Add an alternate layout_. This displays a menu of available layouts. You can define your own layout by choosing _Custom layout_ at the bottom of this menu. Unexpected Keyboard now displays code in the XML format. You make changes by replacing this with different code and tapping OK.
 
@@ -98,13 +99,14 @@ Normally, a key's width is 1.0 unit. Unexpected Keyboard occupies the full width
 * `indication`: An optional extra legend to show under the main label. For example, `<key key0="2" indication="ABC" />` displays ABC at the bottom of the 2 key, as on a pinpad or some telephones. If the key also defines a downward swipe with `s` or `key8`, the legends overlap.
 
 ## Possible key values
-The properties that define the effects of tapping or swiping a key may be one of the built-in strings documented on [this page](Possible-key-values.md). For example, `se="cut"` says that a southeast swipe produces the "cut" key (Ctrl-C).
-
-Some of those strings begin with `loc `. These are place-holders; the tap or swipe does nothing unless enabled through the "Add keys to keyboard" option in the Settings menu, or implicitly enabled by the language the device is set to use. For example, `ne="loc accent_aigu"` says that a northeast swipe produces the acute accent combinatorial key—if enabled.
+The properties that define the effects of tapping or swiping a key, or the `a=` and `b=` fields of a modmap (see **Modmap** below) may be one of the built-in strings documented on [this page](Possible-key-values.md). For example, `se="cut"` says that a southeast swipe produces the "cut" key (Ctrl-C).
 
 If the string defining a tap or a swipe is anything other than one of the built-in strings, the defined string is output *verbatim.* This is what most of the taps and swipes on a typical keyboard do. So `key0="a"` simply outputs the letter a.
 
 The string can output multiple characters, but cannot combine the built-in strings to specify a sequence of keystrokes.
+
+### Place-holders
+Some built-in strings begin with `loc `. These are place-holders; the tap or swipe does nothing unless enabled through the "Add keys to keyboard" option in the Settings menu, or implicitly enabled by the language the device is set to use. For example, `ne="loc accent_aigu"` says that a northeast swipe produces the acute accent combinatorial key—if enabled. The `loc ` prefix is not valid in modmaps.
 
 ## Modmap
 The `<modmap>`...`</modmap>` pair encloses custom mappings for modifier keys. The modmap is placed inside the `<keyboard>`...`</keyboard>` pair, but outside any row. A layout can have at most one modmap.
@@ -113,7 +115,7 @@ A modmap can contain the following tags, each of which must have an `a` and a `b
 * `<shift a="before" b="after" />` If the Shift modifier is on, the key `before` is changed into `after`.
 * `<fn a="before" b="after" />` If the Fn modifier is on, the key `before` is changed into `after`.
 
-Valid values for `before` and `after` are listed in [Possible key values](Possible-key-values.md).
+Valid values for `before` and `after` are described in **Possible key values** above.
 
 There can be as many of these tags inside `<modmap>` as needed.
 


### PR DESCRIPTION
Also—
① New **Place-holders** subsection; put last (it is an exception). Give the exception for modmap.
② Partly revert @Julow, **Modmap** readers should refer above, not only to other .md file.