### PR TITLE
Increase default label size

### DIFF
--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -45,7 +45,7 @@
       <juloo.keyboard2.prefs.IntSlideBarPreference android:key="horizontal_margin_portrait" android:title="@string/pref_portrait" android:summary="%sdp" android:defaultValue="3" min="0" max="30"/>
       <juloo.keyboard2.prefs.IntSlideBarPreference android:key="horizontal_margin_landscape" android:title="@string/pref_landscape" android:summary="%sdp" android:defaultValue="28" min="0" max="200"/>
     </PreferenceScreen>
-    <juloo.keyboard2.prefs.SlideBarPreference android:key="character_size" android:title="@string/pref_character_size_title" android:summary="@string/pref_character_size_summary" android:defaultValue="1.0" min="0.75" max="1.5"/>
+    <juloo.keyboard2.prefs.SlideBarPreference android:key="character_size" android:title="@string/pref_character_size_title" android:summary="@string/pref_character_size_summary" android:defaultValue="1.15" min="0.75" max="1.5"/>
     <juloo.keyboard2.prefs.SlideBarPreference android:key="key_vertical_margin" android:title="@string/pref_key_vertical_space" android:summary="%s%%" android:defaultValue="1.5" min="0" max="5"/>
     <juloo.keyboard2.prefs.SlideBarPreference android:key="key_horizontal_margin" android:title="@string/pref_key_horizontal_space" android:summary="%s%%" android:defaultValue="2" min="0" max="5"/>
     <CheckBoxPreference android:key="border_config" android:title="@string/pref_border_config_title" android:defaultValue="false"/>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -175,7 +175,7 @@ public final class Config
       get_dip_pref_oriented(dm, "horizontal_margin", 3, 28);
     double_tap_lock_shift = _prefs.getBoolean("lock_double_tap", false);
     characterSize =
-      _prefs.getFloat("character_size", 1.f)
+      _prefs.getFloat("character_size", 1.15f)
       * characterSizeScale;
     theme = getThemeId(res, _prefs.getString("theme", ""));
     autocapitalisation = _prefs.getBoolean("autocapitalisation", true);


### PR DESCRIPTION
PR as per #744

This particular implementation increases default label size by 15%, while existing user set preferences remain unaffected. However, upon testing various default values (1.4, 1.3, 1.25, 1.2, 1.15, 1.1) against different keyboard heights (ranging 27%-35% for portrait mode), I came to the conclusion this might not be the right approach to resolve the issue raised there.

Why? Because the reason I believe we were increasing label size is because we were also reducing the height of the keyboard. With default keyboard height of 35%, label size of 1 is just fine. Only as we reduce the height, label becomes smaller and less intelligible.

However, modification to how the label size scales with regard to keyboard height would require a different approach, with more testing...