### PR TITLE
Proper support for Android 15 edge-to-edge

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -10,11 +10,13 @@
       </intent-filter>
       <meta-data android:name="android.view.im" android:resource="@xml/method"/>
     </service>
-    <activity android:name="juloo.keyboard2.SettingsActivity" android:icon="@mipmap/ic_launcher" android:label="@string/settings_activity_label" android:theme="@style/appTheme" android:exported="true" android:directBootAware="true">
+
+    <activity android:name="juloo.keyboard2.SettingsActivity" android:icon="@mipmap/ic_launcher" android:label="@string/settings_activity_label" android:theme="@style/settingsTheme" android:exported="true" android:directBootAware="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
       </intent-filter>
     </activity>
+
     <activity android:name="juloo.keyboard2.LauncherActivity" android:icon="@mipmap/ic_launcher" android:theme="@style/appTheme" android:exported="true" android:directBootAware="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/res/layout/launcher_activity.xml
+++ b/res/layout/launcher_activity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent" android:layout_height="match_parent" android:fillViewport="true">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent" android:layout_height="match_parent" android:fillViewport="true" android:fitsSystemWindows="true">
   <LinearLayout android:layout_width="fill_parent" android:layout_height="wrap_content" android:orientation="vertical">
     <TextView style="@style/paragraph" android:text="@string/launcher_description"/>
     <Button style="@style/paragraph" android:text="@string/launcher_button_imesettings" android:onClick="launch_imesettings" android:layout_width="wrap_content"/>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -81,6 +81,8 @@
   </style>
   <style name="appTheme" parent="@android:style/Theme.DeviceDefault.DayNight"/>
   <style name="settingsTheme" parent="appTheme">
+    <!-- Setting this in the activity theme so it propagate to nested
+         preference screens. -->
     <item name="android:fitsSystemWindows">true</item>
   </style>
 </resources>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -80,4 +80,7 @@
     <item name="android:orientation">horizontal</item>
   </style>
   <style name="appTheme" parent="@android:style/Theme.DeviceDefault.DayNight"/>
+  <style name="settingsTheme" parent="appTheme">
+    <item name="android:fitsSystemWindows">true</item>
+  </style>
 </resources>

--- a/res/values/values.xml
+++ b/res/values/values.xml
@@ -6,5 +6,9 @@
   <dimen name="emoji_text_size">28dp</dimen>
   <dimen name="clipboard_view_height">300dp</dimen>
   <dimen name="pref_button_size">28dp</dimen>
-  <bool name="debug_logs">false</bool> <!-- Will be overwritten automatically by Gradle for the debug build variant -->
+  <!-- Margin needed to accomodate the gesture nav bar on Android 15. Found in
+  [core/res/res/values/dimens.xml]. -->
+  <dimen name="bottom_inset_min">48dp</dimen>
+  <!-- Will be overwritten automatically by Gradle for the debug build variant -->
+  <bool name="debug_logs">false</bool>
 </resources>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -84,6 +84,7 @@ public final class Config
       [get_current_layout()] and [set_current_layout()]. */
   int current_layout_portrait;
   int current_layout_landscape;
+  public float bottomInsetMin;
 
   private Config(SharedPreferences prefs, Resources res, IKeyEventHandler h)
   {
@@ -187,6 +188,8 @@ public final class Config
     current_layout_landscape = _prefs.getInt("current_layout_landscape", 0);
     circle_sensitivity = Integer.valueOf(_prefs.getString("circle_sensitivity", "2"));
     clipboard_history_enabled = _prefs.getBoolean("clipboard_history_enabled", false);
+    bottomInsetMin = Utils.is_navigation_bar_gestural(res) ?
+      res.getDimension(R.dimen.bottom_inset_min) : 0.0f;
   }
 
   public int get_current_layout()

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -84,7 +84,7 @@ public final class Config
       [get_current_layout()] and [set_current_layout()]. */
   int current_layout_portrait;
   int current_layout_landscape;
-  public float bottomInsetMin;
+  public int bottomInsetMin;
 
   private Config(SharedPreferences prefs, Resources res, IKeyEventHandler h)
   {
@@ -189,7 +189,7 @@ public final class Config
     circle_sensitivity = Integer.valueOf(_prefs.getString("circle_sensitivity", "2"));
     clipboard_history_enabled = _prefs.getBoolean("clipboard_history_enabled", false);
     bottomInsetMin = Utils.is_navigation_bar_gestural(res) ?
-      res.getDimension(R.dimen.bottom_inset_min) : 0.0f;
+      (int)res.getDimension(R.dimen.bottom_inset_min) : 0;
   }
 
   public int get_current_layout()

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -295,8 +295,11 @@ public class Keyboard2 extends InputMethodService
     // On API >= 30, Keyboard2View behaves as edge-to-edge
     if (VERSION.SDK_INT >= 30)
     {
-      window.getAttributes().layoutInDisplayCutoutMode =
+      WindowManager.LayoutParams wattrs = window.getAttributes();
+      wattrs.layoutInDisplayCutoutMode =
         WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
+      // Allow to draw behind system bars
+      wattrs.setFitInsetsTypes(0);
     }
     updateLayoutHeightOf(window, ViewGroup.LayoutParams.MATCH_PARENT);
     final View inputArea = window.findViewById(android.R.id.inputArea);

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -292,6 +292,12 @@ public class Keyboard2 extends InputMethodService
 
   private void updateSoftInputWindowLayoutParams() {
     final Window window = getWindow().getWindow();
+    // On API >= 30, Keyboard2View behaves as edge-to-edge
+    if (VERSION.SDK_INT >= 30)
+    {
+      window.getAttributes().layoutInDisplayCutoutMode =
+        WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
+    }
     updateLayoutHeightOf(window, ViewGroup.LayoutParams.MATCH_PARENT);
     final View inputArea = window.findViewById(android.R.id.inputArea);
 

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -268,12 +268,19 @@ public class Keyboard2View extends View
       WindowMetrics metrics =
         ((WindowManager)getContext().getSystemService(Context.WINDOW_SERVICE))
         .getCurrentWindowMetrics();
-      Insets insets = metrics.getWindowInsets().getInsets(
-          WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars()
-          | WindowInsets.Type.displayCutout());
-      width = metrics.getBounds().width();
-      _marginLeft = Math.max(_marginLeft, insets.left);
-      _marginRight = Math.max(_marginRight, insets.right);
+      WindowInsets wi = metrics.getWindowInsets();
+      // Keyboard doesn't draw behind button-navigation bars in landscape mode
+      Insets navigationBarInsets = wi.getInsets(WindowInsets.Type.navigationBars());
+      Insets insets = wi.getInsets(
+          WindowInsets.Type.statusBars()
+          | WindowInsets.Type.navigationBars()
+          | WindowInsets.Type.displayCutout()
+          | WindowInsets.Type.tappableElement()
+          | WindowInsets.Type.mandatorySystemGestures()
+          );
+      width = metrics.getBounds().width() - navigationBarInsets.left - navigationBarInsets.right;
+      _marginLeft = Math.max(_marginLeft, insets.left - navigationBarInsets.left);
+      _marginRight = Math.max(_marginRight, insets.right - navigationBarInsets.right);
       _marginBottom += insets.bottom;
     }
     else

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -259,9 +259,9 @@ public class Keyboard2View extends View
   public void onMeasure(int wSpec, int hSpec)
   {
     int width;
-    _marginLeft = _config.horizontal_margin;
-    _marginRight = _config.horizontal_margin;
-    _marginBottom = _config.margin_bottom;
+    int insets_left = 0;
+    int insets_right = 0;
+    int insets_bottom = 0;
     // LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS is set in [Keyboard2#updateSoftInputWindowLayoutParams].
     // and keyboard is allowed do draw behind status/navigation bars
     if (VERSION.SDK_INT >= 30)
@@ -269,21 +269,31 @@ public class Keyboard2View extends View
       WindowMetrics metrics =
         ((WindowManager)getContext().getSystemService(Context.WINDOW_SERVICE))
         .getCurrentWindowMetrics();
-      WindowInsets wi = metrics.getWindowInsets();
-      Insets insets = wi.getInsets(
-          WindowInsets.Type.statusBars()
-          | WindowInsets.Type.navigationBars()
-          | WindowInsets.Type.displayCutout()
-          | WindowInsets.Type.tappableElement()
-          | WindowInsets.Type.mandatorySystemGestures()
-          );
       width = metrics.getBounds().width();
-      _marginLeft = Math.max(_marginLeft, insets.left);
-      _marginRight = Math.max(_marginRight, insets.right);
+      WindowInsets wi = metrics.getWindowInsets();
+      int insets_types =
+          WindowInsets.Type.statusBars()
+          | WindowInsets.Type.displayCutout()
+          | WindowInsets.Type.mandatorySystemGestures()
+          | WindowInsets.Type.navigationBars();
+      Insets insets = wi.getInsets(insets_types);
+      insets_left = insets.left;
+      insets_right = insets.right;
+      // On API 35, the keyboard is allowed to draw under the
+      // button-navigation bar but on lower APIs, it must be discounted from
+      // the width.
+      if (VERSION.SDK_INT < 35)
+      {
+        Insets nav_insets = wi.getInsets(WindowInsets.Type.navigationBars());
+        width -= nav_insets.left + nav_insets.right;
+        insets_left -= nav_insets.left;
+        insets_right -= nav_insets.right;
+      }
       // [insets.bottom] doesn't take into account the buttons that appear in
       // the gesture navigation bar when the IME is showing so ensure a minimum
       // of margin is added.
-      _marginBottom += Math.max(insets.bottom, _config.bottomInsetMin);
+      if (VERSION.SDK_INT >= 35)
+        insets_bottom = Math.max(insets.bottom, _config.bottomInsetMin);
     }
     else
     {
@@ -294,6 +304,9 @@ public class Keyboard2View extends View
       (int)(_config.keyHeight * _keyboard.keysHeight
           + _config.marginTop + _marginBottom);
     setMeasuredDimension(width, height);
+    _marginLeft = Math.max(_config.horizontal_margin, insets_left);
+    _marginRight = Math.max(_config.horizontal_margin, insets_right);
+    _marginBottom = _config.margin_bottom + insets_bottom;
     _keyWidth = (width - _marginLeft - _marginRight) / _keyboard.keysWidth;
   }
 

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -280,7 +280,10 @@ public class Keyboard2View extends View
       width = metrics.getBounds().width();
       _marginLeft = Math.max(_marginLeft, insets.left);
       _marginRight = Math.max(_marginRight, insets.right);
-      _marginBottom += insets.bottom;
+      // [insets.bottom] doesn't take into account the buttons that appear in
+      // the gesture navigation bar when the IME is showing so ensure a minimum
+      // of margin is added.
+      _marginBottom += Math.max(insets.bottom, _config.bottomInsetMin);
     }
     else
     {

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -42,7 +42,9 @@ public class Keyboard2View extends View
   private Config _config;
 
   private float _keyWidth;
-  private float _bottomMargin;
+  private float _marginRight;
+  private float _marginLeft;
+  private float _marginBottom;
 
   private Theme _theme;
 
@@ -232,7 +234,7 @@ public class Keyboard2View extends View
   private KeyboardData.Key getKeyAtPosition(float tx, float ty)
   {
     KeyboardData.Row row = getRowAtPosition(ty);
-    float x = _config.horizontal_margin;
+    float x = _marginLeft;
     if (row == null || tx < x)
       return null;
     for (KeyboardData.Key key : row.keys)
@@ -256,28 +258,34 @@ public class Keyboard2View extends View
   @Override
   public void onMeasure(int wSpec, int hSpec)
   {
-    DisplayMetrics dm = getContext().getResources().getDisplayMetrics();
-    int width = dm.widthPixels;
-    _bottomMargin = _config.margin_bottom;
-    // Compatibility with display cutouts and navigation on the right
+    int width;
+    _marginLeft = _config.horizontal_margin;
+    _marginRight = _config.horizontal_margin;
+    _marginBottom = _config.margin_bottom;
+    // LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS is set in [Keyboard2#updateSoftInputWindowLayoutParams].
     if (VERSION.SDK_INT >= 30)
     {
       WindowMetrics metrics =
         ((WindowManager)getContext().getSystemService(Context.WINDOW_SERVICE))
         .getCurrentWindowMetrics();
-      Insets insets = metrics.getWindowInsets().getInsetsIgnoringVisibility(
+      Insets insets = metrics.getWindowInsets().getInsets(
           WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars()
           | WindowInsets.Type.displayCutout());
-      width = metrics.getBounds().width() - insets.right - insets.left;
-      // Starting in API 35, keyboard window has LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS
-      if (VERSION.SDK_INT >= 35)
-        _bottomMargin += insets.bottom;
+      width = metrics.getBounds().width();
+      _marginLeft = Math.max(_marginLeft, insets.left);
+      _marginRight = Math.max(_marginRight, insets.right);
+      _marginBottom += insets.bottom;
+    }
+    else
+    {
+      DisplayMetrics dm = getContext().getResources().getDisplayMetrics();
+      width = dm.widthPixels;
     }
     int height =
       (int)(_config.keyHeight * _keyboard.keysHeight
-          + _config.marginTop + _bottomMargin);
+          + _config.marginTop + _marginBottom);
     setMeasuredDimension(width, height);
-    _keyWidth = (width - (_config.horizontal_margin * 2)) / _keyboard.keysWidth;
+    _keyWidth = (width - _marginLeft - _marginRight) / _keyboard.keysWidth;
   }
 
   @Override
@@ -289,10 +297,10 @@ public class Keyboard2View extends View
     {
       // Disable the back-gesture on the keyboard area
       Rect keyboard_area = new Rect(
-          left + (int)_config.horizontal_margin,
+          left + (int)_marginLeft,
           top + (int)_config.marginTop,
-          right - (int)_config.horizontal_margin,
-          bottom - (int)_bottomMargin);
+          right - (int)_marginRight,
+          bottom - (int)_marginBottom);
       setSystemGestureExclusionRects(Arrays.asList(keyboard_area));
     }
   }
@@ -327,7 +335,7 @@ public class Keyboard2View extends View
     for (KeyboardData.Row row : _keyboard.rows)
     {
       y += row.shift * _config.keyHeight;
-      float x = _config.horizontal_margin + key_horizontal_margin / 2;
+      float x = _marginLeft + key_horizontal_margin / 2;
       float keyH = row.height * _config.keyHeight - key_vertical_margin;
       for (KeyboardData.Key k : row.keys)
       {

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -263,14 +263,13 @@ public class Keyboard2View extends View
     _marginRight = _config.horizontal_margin;
     _marginBottom = _config.margin_bottom;
     // LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS is set in [Keyboard2#updateSoftInputWindowLayoutParams].
+    // and keyboard is allowed do draw behind status/navigation bars
     if (VERSION.SDK_INT >= 30)
     {
       WindowMetrics metrics =
         ((WindowManager)getContext().getSystemService(Context.WINDOW_SERVICE))
         .getCurrentWindowMetrics();
       WindowInsets wi = metrics.getWindowInsets();
-      // Keyboard doesn't draw behind button-navigation bars in landscape mode
-      Insets navigationBarInsets = wi.getInsets(WindowInsets.Type.navigationBars());
       Insets insets = wi.getInsets(
           WindowInsets.Type.statusBars()
           | WindowInsets.Type.navigationBars()
@@ -278,9 +277,9 @@ public class Keyboard2View extends View
           | WindowInsets.Type.tappableElement()
           | WindowInsets.Type.mandatorySystemGestures()
           );
-      width = metrics.getBounds().width() - navigationBarInsets.left - navigationBarInsets.right;
-      _marginLeft = Math.max(_marginLeft, insets.left - navigationBarInsets.left);
-      _marginRight = Math.max(_marginRight, insets.right - navigationBarInsets.right);
+      width = metrics.getBounds().width();
+      _marginLeft = Math.max(_marginLeft, insets.left);
+      _marginRight = Math.max(_marginRight, insets.right);
       _marginBottom += insets.bottom;
     }
     else

--- a/srcs/juloo.keyboard2/LauncherActivity.java
+++ b/srcs/juloo.keyboard2/LauncherActivity.java
@@ -36,7 +36,9 @@ public class LauncherActivity extends Activity implements Handler.Callback
   public void onCreate(Bundle savedInstanceState)
   {
     super.onCreate(savedInstanceState);
-    setContentView(R.layout.launcher_activity);
+    View content_view = View.inflate(this, R.layout.launcher_activity, null);
+    setContentView(content_view);
+    Utils.enable_edge_to_edge(content_view);
     _tryhere_text = (TextView)findViewById(R.id.launcher_tryhere_text);
     _tryhere_area = (EditText)findViewById(R.id.launcher_tryhere_area);
     if (VERSION.SDK_INT >= 28)

--- a/srcs/juloo.keyboard2/LauncherActivity.java
+++ b/srcs/juloo.keyboard2/LauncherActivity.java
@@ -36,9 +36,7 @@ public class LauncherActivity extends Activity implements Handler.Callback
   public void onCreate(Bundle savedInstanceState)
   {
     super.onCreate(savedInstanceState);
-    View content_view = View.inflate(this, R.layout.launcher_activity, null);
-    setContentView(content_view);
-    Utils.enable_edge_to_edge(content_view);
+    setContentView(R.layout.launcher_activity);
     _tryhere_text = (TextView)findViewById(R.id.launcher_tryhere_text);
     _tryhere_area = (EditText)findViewById(R.id.launcher_tryhere_area);
     if (VERSION.SDK_INT >= 28)

--- a/srcs/juloo.keyboard2/Utils.java
+++ b/srcs/juloo.keyboard2/Utils.java
@@ -59,20 +59,4 @@ public final class Utils
     int res_id = res.getIdentifier("config_navBarInteractionMode", "integer", "android");
     return (res_id > 0 && res.getInteger(res_id) == 2);
   }
-
-  public static void enable_edge_to_edge(View v)
-  {
-    /* Edge-to-edge became enabled by default on API 35. */
-    if (VERSION.SDK_INT < 35)
-      return;
-    v.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener(){
-      @Override
-      public WindowInsets onApplyWindowInsets(View v, WindowInsets wi)
-      {
-        Insets i = wi.getInsets(WindowInsets.Type.systemBars());
-        v.setPadding(i.left, i.top, i.right, i.bottom);
-        return WindowInsets.CONSUMED;
-      }
-    });
-  }
 }

--- a/srcs/juloo.keyboard2/Utils.java
+++ b/srcs/juloo.keyboard2/Utils.java
@@ -2,8 +2,12 @@ package juloo.keyboard2;
 
 import android.app.AlertDialog;
 import android.content.res.Resources;
+import android.graphics.Insets;
+import android.os.Build.VERSION;
 import android.os.IBinder;
+import android.view.View;
 import android.view.Window;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -54,5 +58,21 @@ public final class Utils
     // core/java/android/view/WindowManagerPolicyConstants.java
     int res_id = res.getIdentifier("config_navBarInteractionMode", "integer", "android");
     return (res_id > 0 && res.getInteger(res_id) == 2);
+  }
+
+  public static void enable_edge_to_edge(View v)
+  {
+    /* Edge-to-edge became enabled by default on API 35. */
+    if (VERSION.SDK_INT < 35)
+      return;
+    v.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener(){
+      @Override
+      public WindowInsets onApplyWindowInsets(View v, WindowInsets wi)
+      {
+        Insets i = wi.getInsets(WindowInsets.Type.systemBars());
+        v.setPadding(i.left, i.top, i.right, i.bottom);
+        return WindowInsets.CONSUMED;
+      }
+    });
   }
 }

--- a/srcs/juloo.keyboard2/Utils.java
+++ b/srcs/juloo.keyboard2/Utils.java
@@ -1,6 +1,7 @@
 package juloo.keyboard2;
 
 import android.app.AlertDialog;
+import android.content.res.Resources;
 import android.os.IBinder;
 import android.view.Window;
 import android.view.WindowManager;
@@ -43,5 +44,15 @@ public final class Utils
     while ((l = reader.read(buff, 0, buff_length)) != -1)
       out.append(buff, 0, l);
     return out.toString();
+  }
+
+  /** Whether the thin gesture-navigation bar is used.
+      https://stackoverflow.com/questions/36514167/how-to-really-get-the-navigation-bar-height-in-android
+       */
+  public static boolean is_navigation_bar_gestural(Resources res)
+  {
+    // core/java/android/view/WindowManagerPolicyConstants.java
+    int res_id = res.getIdentifier("config_navBarInteractionMode", "integer", "android");
+    return (res_id > 0 && res.getInteger(res_id) == 2);
   }
 }


### PR DESCRIPTION
Fix https://github.com/Julow/Unexpected-Keyboard/issues/842

The keyboard background now extends under the system bars and display cutout but the keys do not.
This does not yet handle the gesture navigation bar changing height when the IME dismiss and switch buttons are added.