### PR TITLE
Add Serbian Latin QWERTY layout

### DIFF
--- a/check_layout.output
+++ b/check_layout.output
@@ -98,6 +98,9 @@ Duplicate keys: !, ', ,, -, ., ?
 1 warnings
 # latn_qwerty_sk
 0 warnings
+# latn_qwerty_sr
+Layout doesn't define some important keys, missing: delete, loc esc, loc tab
+1 warnings
 # latn_qwerty_tly
 Duplicate keys: a, c, j, q
 Layout doesn't define some important keys, missing: loc esc, loc tab

--- a/res/values/layouts.xml
+++ b/res/values/layouts.xml
@@ -42,6 +42,7 @@
     <item>latn_qwerty_ro</item>
     <item>latn_qwerty_se</item>
     <item>latn_qwerty_sk</item>
+    <item>latn_qwerty_sr</item>
     <item>latn_qwerty_tly</item>
     <item>latn_qwerty_tr</item>
     <item>latn_qwerty_vi</item>
@@ -97,6 +98,7 @@
     <item>QWERTY (Română)</item>
     <item>QWERTY (Swedish)</item>
     <item>QWERTY (Slovak)</item>
+    <item>QWERTY (Srpski, latinica)</item>
     <item>QWERTY (Talysh New Latin)</item>
     <item>QWERTY (Türkçe)</item>
     <item>QWERTY (Vietnamese)</item>
@@ -152,6 +154,7 @@
     <item>@xml/latn_qwerty_ro</item>
     <item>@xml/latn_qwerty_se</item>
     <item>@xml/latn_qwerty_sk</item>
+    <item>@xml/latn_qwerty_sr</item>
     <item>@xml/latn_qwerty_tly</item>
     <item>@xml/latn_qwerty_tr</item>
     <item>@xml/latn_qwerty_vi</item>

--- a/srcs/layouts/latn_qwerty_sr.xml
+++ b/srcs/layouts/latn_qwerty_sr.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<keyboard name="QWERTY (Srpski, latinica)" script="latin">
+  <modmap>
+    <fn a="a" b="â" />
+    <fn a="o" b="ô" />
+    <fn a="e" b="æ" />
+    <fn a="€" b="œ" />
+    <fn a="cursor_left" b="home" />
+    <fn a="cursor_right" b="end" />
+  </modmap>
+  <row>
+    <key key0="q" ne="1" se="loc esc"/>
+    <key key0="w" nw="~" ne="2" sw="\@"/>
+    <key key0="e" ne="3" sw="\#" se="€"/>
+    <key key0="r" ne="4" sw="$" se="loc £"/>
+    <key key0="t" ne="5" sw="%"/>
+    <key key0="y" ne="6" sw="^"/>
+    <key key0="u" ne="7" sw="&amp;"/>
+    <key key0="i" ne="8" sw="*"/>
+    <key key0="o" ne="9" sw="(" se=")"/>
+    <key key0="p" ne="0" sw="[" se="]"/>
+  </row>
+  <row>
+    <key key0="a" nw="loc tab" ne="loc selectAll"/>
+    <key key0="s" nw="loc §" ne="š"/>
+    <key key0="d" ne="đ"/>
+    <key key0="f"/>
+    <key key0="g"/>
+    <key key0="h" ne="loc accent_circonflexe" sw="{" se="}"/>
+    <key key0="j" ne="-" sw="_"/>
+    <key key0="k" ne="=" sw="+"/>
+    <key key0="l" nw="'" ne="&quot;" sw="\\"/>
+    <key key0="č" ne="`" sw="|"/>    
+  </row>
+  <row>
+    <key width="1.5" key0="shift" nw="loc superscript" ne="loc capslock" sw="loc subscript"/>
+    <key key0="z" nw="loc undo" ne="ž"/>
+    <key key0="x" nw="loc cut"/>
+    <key key0="c" nw="loc copy" ne="ć"/>
+    <key key0="v" nw="loc paste" ne="&lt;" se="&gt;"/>
+    <key key0="b" nw="!" ne="\?" sw="/"/>
+    <key key0="n" ne=";" sw=","/>
+    <key key0="m" ne=":" sw="."/>    
+    <key width="1.5" key0="backspace" ne="delete"/>
+  </row>
+</keyboard>


### PR DESCRIPTION
Adds Serbian Latin QWERTY layout. Serbian language uses both Latin and Cyrillic as its official scripts, and this variant should cover anyone from Serbo-Croatian speaking group that uses Latin script.