### PR TITLE
Update cyrl_lynyertz_sr.xml

### DIFF
--- a/srcs/layouts/cyrl_lynyertz_sr.xml
+++ b/srcs/layouts/cyrl_lynyertz_sr.xml
@@ -6,14 +6,34 @@
     <fn a="и" b="и̂" />
     <fn a="о" b="о̂" />
     <fn a="у" b="у̂" />
-    <fn a="ж" b="selectAll" />
-    <fn a="&lt;" b="undo" />
-    <fn a="&gt;" b="redo" />
-    <fn a="џ" b="cut" />
-    <fn a="ц" b="copy" />
-    <fn a="в" b="paste" />
     <fn a="cursor_left" b="home" />
     <fn a="cursor_right" b="end" />
+    <ctrl a="љ" b="q" />
+    <ctrl a="њ" b="w" />
+    <ctrl a="е" b="e" />
+    <ctrl a="р" b="r" />
+    <ctrl a="т" b="t" />
+    <ctrl a="ж" b="y" />
+    <ctrl a="у" b="u" />
+    <ctrl a="и" b="i" />
+    <ctrl a="о" b="o" />
+    <ctrl a="п" b="p" />
+    <ctrl a="а" b="a" />
+    <ctrl a="с" b="s" />
+    <ctrl a="д" b="d" />
+    <ctrl a="ф" b="f" />
+    <ctrl a="г" b="g" />
+    <ctrl a="х" b="h" />
+    <ctrl a="ј" b="j" />
+    <ctrl a="к" b="k" />
+    <ctrl a="л" b="l" />
+    <ctrl a="з" b="z" />
+    <ctrl a="џ" b="x" />
+    <ctrl a="ц" b="c" />
+    <ctrl a="в" b="v" />
+    <ctrl a="б" b="b" />
+    <ctrl a="н" b="n" />
+    <ctrl a="м" b="m" />
   </modmap>
   <row>
     <key key0="љ" ne="1" se="loc esc"/>


### PR DESCRIPTION
Include comprehensive ctrl modmap, enabling the use of ctrl modifier with Serbian Cyrillic keys. Remove clunky fn modmap previously used for just a few actions such as cut/copy/paste/etc.

(I don't know why diff is showing also the closing &lt;/keyboard&gt; tag as modified; I just used github's "in place" web editor to edit the modmap)