### PR TITLE
Update kann_kannada.xml

### DIFF
--- a/res/values/layouts.xml
+++ b/res/values/layouts.xml
@@ -111,7 +111,7 @@
     <item>두벌식 (Korean)</item>
     <item>Hebrew 1</item>
     <item>Hebrew 2</item>
-    <item>ಕನ್ನಡ</item>
+    <item>ಕನ್ನಡ - Kannada</item>
     <item>AZERTY (Belgian)</item>
     <item>AZERTY (Français)</item>
     <item>BEPO (Français)</item>

--- a/srcs/layouts/kann_kannada.xml
+++ b/srcs/layouts/kann_kannada.xml
@@ -7,7 +7,7 @@
     <key key0="ತ" key1="ಥ" key2="ಧ" key3="ನ" key4="ದ"/>
     <key key0="ಪ" key1="ಫ" key2="ಭ" key3="ಮ" key4="ಬ"/>
     <key key0="ಯ" key1="ರ" key2="ವ" key3="ಱ" key4="ಲ" key8="ೞ"/>
-    <key key0="ಶ" key1="ಷ" key2="ಹ" key3="ಳ" key4="ಸ" key8="※"/>
+    <key key0="ಶ" key1="ಷ" key2="ಹ" key3="ಳ" key4="ಸ"/>
   </row>
   <row>
     <key key0="ಾ" key1="ಅ" key2="ಆ"/>
@@ -23,7 +23,7 @@
     <key key0="ಂ" key1="₹" key2="卐" key3="!" key4="\?" key7="ॐ"/>
     <key key0="ಃ" key5="ೲ" key6="ೱ" key7="ಽ"/>
     <key key0="।" key1="'" key2="&quot;" key3="." key4="," key6="॥"/>
-    <key key0="೦" key3="-" key4="_" key5=":" key6=";"/>
+    <key key0="೦" key1=":" key2=";" key3="-" key4="_"/>
     <key key0="೫" key1="೧" key2="೩" key3="೭" key4="೯" key5="೪" key6="೬" key7="೨" key8="೮"/>
     <key key0="backspace" key2="delete"/>
   </row>

--- a/srcs/layouts/kann_kannada.xml
+++ b/srcs/layouts/kann_kannada.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<keyboard name="ಕನ್ನಡ" script="kannada">
+<keyboard name="ಕನ್ನಡ - Kannada" script="kannada">
   <row>
     <key key0="ಕ" key1="ಖ" key2="ಘ" key3="ಙ" key4="ಗ"/>
     <key key0="ಚ" key1="ಛ" key2="ಝ" key3="ಞ" key4="ಜ"/>
@@ -19,11 +19,11 @@
     <key key0="ೋ" key1="ಓ" key2="ಔ" key4="ೌ"/>
   </row>
   <row>
-    <key key0="್" key1="\@" key2="&amp;" key8="಼"/>
+    <key key0="್" key1="\@" key2="&amp;" key3="zwnj" key4="zwj" key8="಼"/>
     <key key0="ಂ" key1="₹" key2="卐" key3="!" key4="\?" key7="ॐ"/>
     <key key0="ಃ" key5="ೲ" key6="ೱ" key7="ಽ"/>
-    <key key0="।" key1="'" key2="&quot;" key3="." key4="," key5="∪" key6="॥" key8="॰"/>
-    <key key0="೦" key3="-" key4="_" key5=":" key6=";" key8="•"/>
+    <key key0="।" key1="'" key2="&quot;" key3="." key4="," key6="॥"/>
+    <key key0="೦" key3="-" key4="_" key5=":" key6=";"/>
     <key key0="೫" key1="೧" key2="೩" key3="೭" key4="೯" key5="೪" key6="೬" key7="೨" key8="೮"/>
     <key key0="backspace" key2="delete"/>
   </row>


### PR DESCRIPTION
Added zwnj & zwj
1. zwnj used for writing non Kannada words or nouns like Leo Tolstoy as ಲಿಯೊ ಟಾಲ್‌ಸ್ಟಾಯ್ (also can be written as ಲಿಯೊ ಟಾಲ್ಸ್ಟಾಯ್)
2. zwj used for writing ಅರ್ಕ as ಅರ‍್ಕ

Removed unecessary symbols not present in Kannada language:
1. ∪ is a set symbol, a similar symbol is used in Carnatic music, unfortunately not present in Unicode
2. ॰ used only in Devanagari
3. • bullet, not a character or alphabet in Kannada (Can't remember why I added it, maybe because I use it personally in non markdown texts)