### PR TITLE
New Layouts for Old Slavonic and Tajiki

### DIFF
--- a/res/values/layouts.xml
+++ b/res/values/layouts.xml
@@ -10,6 +10,7 @@
     <item>arab_hamvaj_tly</item>
     <item>arab_pc</item>
     <item>arab_pc_ckb</item>
+    <item>arab_pc_ckb_fa</item>
     <item>arab_pc_hindu</item>
     <item>arab_pc_ir</item>
     <item>armenian_ph_am</item>
@@ -67,7 +68,8 @@
     <item>Arabic Alt</item>
     <item>Talysh (تالشی همواج)</item>
     <item>Arabic PC</item>
-    <item>Kurdish (کوردی)</item>
+    <item>Kurdish (کوردی) QWERTY</item>
+    <item>Central Kurdish (سۆرانی) Persian Layout</item>
     <item>Arabic PC (Hindu numerals)</item>
     <item>Persian PC</item>
     <item>Armenian</item>
@@ -126,6 +128,7 @@
     <item>@xml/arab_hamvaj_tly</item>
     <item>@xml/arab_pc</item>
     <item>@xml/arab_pc_ckb</item>
+    <item>@xml/arab_pc_ckb_fa</item>
     <item>@xml/arab_pc_hindu</item>
     <item>@xml/arab_pc_ir</item>
     <item>@xml/armenian_ph_am</item>

--- a/srcs/layouts/arab_pc_ckb.xml
+++ b/srcs/layouts/arab_pc_ckb.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <keyboard name="Kurdish (کوردی)" script="arabic" numpad_script="hindu-arabic">
   <row>
-    <key key0="ق" key1="ٯ" key2="١" key3="loc esc"/>
-    <key key0="و" key1="وو" key2="٢" key3="\@"/>
-    <key key0="ە" key1="ة" key2="٣" key3="\#" />
+    <key key0="ق" key2="١" key3="loc esc"/>
+    <key key0="و" key1="وو" key2="٢" key3="\@" key4="ڡ" />
+    <key key0="ە" key1="ة" key2="٣" key3="\#" key4="ۉ" />
     <key key0="ر" key1="ڕ" key2="٤" key3="$"/>
     <key key0="ت" key1="ط" key2="٥" key3="٪"/>
     <key key0="ی" key1="ي" key2="٦" key3="^"/>
     <key key0="ێ" key1="ؽ" key2="٧" key3="&amp;"/>
     <key key0="ئ" key1="ء" key2="٨" key3="*"/>
-    <key key0="ۆ" key1="ؤ" key2="٩" key3=")" key4="("/>
+    <key key0="ۆ" key1="ۊ" key2="٩" key4=")" key3="("/>
     <key key0="پ" key1="ث" key2="٠"/>
   </row>
   <row>
-    <key key0="ا" key1="أ" key2="loc tab"/>
+    <key key0="ا" key1="آ" key2="loc tab"/>
     <key key0="س" key1="ص"/>
     <key key0="ش" key1="ض"/>
-    <key key0="د" key1="ذ" key2="ۮ"/>
+    <key key0="د" key1="ذ" key4="ۮ"/>
     <key key0="ف" key1="ڤ" key2="-" key3="_"/>
-    <key key0="ه" key2="ھ" key3="ـہ"/>
+    <key key2="ه" key0="ھ" key3="ہ"/>
     <key key0="ژ" key1="ـ" key4="}" key3="{"/>
-    <key key0="ل" key1="ڵ" key3="]" key4="["/>
+    <key key0="ل" key1="ڵ" key4="]" key3="["/>
     <key key0="ک" key2="ك" key3="\\"/>
     <key key0="گ" key2="غ" key3="/"/>
   </row>
@@ -29,11 +29,11 @@
     <key key0="خ"/>
     <key key0="ج"/>
     <key key0="چ"/>
-    <key key0="ح" key1="&#1567;" key3="!"/>
-    <key key0="ع" />
-    <key key0="ب"/>
+    <key key0="ح" key2="&#1567;" key3="!"/>
+    <key key0="ع" key1="ٔ" key4="ٕ" />
+    <key key0="ب" key1="ٮ" />
     <key key0="ن" key2="&#1548;" key3="&#1563;"/>
-    <key key0="م"/>
+    <key key0="م" key2="halfspace" />
     <key key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/arab_pc_ckb.xml
+++ b/srcs/layouts/arab_pc_ckb.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<keyboard name="Kurdish (کوردی)" script="arabic" numpad_script="hindu-arabic">
+<keyboard name="Kurdish (کوردی) QWERTY" script="arabic" numpad_script="hindu-arabic">
   <row>
     <key key0="ق" key2="١" key3="loc esc"/>
     <key key0="و" key1="وو" key2="٢" key3="\@" key4="ڡ" />

--- a/srcs/layouts/arab_pc_ckb.xml
+++ b/srcs/layouts/arab_pc_ckb.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <keyboard name="Kurdish (کوردی) QWERTY" script="arabic" numpad_script="hindu-arabic">
   <row>
-    <key key0="ق" key2="١" key3="loc esc"/>
+    <key key0="ق" key1="halfspace" key2="١" key3="loc esc"/>
     <key key0="و" key1="وو" key2="٢" key3="\@" key4="ڡ" />
     <key key0="ە" key1="ة" key2="٣" key3="\#" key4="ۉ" />
     <key key0="ر" key1="ڕ" key2="٤" key3="$"/>
@@ -33,7 +33,7 @@
     <key key0="ع" key1="ٔ" key4="ٕ" />
     <key key0="ب" key1="ٮ" />
     <key key0="ن" key2="&#1548;" key3="&#1563;"/>
-    <key key0="م" key2="halfspace" />
+    <key key0="م" key2="." key3=":" />
     <key key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/arab_pc_ckb_fa.xml
+++ b/srcs/layouts/arab_pc_ckb_fa.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<keyboard name="Central Kurdish (سۆرانی) Persian Layout" script="arabic" numpad_script="hindu-arabic">
+  <row>
+    <key key0="،" key7="esc" key4="delete" />
+    <key key0="." key1="&lt;" key4="&gt;" />
+    <key key0="ە" key1="(" key4=")" />
+    <key key0="ق" key7=":" key8="*" />
+    <key key0="ف" key7="؟" key8="+" />
+    <key key0="ۆ" key7="!" key8="ۊ" />
+    <key key0="ع" key7="غ" key8="_" />
+    <key key0="ھ" key7="٪" key8="ه" />
+    <key key0="خ"  key3="[" key2="]" />
+    <key key0="ح" key3="{" key2="}" />
+    <key key0="ج" key3="backspace" key7="halfspace" />
+  </row>
+  <row>
+    <key key0="ش" key7="١" key8="ض" />
+    <key key0="س" key7="٢" key8="ص" />
+    <key key0="ی" key7="٣" key8="ؽ" />
+    <key key0="ب" key7="٤" key8="ٮ" />
+    <key key0="ل" key7="٥" key8="ڵ" />
+    <key key0="ا" key7="٦" key8="آ" />
+    <key key0="ت" key7="٧" key8="ط" />
+    <key key0="ن" key7="٨" key8="-" />
+    <key key0="م" key7="٩" key8="=" />
+    <key key0="ک" key7="٠" key8="ك" />
+    <key key0="گ" key7="tab" key3="f11_placeholder" />
+  </row>
+  <row>
+    <key key0="ڕ" key7="&#1563;" />
+    <key key0="ژ" key7="ـ" />
+    <key key0="ز" key7="ظ" />
+    <key key0="ر" key7="ٔ" />
+    <key key0="ڤ" key7="ڡ" />
+    <key key0="د" key7="ذ" />
+    <key key0="پ" key7="ث" />
+    <key key0="و" key7="ۉ" />
+    <key key0="ێ" key7="ٕ" />
+    <key key0="ئ" key7="ء" />
+    <key key0="چ" key1="f12_placeholder" />
+  </row>
+</keyboard>

--- a/srcs/layouts/slavonic.xml
+++ b/srcs/layouts/slavonic.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<keyboard name="Old Church Slavonic (Црькъвьнословѣньскъ ѩзыкъ)" script="cyrillic">
+  <row>
+    <key key0="й" key7="ё" key4="delete" />
+    <key key0="ѯ" key7="ѱ" key8="ц" />
+    <key key0="у" key7="ꙋ" key8="ѵ" />
+    <key key0="к" key7="%" key8="*" />
+    <key key0="е" key7="̈" key8="!" />
+    <key key0="н" key7="҃" key8="="/>
+    <key key0="г" key7="꙽" key8="+" />
+    <key key0="ш" key7="꙯" key8="щ" />
+    <key key0="ѫ" key7="ѭ" key8="ѧ" />
+    <key key0="з" key7="ѕ" key8="ꙁ" />
+    <key key0="х" key7="ҁ" key3="backspace" key1="f11_placeholder" key4="f12_placeholder"/>
+  </row>
+  <row>
+    <key key0="ф" key7="esc" key4="tab" />
+    <key key0="ꙉ" key7="^" key8="ꙃ" />
+    <key key0="в" key7="ꙑ" key8="ъ" />
+    <key key0="а" key7="ꙝ" key8="ꙙ" />
+    <key key0="п" key7="̀" key4="́" />
+    <key key0="р" key7="҅" key4="҆" />
+    <key key0="о" key7="ѡ" key8="ꙍ"/>
+    <key key0="л" key3="&lt;" key2="&gt;" />
+    <key key0="д" key3="(" key2=")" />
+    <key key0="ж" key3="{" key2="}" />
+    <key key0="э" key3="є" key7="/" />
+  </row>
+  <row>
+    <key width="1.18" key0="shift" />
+    <key width="0.96" key0="ꙗ" key7="̆" key8=";" />
+    <key width="0.96" key0="ч" key7="҇" key8=":" />
+    <key width="0.96" key0="с" key7="̑" key8="`" />
+    <key width="0.96" key0="м" key7="\?" key8="\\" />
+    <key width="0.96" key0="и" key8="|" key7="і" />
+    <key width="0.96" key0="т" key7="ѳ" key8="ѿ" />
+    <key width="0.96" key0="ѥ" key7="ѻ" key8="ѩ" />
+    <key width="0.96" key0="б" key7="ь" key8="ѣ" />
+    <key width="0.96" key0="ю" key7="̾" key8="-" />
+    <key width="1.18" key0="." key7="," key8="_" />
+  </row>
+</keyboard>

--- a/srcs/layouts/tajiki.xml
+++ b/srcs/layouts/tajiki.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<keyboard name="Tajiki Persian (Тоҷикӣ)" script="cyrillic">
+  <row>
+    <key key0="й" key7="esc" key4="delete" />
+    <key key0="қ" key7="-" key8="_" />
+    <key key0="у" key7="ў" key8="ӯ" />
+    <key key0="к" key7="=" key8="+" />
+    <key key0="е" key8="ё" key7="!" />
+    <key key0="н" key7="$" key8="%"/>
+    <key key0="г" key7="^" key8="ғ" />
+    <key key0="ш" key7="\@" key8="*" />
+    <key key0="ҳ" key3="(" key2=")"/>
+    <key key0="з" key3="{" key2="}" />
+    <key key0="х" key3="backspace" key7="tab" />
+  </row>
+  <row>
+    <key key0="ф" key7="1" />
+    <key key0="ҷ" key7="2" />
+    <key key0="в" key7="3" />
+    <key key0="а" key7="4" />
+    <key key0="п" key7="5" />
+    <key key0="р" key7="6" />
+    <key key0="о" key7="7" />
+    <key key0="л" key7="8" />
+    <key key0="д" key7="9" />
+    <key key0="ж" key7="0" />
+    <key key0="э" key3="[" key7="]" key1="f11_placeholder" key4="f12_placeholder" />
+  </row>
+  <row>
+    <key width="1.18" key0="shift" key2="loc capslock" />
+    <key width="0.96" key0="я" key7="`" key8=";" />
+    <key width="0.96" key0="ч" key7="щ" key8=":" />
+    <key width="0.96" key0="с"  key7="&amp;" key8="\#" />
+    <key width="0.96" key0="м" key7="\?" key8="/" />
+    <key width="0.96" key0="и" key7="|" key8="\\" key1="loc і" />
+    <key width="0.96" key0="т" key3="&lt;" key2="&gt;" />
+    <key width="0.96" key0="ӣ" key7="ъ" key8="~" />
+    <key width="0.96" key0="б" key7="ь" key8="ы" />
+    <key width="0.96" key0="ю" key7="&quot;" key8="'"/>
+    <key width="1.18" key0="." key7="," />
+  </row>
+</keyboard>


### PR DESCRIPTION
These are two new layouts. One enables people to type the Tajik language, which is a regional form of the Persian language, except it's written with a totally different alphabet. It's similar to the Russian keyboard, except with some different letters for Tajiki.

The other layout is for typing Old Church Slavonic, which is still today the standard liturgical language of slavic churches. They sing the services either in Old Slavonic or in a somewhat newer form of the same language. Either way, this keyboard layout should allow them to type in their liturgical language.