### PR TITLE
Czech diacritic QWERTZ layout

### DIFF
--- a/check_layout.output
+++ b/check_layout.output
@@ -132,6 +132,8 @@ Layout doesn't define some important keys, missing: loc esc, loc tab
 0 warnings
 # latn_qwertz_cz
 0 warnings
+# latn_qwertz_cz_diacritics
+0 warnings
 # latn_qwertz_cz_multifunctional
 Layout includes some ASCII punctuation but not all, missing: `
 1 warnings

--- a/res/values/layouts.xml
+++ b/res/values/layouts.xml
@@ -53,6 +53,7 @@
     <item>latn_qwerty_vi</item>
     <item>latn_qwertz</item>
     <item>latn_qwertz_cz</item>
+    <item>latn_qwertz_cz_diacritics</item>
     <item>latn_qwertz_cz_multifunctional</item>
     <item>latn_qwertz_de</item>
     <item>latn_qwertz_fr_ch</item>
@@ -114,6 +115,7 @@
     <item>QWERTY (Vietnamese)</item>
     <item>QWERTZ</item>
     <item>QWERTZ (Czech)</item>
+    <item>QWERTZ (Czech with diacritic keys)</item>
     <item>QWERTZ Multifunctional (Czech)</item>
     <item>QWERTZ (Deutsch)</item>
     <item>QWERTZ (Swiss French)</item>
@@ -175,6 +177,7 @@
     <item>@xml/latn_qwerty_vi</item>
     <item>@xml/latn_qwertz</item>
     <item>@xml/latn_qwertz_cz</item>
+    <item>@xml/latn_qwertz_cz_diacritics</item>
     <item>@xml/latn_qwertz_cz_multifunctional</item>
     <item>@xml/latn_qwertz_de</item>
     <item>@xml/latn_qwertz_fr_ch</item>

--- a/srcs/layouts/latn_qwertz_cz_diacritics.xml
+++ b/srcs/layouts/latn_qwertz_cz_diacritics.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<keyboard script="latin" name="QWERTZ (Czech with diacritic keys)">
+  <row>
+    <key key0="q" key1="1" key2="loc esc" key4="~"/>
+    <key key0="w" key1="2" key2="+" key3="|" key4="\\"/>
+    <key key0="e" key1="3" key2="é" key3="^" key4="ě"/>
+    <key key0="r" key1="4" key4="ř"/>
+    <key key0="t" key1="5" key3="°" key4="ť"/>
+    <key key0="z" key1="6" key4="ž"/>
+    <key key0="u" key1="7" key2="ú" key3="`" key4="ů"/>
+    <key key0="i" key1="8" key2="í" key3="(" key4=")"/>
+    <key key0="o" key1="9" key2="ó" key3="/" key4="%"/>
+    <key key0="p" key1="0" key3="="/>
+  </row>
+  <row>
+    <key key0="a" key1="loc tab" key2="á" key3=";"/>
+    <key key0="s" key1="loc §" key4="š"/>
+    <key key0="d" key4="ď"/>
+    <key key0="f" key3="["/>
+    <key key0="g" key3="]"/>
+    <key key0="h"/>
+    <key key0="j"/>
+    <key key0="k"/>
+    <key key0="l" key1="&quot;" key2="'" key3="$" key4="!"/>
+    <key key0="accent_aigu" key1="accent_trema"/>
+  </row>
+  <row>
+    <key key0="shift" key2="loc capslock"/>
+    <key key0="y" key2="ý"/>
+    <key key0="x" key1="loc †" key3="\#"/>
+    <key key0="c" key3="&amp;" key4="č"/>
+    <key key0="v" key3="\@"/>
+    <key key0="b" key1="&lt;" key2="&gt;" key3="{" key4="}"/>
+    <key key0="n" key1="\?" key2="." key3="," key4="ň"/>
+    <key key0="m" key1=":" key2="*" key3="-" key4="_"/>
+    <key key0="accent_caron" key1="accent_circonflexe"/>
+    <key key0="backspace" key2="delete"/>
+  </row>
+</keyboard>


### PR DESCRIPTION
Layout similar to https://f-droid.org/en/packages/cz.vitSkalicky.klavesnice/ or iPhone Czech keyboard
