### PR TITLE
Change the appareance of some keys

### DIFF
--- a/check_layout.py
+++ b/check_layout.py
@@ -43,37 +43,50 @@ def unexpected_keys(keys, symbols, msg):
     if len(unexpected) > 0:
         warn("%s, unexpected: %s" % (msg, key_list_str(unexpected)))
 
-# Write to [keys] and [dup].
-def parse_row_from_et(row, keys, dup):
-    for key in row:
-        for attr in key.keys():
+def duplicates(keys):
+    dup = [ k for k, key_elts in keys.items() if len(key_elts) >= 2 ]
+    if len(dup) > 0:
+        warn("Duplicate keys: " + key_list_str(dup))
+
+def should_have_role(keys_map, role, keys):
+    def is_center_key(key):
+        def center(key_elt): return key_elt.get("key0", key_elt.get("c"))
+        return any(( center(key_elt) == key for key_elt in keys_map.get(key, []) ))
+    def key_roles(key):
+        return ( key_elt.get("role", "normal") for key_elt in keys_map[key] )
+    for key in keys:
+        if is_center_key(key) and role not in key_roles(key):
+            warn("Key '%s' is not on a key with role=\"%s\"" % (key, role))
+
+# Write to [keys], dict of keyvalue to the key elements they appear in
+def parse_row_from_et(row, keys):
+    for key_elt in row:
+        for attr in key_elt.keys():
             if attr in KEY_ATTRIBUTES:
-                k = key.get(attr).removeprefix("\\")
-                if k in keys: dup.add(k)
-                keys.add(k)
+                k = key_elt.get(attr).removeprefix("\\")
+                keys.setdefault(k, []).append(key_elt)
 
 def parse_layout(fname):
-    keys = set()
-    dup = set()
+    keys = {}
     root = ET.parse(fname).getroot()
     if root.tag != "keyboard":
         return None
     for row in root:
-        parse_row_from_et(row, keys, dup)
-    return root, keys, dup
+        parse_row_from_et(row, keys)
+    return root, keys
 
 def parse_row(fname):
-    keys = set()
-    dup = set()
+    keys = {}
     root = ET.parse(fname).getroot()
     if root.tag != "row":
         return None
-    parse_row_from_et(root, keys, dup)
-    return root, keys, dup
+    parse_row_from_et(root, keys)
+    return root, keys
 
 def check_layout(layout):
-    root, keys, dup = layout
-    if len(dup) > 0: warn("Duplicate keys: " + key_list_str(dup))
+    root, keys_map = layout
+    keys = set(keys_map.keys())
+    duplicates(keys_map)
     missing_some_of(keys, "~!@#$%^&*(){}`[]=\\-_;:/.,?<>'\"+|", "ASCII punctuation")
     missing_some_of(keys, "0123456789", "digits")
     missing_required(keys, ["backspace", "delete"], "Layout doesn't define some important keys")
@@ -94,8 +107,8 @@ def check_layout(layout):
         missing_required(keys, ["shift", "loc capslock"], "Missing important key")
         missing_required(keys, ["loc esc", "loc tab"], "Missing programming keys")
 
-    _, bottom_row_keys, _ = parse_row("res/xml/bottom_row.xml")
-
+    _, bottom_row_keys_map = parse_row("res/xml/bottom_row.xml")
+    bottom_row_keys = set(bottom_row_keys_map.keys())
     if root.get("bottom_row") == "false":
         missing_required(keys, bottom_row_keys,
                          "Layout redefines the bottom row but some important keys are missing")
@@ -105,6 +118,10 @@ def check_layout(layout):
 
     if root.get("script") == None:
         warn("Layout doesn't specify a script.")
+
+    should_have_role(keys_map, "action",
+                     [ "shift", "ctrl", "fn", "backspace", "enter" ])
+    should_have_role(keys_map, "space_bar", [ "space" ])
 
     keys_without_loc = set(( k.removeprefix("loc ") for k in keys ))
     # Keys with a len under 3 are often composed characters

--- a/res/values-v31/values.xml
+++ b/res/values-v31/values.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <!-- Colors for the Monet themes. -->
+  <color name="system_accent1_100">@android:color/system_accent1_100</color>
+  <color name="system_accent1_200">@android:color/system_accent1_200</color>
   <color name="system_accent1_400">@android:color/system_accent1_400</color>
   <color name="system_accent1_600">@android:color/system_accent1_600</color>
+  <color name="system_accent2_900">@android:color/system_accent2_900</color>
   <color name="system_neutral1_0">@android:color/system_neutral1_0</color>
   <color name="system_neutral1_100">@android:color/system_neutral1_100</color>
   <color name="system_neutral1_400">@android:color/system_neutral1_400</color>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -7,6 +7,9 @@
     <attr name="colorKey" format="color"/>
     <!-- Background of the keys when pressed -->
     <attr name="colorKeyActivated" format="color"/>
+    <!-- Adjust the lightness of keys depending on their role. -->
+    <attr name="colorKeyAction" format="color"/>
+    <attr name="colorKeySpaceBar" format="color"/>
     <!-- Label colors -->
     <attr name="colorLabel" format="color"/>
     <attr name="colorLabelPressed" format="color"/> <!-- defaults to colorLabel -->
@@ -20,6 +23,8 @@
     <attr name="keyBorderRadius" format="dimension"/>
     <attr name="keyBorderWidth" format="dimension"/>
     <attr name="keyBorderWidthActivated" format="dimension"/>
+    <attr name="keyBorderWidthAction" format="dimension"/>
+    <attr name="keyBorderWidthSpaceBar" format="dimension"/>
     <attr name="keyBorderColorLeft" format="color"/>
     <attr name="keyBorderColorTop" format="color"/>
     <attr name="keyBorderColorRight" format="color"/>
@@ -46,6 +51,8 @@
     <item name="keyBorderRadius">5dp</item>
     <item name="keyBorderWidth">0dp</item>
     <item name="keyBorderWidthActivated">0dp</item>
+    <item name="keyBorderWidthAction">?attr/keyBorderWidth</item>
+    <item name="keyBorderWidthSpaceBar">?attr/keyBorderWidth</item>
     <item name="secondaryDimming">0.25</item>
     <item name="greyedDimming">0.5</item>
     <item name="emoji_key_bg" type="color">?attr/emoji_button_bg</item>
@@ -60,8 +67,12 @@
     <item name="colorKeyboard">#1b1b1b</item>
     <item name="colorKey">#333333</item>
     <item name="colorKeyActivated">#1b1b1b</item>
+    <item name="colorKeyAction">#262626</item>
+    <item name="colorKeySpaceBar">#2b2b2b</item>
     <item name="keyBorderWidth">1.2dp</item>
     <item name="keyBorderWidthActivated">0dp</item>
+    <item name="keyBorderWidthAction">0dp</item>
+    <item name="keyBorderWidthSpaceBar">0dp</item>
     <item name="keyBorderColorBottom">#404040</item>
     <item name="colorLabel">#ffffff</item>
     <item name="colorLabelActivated">#3399ff</item>
@@ -75,8 +86,12 @@
     <item name="colorKeyboard">#e3e3e3</item>
     <item name="colorKey">#cccccc</item>
     <item name="colorKeyActivated">#e3e3e3</item>
+    <item name="colorKeyAction">#d9d9d9</item>
+    <item name="colorKeySpaceBar">#dedede</item>
     <item name="keyBorderWidth">0.6dp</item>
     <item name="keyBorderWidthActivated">0dp</item>
+    <item name="keyBorderWidthAction">0dp</item>
+    <item name="keyBorderWidthSpaceBar">0dp</item>
     <item name="keyBorderColorLeft">#cccccc</item>
     <item name="keyBorderColorTop">#eeeeee</item>
     <item name="keyBorderColorRight">#cccccc</item>
@@ -93,6 +108,8 @@
     <item name="colorKeyboard">#000000</item>
     <item name="colorKey">#000000</item>
     <item name="colorKeyActivated">#333333</item>
+    <item name="colorKeyAction">#000000</item>
+    <item name="colorKeySpaceBar">#000000</item>
     <item name="keyBorderWidth">0dp</item>
     <item name="keyBorderWidthActivated">1dp</item>
     <item name="keyBorderColorLeft">#2a2a2a</item>
@@ -114,6 +131,8 @@
     <item name="android:isLightTheme">true</item>
     <item name="colorKeyboard">#ffffff</item>
     <item name="colorKey">#ffffff</item>
+    <item name="colorKeyAction">#ffffff</item>
+    <item name="colorKeySpaceBar">#ffffff</item>
     <item name="keyBorderWidth">1dp</item>
     <item name="keyBorderWidthActivated">1dp</item>
     <item name="keyBorderColorLeft">#f0f0f0</item>
@@ -133,6 +152,8 @@
     <item name="android:isLightTheme">true</item>
     <item name="colorKeyboard">#ffffff</item>
     <item name="colorKey">#ffffff</item>
+    <item name="colorKeyAction">#ffffff</item>
+    <item name="colorKeySpaceBar">#ffffff</item>
     <item name="keyBorderWidth">2dp</item>
     <item name="keyBorderWidthActivated">5dp</item>
     <item name="keyBorderColorLeft">#000000</item>
@@ -154,6 +175,8 @@
     <item name="colorKeyboard">#ffe0b2</item>
     <item name="colorKey">#fff3e0</item>
     <item name="colorKeyActivated">#ffcc80</item>
+    <item name="colorKeyAction">#ffe9c6</item>
+    <item name="colorKeySpaceBar">#ffedd0</item>
     <item name="colorLabel">#000000</item>
     <item name="colorLabelActivated">#ffffff</item>
     <item name="colorLabelLocked">#e65100</item>
@@ -172,6 +195,8 @@
     <item name="colorKeyboard">#4db6ac</item>
     <item name="colorKey">#e0f2f1</item>
     <item name="colorKeyActivated">#00695c</item>
+    <item name="colorKeyAction">#b8e3de</item>
+    <item name="colorKeySpaceBar">#c3e7e3</item>
     <item name="colorLabel">#000000</item>
     <item name="colorLabelActivated">#ffffff</item>
     <item name="colorLabelLocked">#64ffda</item>
@@ -190,6 +215,8 @@
     <item name="colorKeyboard">@color/system_neutral1_100</item>
     <item name="colorKey">@color/system_neutral1_50</item>
     <item name="colorKeyActivated">?colorKeyboard</item>
+    <item name="colorKeyAction">@color/system_accent1_100</item>
+    <item name="colorKeySpaceBar">@color/system_accent1_200</item>
     <item name="colorLabel">@color/system_neutral1_800</item>
     <item name="colorLabelActivated">@color/system_accent1_400</item>
     <item name="colorLabelLocked">@color/system_accent1_600</item>
@@ -202,6 +229,7 @@
     <item name="colorKeyboard">@color/system_neutral1_900</item>
     <item name="colorKey">@color/system_neutral1_800</item>
     <item name="colorKeyActivated">?colorKeyboard</item>
+    <item name="colorKeyAction">@color/system_accent2_900</item>
     <item name="colorLabel">@color/system_neutral1_0</item>
     <item name="colorLabelActivated">@color/system_accent1_400</item>
     <item name="colorLabelLocked">@color/system_accent1_600</item>
@@ -214,6 +242,8 @@
     <item name="colorKeyboard">#191724</item>
     <item name="colorKey">#26233a</item>
     <item name="colorKeyActivated">#403d52</item>
+    <item name="colorKeyAction">#2a2740</item>
+    <item name="colorKeySpaceBar">#2e2b47</item>
     <item name="keyBorderWidth">0dp</item>
     <item name="keyBorderWidthActivated">1dp</item>
     <item name="keyBorderColorLeft">#6e6a86</item>

--- a/res/values/values.xml
+++ b/res/values/values.xml
@@ -15,8 +15,13 @@
   <bool name="debug_logs">false</bool>
   <!-- Color fallback for the Monet themes on Android API < 31. This makes the
        Monet themes very similar to the "Dark" and "Light" themes. -->
+  <color name="system_accent1_100">#3333ff</color>
+  <color name="system_accent1_200">#3366ff</color>
   <color name="system_accent1_400">#3399ff</color>
-  <color name="system_accent1_600">#33cc33</color>
+  <color name="system_accent1_600">#33ccff</color>
+  <color name="system_accent1_900">#33ffff</color>
+  <!-- accent2 is inverted accent1-->
+  <color name="system_accent2_900">#009999</color>
   <color name="system_neutral1_0">#ffffff</color>
   <color name="system_neutral1_100">#e3e3e3</color>
   <color name="system_neutral1_400">#cccccc</color>

--- a/res/xml/bottom_row.xml
+++ b/res/xml/bottom_row.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <row height="0.95">
-  <key width="1.7" key0="ctrl" key1="loc switch_greekmath" key2="loc meta" key3="loc switch_clipboard" key4="switch_numeric"/>
-  <key width="1.1" key0="fn" key1="loc alt" key2="loc change_method" key3="switch_emoji" key4="config"/>
-  <key width="4.4" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right"/>
-  <key width="1.1" key0="loc compose" key7="up" key6="right" key5="left" key8="down" key1="loc home" key2="loc page_up" key3="loc end" key4="loc page_down"/>
-  <key width="1.7" key0="enter" key1="loc voice_typing" key2="action"/>
+  <key width="1.7" role="action" key0="ctrl" key1="loc switch_greekmath" key2="loc meta" key3="loc switch_clipboard" key4="switch_numeric"/>
+  <key width="1.1" role="action" key0="fn" key1="loc alt" key2="loc change_method" key3="switch_emoji" key4="config"/>
+  <key width="4.4" role="space_bar" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right"/>
+  <key width="1.1" role="action" key0="loc compose" key7="up" key6="right" key5="left" key8="down" key1="loc home" key2="loc page_up" key3="loc end" key4="loc page_down"/>
+  <key width="1.7" role="action" key0="enter" key1="loc voice_typing" key2="action"/>
 </row>

--- a/res/xml/clipboard_bottom_row.xml
+++ b/res/xml/clipboard_bottom_row.xml
@@ -2,9 +2,9 @@
 <!-- The bottom row used in the clipboard history pane. -->
 <keyboard bottom_row="false">
   <row height="0.95">
-    <key key0="switch_back_clipboard"/>
-    <key width="3" key0="space" key5="cursor_left" key6="cursor_right"/>
-    <key key0="backspace" key2="delete"/>
-    <key key0="enter" key2="action"/>
+    <key role="action" key0="switch_back_clipboard"/>
+    <key width="3" role="space_bar" key0="space" key5="cursor_left" key6="cursor_right"/>
+    <key role="action" key0="backspace" key2="delete"/>
+    <key role="action" key0="enter" key2="action"/>
   </row>
 </keyboard>

--- a/res/xml/emoji_bottom_row.xml
+++ b/res/xml/emoji_bottom_row.xml
@@ -2,9 +2,9 @@
 <!-- The bottom row used in the emoji pane. -->
 <keyboard bottom_row="false">
   <row height="0.95">
-    <key key0="switch_back_emoji"/>
-    <key width="3" key0="space" key5="cursor_left" key6="cursor_right"/>
-    <key key0="backspace" key2="delete"/>
-    <key key0="enter" key2="action"/>
+    <key role="action" key0="switch_back_emoji"/>
+    <key role="space_bar" width="3" key0="space" key5="cursor_left" key6="cursor_right"/>
+    <key role="action" key0="backspace" key2="delete"/>
+    <key role="action" key0="enter" key2="action"/>
   </row>
 </keyboard>

--- a/res/xml/greekmath.xml
+++ b/res/xml/greekmath.xml
@@ -25,7 +25,7 @@
     <key key0="ϡ" key1="⌀"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="ζ" key3="⇌" key4="√"/>
     <key key0="χ" key3="accent_arrow_right" key4="∪"/>
     <key key0="ϛ" key4="∩"/>
@@ -33,15 +33,15 @@
     <key key0="β" key1="≤" key3="ℤ" key4="1"/>
     <key key0="ν" key1="≠" key3="ℚ" key4="2"/>
     <key key0="μ" key1="≥" key3="×" key4="3"/>
-    <key width="1.5" key0="backspace" key3="delete"/>
+    <key width="1.5" role="action" key0="backspace" key3="delete"/>
   </row>
   <row height="0.95">
-    <key width="1.2" key0="switch_text" key2="loc esc"/>
-    <key width="1.2" key0="switch_numeric" key2="loc tab"/>
-    <key width="1.2" key0="fn"/>
-    <key width="2.8" key0="space" key1="superscript" key3="subscript"/>
-    <key width="1.2" key0="0" key2="."/>
-    <key width="1.2" key0="loc compose" key7="up" key6="right" key5="left" key8="down"/>
-    <key width="1.2" key0="enter" key1="=" key2="action"/>
+    <key width="1.2" role="action" key0="switch_text" key2="loc esc"/>
+    <key width="1.2" role="action" key0="switch_numeric" key2="loc tab"/>
+    <key width="1.2" role="action" key0="fn"/>
+    <key width="2.8" role="space_bar" key0="space" key1="superscript" key3="subscript"/>
+    <key width="1.2" role="action" key0="0" key2="."/>
+    <key width="1.2" role="action" key0="loc compose" key7="up" key6="right" key5="left" key8="down"/>
+    <key width="1.2" role="action" key0="enter" key1="=" key2="action"/>
   </row>
 </keyboard>

--- a/res/xml/number_row.xml
+++ b/res/xml/number_row.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- See [number_row_no_symbols.xml] for the number row with no symbols. -->
 <row height="0.75">
-  <key key0="1" se="!"/>
-  <key key0="2" se="@"/>
-  <key key0="3" se="#"/>
-  <key key0="4" se="$"/>
-  <key key0="5" se="%"/>
-  <key key0="6" sw="^"/>
-  <key key0="7" sw="&amp;"/>
-  <key key0="8" sw="*"/>
-  <key key0="9" sw="("/>
-  <key key0="0" sw=")"/>
+  <key role="action" key0="1" se="!"/>
+  <key role="action" key0="2" se="@"/>
+  <key role="action" key0="3" se="#"/>
+  <key role="action" key0="4" se="$"/>
+  <key role="action" key0="5" se="%"/>
+  <key role="action" key0="6" sw="^"/>
+  <key role="action" key0="7" sw="&amp;"/>
+  <key role="action" key0="8" sw="*"/>
+  <key role="action" key0="9" sw="("/>
+  <key role="action" key0="0" sw=")"/>
 </row>

--- a/res/xml/number_row_no_symbols.xml
+++ b/res/xml/number_row_no_symbols.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <row height="0.75">
-  <key key0="1"/>
-  <key key0="2"/>
-  <key key0="3"/>
-  <key key0="4"/>
-  <key key0="5"/>
-  <key key0="6"/>
-  <key key0="7"/>
-  <key key0="8"/>
-  <key key0="9"/>
-  <key key0="0"/>
+  <key role="action" key0="1"/>
+  <key role="action" key0="2"/>
+  <key role="action" key0="3"/>
+  <key role="action" key0="4"/>
+  <key role="action" key0="5"/>
+  <key role="action" key0="6"/>
+  <key role="action" key0="7"/>
+  <key role="action" key0="8"/>
+  <key role="action" key0="9"/>
+  <key role="action" key0="0"/>
 </row>

--- a/res/xml/numeric.xml
+++ b/res/xml/numeric.xml
@@ -19,18 +19,18 @@
     <key width="0.75" key0="-" key1="^"/>
   </row>
   <row>
-    <key width="0.75" key0="switch_greekmath"/>
-    <key width="0.75" key0="shift" key2="fn" key4="loc alt"/>
+    <key width="0.75" role="action" key0="switch_greekmath"/>
+    <key width="0.75" role="action" key0="shift" key2="fn" key4="loc alt"/>
     <key key0="1" key1="superscript" key2="ordinal" key3="subscript"/>
     <key key0="2"/>
     <key key0="3"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
   <row height="0.95">
-    <key width="1.5" key0="switch_text" key2="ctrl"/>
+    <key width="1.5" role="action" key0="switch_text" key2="ctrl"/>
     <key width="1.5" key0="0"/>
     <key width="0.75" key0="." key1=":" key2="," key3=";"/>
     <key width="0.75" key0="space" key1="&quot;" key2="'" key3="loc compose" key4="_"/>
-    <key width="1.5" key0="enter" key1="±" key2="action" key3="="/>
+    <key width="1.5" role="action" key0="enter" key1="±" key2="action" key3="="/>
   </row>
 </keyboard>

--- a/res/xml/numeric.xml
+++ b/res/xml/numeric.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <keyboard bottom_row="false">
   <row>
-    <key width="0.75" key0="loc esc" key2="~" key4="!"/>
-    <key width="0.75" key0="(" key2="[" key4="{"/>
+    <key width="0.75" role="action" key0="loc esc" key2="~" key4="!"/>
+    <key width="0.75" role="action" key0="(" key2="[" key4="{"/>
     <key key0="7" key1="&lt;" key2="&gt;"/>
     <key key0="8" key2="∞"/>
     <key key0="9" key2="π"/>
-    <key width="0.75" key0="*" key1="√" key2="×" key3="\#"/>
-    <key width="0.75" key0="/" key1="%" key3="÷"/>
+    <key width="0.75" role="action" key0="*" key1="√" key2="×" key3="\#"/>
+    <key width="0.75" role="action" key0="/" key1="%" key3="÷"/>
   </row>
   <row>
-    <key width="0.75" key0="loc tab" key2="|" key4="\\"/>
-    <key width="0.75" key0=")" key2="]" key4="}"/>
+    <key width="0.75" role="action" key0="loc tab" key2="|" key4="\\"/>
+    <key width="0.75" role="action" key0=")" key2="]" key4="}"/>
     <key key0="4" key1="box" key3="arrows"/>
     <key key0="5" key7="up" key6="right" key5="left" key8="down"/>
     <key key0="6"/>
-    <key width="0.75" key0="+" key1="Σ" key2="$"/>
-    <key width="0.75" key0="-" key1="^"/>
+    <key width="0.75" role="action" key0="+" key1="Σ" key2="$"/>
+    <key width="0.75" role="action" key0="-" key1="^"/>
   </row>
   <row>
     <key width="0.75" role="action" key0="switch_greekmath"/>
@@ -29,8 +29,8 @@
   <row height="0.95">
     <key width="1.5" role="action" key0="switch_text" key2="ctrl"/>
     <key width="1.5" key0="0"/>
-    <key width="0.75" key0="." key1=":" key2="," key3=";"/>
-    <key width="0.75" key0="space" key1="&quot;" key2="'" key3="loc compose" key4="_"/>
+    <key width="0.75" role="action" key0="." key1=":" key2="," key3=";"/>
+    <key width="0.75" role="action" key0="action" key1="&quot;" key2="'" key3="loc compose" key4="_"/>
     <key width="1.5" role="action" key0="enter" key1="±" key2="action" key3="="/>
   </row>
 </keyboard>

--- a/res/xml/numpad.xml
+++ b/res/xml/numpad.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <keyboard bottom_row="false">
     <row>
-        <key key0="7"/>
-        <key key0="8"/>
-        <key key0="9"/>
-        <key key0="/"/>
+        <key role="action" key0="7"/>
+        <key role="action" key0="8"/>
+        <key role="action" key0="9"/>
+        <key role="action" key0="/"/>
     </row>
     <row>
-        <key key0="4"/>
-        <key key0="5"/>
-        <key key0="6"/>
-        <key key0="*"/>
+        <key role="action" key0="4"/>
+        <key role="action" key0="5"/>
+        <key role="action" key0="6"/>
+        <key role="action" key0="*"/>
     </row>
     <row>
-        <key key0="1"/>
-        <key key0="2"/>
-        <key key0="3"/>
-        <key key0="-"/>
+        <key role="action" key0="1"/>
+        <key role="action" key0="2"/>
+        <key role="action" key0="3"/>
+        <key role="action" key0="-"/>
     </row>
     <row height="0.95">
-        <key key0="0"/>
-        <key key0="."/>
-        <key key0="="/>
-        <key key0="+"/>
+        <key role="action" key0="0"/>
+        <key role="action" key0="."/>
+        <key role="action" key0="="/>
+        <key role="action" key0="+"/>
     </row>
 </keyboard>

--- a/res/xml/pin.xml
+++ b/res/xml/pin.xml
@@ -4,24 +4,24 @@
     <key shift="1.0" key0="1"/>
     <key key0="2" indication="ABC"/>
     <key key0="3" indication="DEF"/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
   <row>
     <key shift="1.0" key0="4" indication="GHI"/>
     <key key0="5" indication="JKL"/>
     <key key0="6" indication="MNO"/>
-    <key key0="(" key1="paste" key2="=" key3=":" key4="-"/>
+    <key role="action" key0="(" key1="paste" key2="=" key3=":" key4="-"/>
   </row>
   <row>
     <key shift="1.0" key0="7" indication="PQRS"/>
     <key key0="8" indication="TUV"/>
     <key key0="9" indication="WXYZ"/>
-    <key key0=")" key2="," key3="/" key4="."/>
+    <key role="action" key0=")" key2="," key3="/" key4="."/>
   </row>
   <row>
-    <key shift="1.0" key0="*" key1="switch_text" key3="switch_numeric"/>
+    <key role="action" shift="1.0" key0="*" key1="switch_text" key3="switch_numeric"/>
     <key key0="0" key3="+" key4="space"/>
-    <key key0="\#" key7="up" key6="right" key5="left" key8="down"/>
-    <key key0="action" key2="enter"/>
+    <key role="action" key0="\#" key7="up" key6="right" key5="left" key8="down"/>
+    <key role="action" key0="action" key2="enter"/>
   </row>
 </keyboard>

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -351,7 +351,17 @@ public class Keyboard2View extends View
         x += k.shift * _keyWidth;
         float keyW = _keyWidth * k.width - _tc.horizontal_margin;
         boolean isKeyDown = _pointers.isKeyDown(k);
-        Theme.Computed.Key tc_key = isKeyDown ? _tc.key_activated : _tc.key;
+        Theme.Computed.Key tc_key;
+        if (isKeyDown)
+          tc_key = _tc.key_activated;
+        else
+          switch (k.role)
+          {
+            case Action: tc_key = _tc.key_action; break;
+            case Space_bar: tc_key = _tc.key_space_bar; break;
+            default:
+            case Normal: tc_key = _tc.key; break;
+          }
         drawKeyFrame(canvas, x, y, keyW, keyH, tc_key);
         if (k.keys[0] != null)
           drawLabel(canvas, k.keys[0], keyW / 2f + x, y, keyH, isKeyDown, tc_key);

--- a/srcs/juloo.keyboard2/KeyboardData.java
+++ b/srcs/juloo.keyboard2/KeyboardData.java
@@ -406,12 +406,14 @@ public final class KeyboardData
     public final float shift;
     /** String printed on the keys. It has no other effect. */
     public final String indication;
+    /** Keys are rendered differently according to their role. */
+    public final Role role;
 
     /** Whether a key was declared with the 'loc' prefix. */
     public static final int F_LOC = 1;
     public static final int ALL_FLAGS = F_LOC;
 
-    protected Key(KeyValue[] ks, KeyValue antic, int f, float w, float s, String i)
+    protected Key(KeyValue[] ks, KeyValue antic, int f, float w, float s, String i, Role role_)
     {
       keys = ks;
       anticircle = antic;
@@ -419,6 +421,7 @@ public final class KeyboardData
       width = Math.max(w, 0f);
       shift = Math.max(s, 0f);
       indication = i;
+      role = role_;
     }
 
     static final Key EMPTY = new Key(new KeyValue[9], null, 0, 1.f, 1.f, null);
@@ -489,9 +492,11 @@ public final class KeyboardData
       float width = attribute_float(parser, "width", 1f);
       float shift = attribute_float(parser, "shift", 0.f);
       String indication = parser.getAttributeValue(null, "indication");
+      String role_str = parser.getAttributeValue(null, "role");
+      Role role = (role_str == null) ? Role.Normal : Role.parse(role_str);
       while (parser.next() != XmlPullParser.END_TAG)
         continue;
-      return new Key(ks, anticircle, keysflags, width, shift, indication);
+      return new Key(ks, anticircle, keysflags, width, shift, indication, role);
     }
 
     /** Whether key at [index] as [flag]. */
@@ -503,7 +508,7 @@ public final class KeyboardData
     /** New key with the width multiplied by 's'. */
     public Key scaleWidth(float s)
     {
-      return new Key(keys, anticircle, keysflags, width * s, shift, indication);
+      return new Key(keys, anticircle, keysflags, width * s, shift, indication, role);
     }
 
     public void getKeys(Map<KeyValue, KeyPos> dst, int row, int col)
@@ -524,12 +529,12 @@ public final class KeyboardData
       for (int j = 0; j < keys.length; j++) ks[j] = keys[j];
       ks[i] = kv;
       int flags = (keysflags & ~(ALL_FLAGS << i));
-      return new Key(ks, anticircle, flags, width, shift, indication);
+      return new Key(ks, anticircle, flags, width, shift, indication, role);
     }
 
     public Key withShift(float s)
     {
-      return new Key(keys, anticircle, keysflags, width, s, indication);
+      return new Key(keys, anticircle, keysflags, width, s, indication, role);
     }
 
     public boolean hasValue(KeyValue kv)
@@ -538,6 +543,23 @@ public final class KeyboardData
         if (keys[i] != null && keys[i].equals(kv))
           return true;
       return false;
+    }
+
+    public static enum Role
+    {
+      Normal,
+      Action, // Generally Shift, Delete and keys on the bottom row
+      Space_bar;
+
+      public static Role parse(String str)
+      {
+        switch (str)
+        {
+          case "action": return Action;
+          case "space_bar": return Space_bar;
+          default: case "normal": return Normal;
+        }
+      }
     }
   }
 
@@ -555,7 +577,7 @@ public final class KeyboardData
       for (int i = 0; i < ks.length; i++)
         if (k.keys[i] != null)
           ks[i] = apply(k.keys[i], k.keyHasFlag(i, Key.F_LOC));
-      return new Key(ks, k.anticircle, k.keysflags, k.width, k.shift, k.indication);
+      return new Key(ks, k.anticircle, k.keysflags, k.width, k.shift, k.indication, k.role);
     }
   }
 

--- a/srcs/juloo.keyboard2/KeyboardData.java
+++ b/srcs/juloo.keyboard2/KeyboardData.java
@@ -424,7 +424,8 @@ public final class KeyboardData
       role = role_;
     }
 
-    static final Key EMPTY = new Key(new KeyValue[9], null, 0, 1.f, 1.f, null);
+    static final Key EMPTY =
+      new Key(new KeyValue[9], null, 0, 1.f, 1.f, null, Role.Normal);
 
     /** Read a key value attribute that have a synonym. Having both synonyms
         present at the same time is an error.

--- a/srcs/juloo.keyboard2/Theme.java
+++ b/srcs/juloo.keyboard2/Theme.java
@@ -12,6 +12,8 @@ public class Theme
   // Key colors
   public final int colorKey;
   public final int colorKeyActivated;
+  public final int colorKeyAction;
+  public final int colorKeySpaceBar;
 
   // Label colors
   public final int lockedColor;
@@ -26,6 +28,8 @@ public class Theme
   public final float keyBorderRadius;
   public final float keyBorderWidth;
   public final float keyBorderWidthActivated;
+  public final float keyBorderWidthAction;
+  public final float keyBorderWidthSpaceBar;
   public final int keyBorderColorLeft;
   public final int keyBorderColorTop;
   public final int keyBorderColorRight;
@@ -40,6 +44,8 @@ public class Theme
     TypedArray s = context.getTheme().obtainStyledAttributes(attrs, R.styleable.keyboard, 0, 0);
     colorKey = s.getColor(R.styleable.keyboard_colorKey, 0);
     colorKeyActivated = s.getColor(R.styleable.keyboard_colorKeyActivated, 0);
+    colorKeyAction = s.getColor(R.styleable.keyboard_colorKeyAction, colorKey);
+    colorKeySpaceBar = s.getColor(R.styleable.keyboard_colorKeySpaceBar, colorKey);
     // colorKeyboard = s.getColor(R.styleable.keyboard_colorKeyboard, 0);
     colorNavBar = s.getColor(R.styleable.keyboard_navigationBarColor, 0);
     isLightNavBar = s.getBoolean(R.styleable.keyboard_windowLightNavigationBar, false);
@@ -55,6 +61,8 @@ public class Theme
     keyBorderRadius = s.getDimension(R.styleable.keyboard_keyBorderRadius, 0);
     keyBorderWidth = s.getDimension(R.styleable.keyboard_keyBorderWidth, 0);
     keyBorderWidthActivated = s.getDimension(R.styleable.keyboard_keyBorderWidthActivated, 0);
+    keyBorderWidthAction = s.getDimension(R.styleable.keyboard_keyBorderWidthAction, 0);
+    keyBorderWidthSpaceBar = s.getDimension(R.styleable.keyboard_keyBorderWidthSpaceBar, 0);
     keyBorderColorLeft = s.getColor(R.styleable.keyboard_keyBorderColorLeft, colorKey);
     keyBorderColorTop = s.getColor(R.styleable.keyboard_keyBorderColorTop, colorKey);
     keyBorderColorRight = s.getColor(R.styleable.keyboard_keyBorderColorRight, colorKey);
@@ -63,7 +71,7 @@ public class Theme
   }
 
   /** Interpolate the 'value' component toward its opposite by 'alpha'. */
-  int adjustLight(int color, float alpha)
+  static int adjustLight(int color, float alpha)
   {
     float[] hsv = new float[3];
     Color.colorToHSV(color, hsv);
@@ -101,6 +109,8 @@ public class Theme
 
     public final Key key;
     public final Key key_activated;
+    public final Key key_action;
+    public final Key key_space_bar;
 
     public Computed(Theme theme, Config config, float keyWidth, KeyboardData layout)
     {
@@ -114,8 +124,10 @@ public class Theme
       // added on the right and on the bottom of every keys.
       margin_top = config.marginTop + vertical_margin / 2;
       margin_left = horizontal_margin / 2;
-      key = new Key(theme, config, keyWidth, false);
-      key_activated = new Key(theme, config, keyWidth, true);
+      key = new Key(theme, config, keyWidth, false, KeyboardData.Key.Role.Normal);
+      key_action = new Key(theme, config, keyWidth, false, KeyboardData.Key.Role.Action);
+      key_space_bar = new Key(theme, config, keyWidth, false, KeyboardData.Key.Role.Space_bar);
+      key_activated = new Key(theme, config, keyWidth, true, KeyboardData.Key.Role.Normal);
       indication_paint = init_label_paint(config, null);
       indication_paint.setColor(theme.subLabelColor);
     }
@@ -135,20 +147,37 @@ public class Theme
       final Paint _special_sublabel_paint;
       final int _label_alpha_bits;
 
-      public Key(Theme theme, Config config, float keyWidth, boolean activated)
+      public Key(Theme theme, Config config, float keyWidth, boolean activated,
+          KeyboardData.Key.Role role)
       {
-        bg_paint.setColor(activated ? theme.colorKeyActivated : theme.colorKey);
-        if (config.borderConfig)
+        border_radius = config.borderConfig ? config.customBorderRadius * keyWidth : theme.keyBorderRadius;
+        int bg_color;
+        if (activated)
         {
-          border_radius = config.customBorderRadius * keyWidth;
-          border_width = config.customBorderLineWidth;
+          bg_color = theme.colorKeyActivated;
+          border_width = theme.keyBorderWidthActivated;
+          bg_paint.setAlpha(config.keyActivatedOpacity);
         }
         else
         {
-          border_radius = theme.keyBorderRadius;
-          border_width = activated ? theme.keyBorderWidthActivated : theme.keyBorderWidth;
+          switch (role)
+          {
+            case Action:
+              bg_color = theme.colorKeyAction;
+              border_width = theme.keyBorderWidthAction;
+              break;
+            case Space_bar:
+              bg_color = theme.colorKeySpaceBar;
+              border_width = theme.keyBorderWidthSpaceBar;
+              break;
+            default:
+              bg_color = theme.colorKey;
+              border_width = config.borderConfig ? config.customBorderLineWidth : theme.keyBorderWidth;
+              break;
+          }
+          bg_paint.setAlpha(config.keyOpacity);
         }
-        bg_paint.setAlpha(activated ? config.keyActivatedOpacity : config.keyOpacity);
+        bg_paint.setColor(bg_color);
         border_left_paint = init_border_paint(config, border_width, theme.keyBorderColorLeft);
         border_top_paint = init_border_paint(config, border_width, theme.keyBorderColorTop);
         border_right_paint = init_border_paint(config, border_width, theme.keyBorderColorRight);

--- a/srcs/layouts/arab_alt.xml
+++ b/srcs/layouts/arab_alt.xml
@@ -37,6 +37,6 @@
     <key key0="ز" key3="."/>
     <key key0="ظ" key3="&#1567;"/>
     <key key0="د"/>
-    <key width="1.0" key0="backspace" key2="delete"/>
+    <key width="1.0" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/arab_hamvaj_tly.xml
+++ b/srcs/layouts/arab_hamvaj_tly.xml
@@ -37,6 +37,6 @@
     <key key0="و" key1="ۋ" key4="ۊ"/>
     <key key0="چ"/>
     <key key0="ٚ" key1="ٛ"/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/arab_pc.xml
+++ b/srcs/layouts/arab_pc.xml
@@ -39,6 +39,6 @@
     <key key0="و" key1=","/>
     <key key0="ز" key1="."/>
     <key key0="ظ" key1="&#1567;"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/arab_pc_ckb.xml
+++ b/srcs/layouts/arab_pc_ckb.xml
@@ -34,6 +34,6 @@
     <key key0="ب" key1="ٮ" />
     <key key0="ن" key2="&#1548;" key3="&#1563;"/>
     <key key0="م" key2="." key3=":" />
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/arab_pc_hindu.xml
+++ b/srcs/layouts/arab_pc_hindu.xml
@@ -39,6 +39,6 @@
     <key key0="و" key1=","/>
     <key key0="ز" key1="."/>
     <key key0="ظ" key1="&#1567;"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/arab_pc_ir.xml
+++ b/srcs/layouts/arab_pc_ir.xml
@@ -36,6 +36,6 @@
     <key key0="پ" key2="&#1567;"/>
     <key key0="و"/>
     <key key0="چ"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/armn_cpbsmo.xml
+++ b/srcs/layouts/armn_cpbsmo.xml
@@ -37,7 +37,7 @@
     <key key0="պ" key4=":"/>
   </row>
   <row>
-    <key key0="shift" key2="loc capslock"/>
+    <key role="action" key0="shift" key2="loc capslock"/>
     <key key0="դ"/>
     <key key0="չ"/>
     <key key0="յ"/>
@@ -46,6 +46,6 @@
     <key key0="ք"/>
     <key key0="խ"/>
     <key key0="շ" key4="."/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/armn_kvertc.xml
+++ b/srcs/layouts/armn_kvertc.xml
@@ -37,7 +37,7 @@
     <key key0="ե" key2="և" key4=":"/>
   </row>
   <row>
-    <key key0="shift" key2="loc capslock"/>
+    <key role="action" key0="shift" key2="loc capslock"/>
     <key key0="ց"/>
     <key key0="զ"/>
     <key key0="չ"/>
@@ -46,6 +46,6 @@
     <key key0="ն"/>
     <key key0="մ"/>
     <key key0="շ" key4="."/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/beng_assamese.xml
+++ b/srcs/layouts/beng_assamese.xml
@@ -35,6 +35,6 @@
     <key c="," sw="ষ" ne="("/>
     <key c="." sw="।" ne=")"/>
     <key c="য়" sw="য"/>
-    <key width="1.5" c="backspace" ne="delete"/>
+    <key role="action" width="1.5" c="backspace" ne="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/beng_national.xml
+++ b/srcs/layouts/beng_national.xml
@@ -24,7 +24,7 @@
     <key key0="দ" key1="_" key2="ধ" key3="(" key4=")"/>
   </row>
   <row>
-    <key width="1.4" key0="shift" key2="loc capslock"/>
+    <key width="1.4" role="action" key0="shift" key2="loc capslock"/>
     <key shift="0.1" key0="্র" key2="্য" key3="\#" key4="*"/>
     <key key0="ো" key1="ৌ" key2="ও" key3="ঔ" key4="\@"/>
     <key key0="ে" key1="ৈ" key2="এ" key3="ঐ" key4="%"/>
@@ -32,6 +32,6 @@
     <key key0="ন" key1="৳" key2="ণ" key3=";" key4="."/>
     <key key0="স" key1="&quot;" key2="ষ" key3="!" key4=","/>
     <key key0="ম" key1="'" key2="শ" key3="\?" key4="।"/>
-    <key shift="0.1" width="1.4" key0="backspace" key2="delete"/>
+    <key shift="0.1" width="1.4" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/beng_provat.xml
+++ b/srcs/layouts/beng_provat.xml
@@ -24,7 +24,7 @@
 		<key 				key0="ল"	key1="ং"		key2="॥"		key3="halfspace"							/>
 	</row>
 	<row>
-		<key width="1.5"	key0="shift"															/>
+		<key width="1.5"	role="action" key0="shift"															/>
 		<key 				key0="য়"	key1="য"													/>
 		<key 				key0="শ"	key1="ঢ়"														/>
 		<key 				key0="চ"		key1="ছ"	key2="ৃ"			key3=","						/>
@@ -32,6 +32,6 @@
 		<key 				key0="ব"	key1="ভ"	key2="\?"		key3="্"							/>
 		<key 				key0="ন"	key1="ণ"	key2=":"		key3=";"						/>
 		<key 				key0="ম"	key1="ঙ"	key2="&quot;"	key3="'"						/>
-		<key width="1.5"	key0="backspace"		key2="delete"									/>
+		<key width="1.5"	role="action" key0="backspace"		key2="delete"									/>
 	</row>
 </keyboard>

--- a/srcs/layouts/cyrl_fcuzhen_mn.xml
+++ b/srcs/layouts/cyrl_fcuzhen_mn.xml
@@ -27,7 +27,7 @@
     <key key0="п" key2="|" key3="\\"/>
   </row>
   <row>
-    <key key0="shift" key2="loc capslock"/>
+    <key role="action" key0="shift" key2="loc capslock"/>
     <key key0="я"/>
     <key key0="ч"/>
     <key key0="ё" key1="е"/>
@@ -37,6 +37,6 @@
     <key key0="т" key1="₮" key2="\?" key3="/"/>
     <key key0="ь" key1="ъ" key2=":" key3=";"/>
     <key key0="в" key1="ю" key2="&quot;" key3="'"/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/cyrl_jcuken_as.xml
+++ b/srcs/layouts/cyrl_jcuken_as.xml
@@ -27,7 +27,7 @@
     <key key0="ѣ" key1="ԑ" key2="/" key3="\\" key4="|" />
   </row>
   <row>
-    <key width="1.18" key0="shift" key2="loc capslock" key3="loc tab" key4="loc esc"
+    <key role="action" width="1.18" key0="shift" key2="loc capslock" key3="loc tab" key4="loc esc"
  />
     <key width="0.96" key0="я" key1="ꙗ" key2="ꙝ" key4="combining_titlo" />
     <key width="0.96" key0="ч" key1="ћ" key2="ќ" key4="combining_breve" />
@@ -38,6 +38,6 @@
     <key width="0.96" key0="ь" key1="ѧ" key2="&lt;" key3="⁙" />
     <key width="0.96" key0="б" key1="ђ" key2="&gt;" key3="⁘" />
     <key width="0.96" key0="ю" key1="ꙛ" key2="·" key3="⁖"/>
-    <key width="1.18" key0="backspace" key2="delete"/>
+    <key role="action" width="1.18" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/cyrl_jcuken_kk.xml
+++ b/srcs/layouts/cyrl_jcuken_kk.xml
@@ -40,7 +40,7 @@
     <key key0="э" key2="|" key3="\\"/>
   </row>
   <row>
-    <key key0="shift" key2="loc capslock"/>
+    <key role="action" key0="shift" key2="loc capslock"/>
     <key key0="я"/>
     <key key0="ч"/>
     <key key0="с"/>
@@ -50,6 +50,6 @@
     <key key0="ь" key2="\?" key3="/"/>
     <key key0="б" key2=":" key3=";"/>
     <key key0="ю" key2="&quot;" key3="'"/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/cyrl_jcuken_ru.xml
+++ b/srcs/layouts/cyrl_jcuken_ru.xml
@@ -27,7 +27,7 @@
     <key key0="э" key2="|" key3="\\"/>
   </row>
   <row scale="11">
-    <key width="1.22" key0="shift" key2="loc capslock"/>
+    <key width="1.22" role="action" key0="shift" key2="loc capslock"/>
     <key key0="я"/>
     <key key0="ч"/>
     <key key0="с"/>
@@ -37,6 +37,6 @@
     <key key0="ь" key1="ъ" key2="\?" key3="/"/>
     <key key0="б" key2=":" key3=";"/>
     <key key0="ю" key2="&quot;" key3="'"/>
-    <key width="1.22" key0="backspace" key2="delete"/>
+    <key width="1.22" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/cyrl_jcuken_uk.xml
+++ b/srcs/layouts/cyrl_jcuken_uk.xml
@@ -27,7 +27,7 @@
     <key key0="є" key2="|" key3="\\"/>
   </row>
   <row>
-    <key width="1.1" key0="shift" key2="loc capslock"/>
+    <key width="1.1" role="action" key0="shift" key2="loc capslock"/>
     <key key0="я"/>
     <key key0="ч" />
     <key key0="с" />
@@ -37,6 +37,6 @@
     <key key0="ь" key2=":" key3=";"/>
     <key key0="б" key2="&quot;" key3="'"/>
     <key key0="ю" key1="«" key2="»"/>
-    <key width="1.1" key0="backspace" key2="delete"/>
+    <key width="1.1" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/cyrl_jiuken.xml
+++ b/srcs/layouts/cyrl_jiuken.xml
@@ -29,7 +29,7 @@
     <key key0="ж" key2=")" key3="("/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key role="action" width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="я"/>
     <key key0="ч"/>
     <key key0="ѣ"/>
@@ -40,6 +40,6 @@
     <key key0="ь"/>
     <key key0="б" key2="«"/>
     <key key0="ю" key2="»"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key role="action" width="1.5" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/cyrl_lynyertdz_mk.xml
+++ b/srcs/layouts/cyrl_lynyertdz_mk.xml
@@ -27,7 +27,7 @@
     <key key0="ќ" key2="=" key3="+"/>
   </row>
   <row scale="11">
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key role="action" width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="з"/>
     <key key0="џ"/>
     <key key0="ц"/>
@@ -37,7 +37,7 @@
     <key key0="м" key2=":" key3=";"/>
     <key key0="ѓ" key2="`" key3="'"/>
     <key key0="ж" key2="“" key3="„"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key role="action" width="1.5" key0="backspace" key2="delete"/>
   </row>
 </keyboard>
 

--- a/srcs/layouts/cyrl_lynyertz_sr.xml
+++ b/srcs/layouts/cyrl_lynyertz_sr.xml
@@ -62,7 +62,7 @@
     <key key0="ћ" ne="`" sw="|"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" nw="loc superscript" ne="loc capslock" sw="loc subscript"/>
+    <key width="1.5" role="action" key0="shift" nw="loc superscript" ne="loc capslock" sw="loc subscript"/>
     <key key0="ж" nw="loc undo" ne="loc redo" sw="&lt;" se="&gt;"/>
     <key key0="џ" ne="loc cut"/>
     <key key0="ц" ne="loc copy"/>
@@ -71,6 +71,6 @@
     <key key0="н" nw="!" ne="\?" sw="/"/>
     <key key0="м" ne=";" sw=","/>
     <key key0="ђ" ne=":" sw="."/>
-    <key width="1.5" key0="backspace" ne="delete"/>
+    <key width="1.5" role="action" key0="backspace" ne="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/cyrl_ueishsht.xml
+++ b/srcs/layouts/cyrl_ueishsht.xml
@@ -27,7 +27,7 @@
     <key key0="ч" key1="„" key2="“"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="ю"/>
     <key key0="й"/>
     <key key0="ъ" key1="loc accent_cedille" key2="&lt;" key4=">"/>
@@ -36,6 +36,6 @@
     <key key0="п" key2="&quot;" key3="'"/>
     <key key0="р" key3=","/>
     <key key0="л" key3="."/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/cyrl_yaverti.xml
+++ b/srcs/layouts/cyrl_yaverti.xml
@@ -24,7 +24,7 @@
     <key key0="л" key1="щ" key2="|" key3="\\" key4="ю"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="з"/>
     <key key0="ь" key3="ѝ"/>
     <key key0="ц" key2="&lt;" key3="."/>
@@ -32,6 +32,6 @@
     <key key0="б" key2="\?" key3="/"/>
     <key key0="н" key2=":" key3=";"/>
     <key key0="м" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/cyrl_yawerty.xml
+++ b/srcs/layouts/cyrl_yawerty.xml
@@ -28,7 +28,7 @@
     <key key0="щ" key2="/" key3="\\"/>
   </row>
   <row>
-    <key width="2" key0="shift" key2="loc capslock"/>
+    <key role="action" width="2" key0="shift" key2="loc capslock"/>
     <key key0="э"/>
     <key key0="з"/>
     <key key0="ь" key1="ъ"/>
@@ -37,6 +37,6 @@
     <key key0="б"/>
     <key key0="н" key2="«" key3=","/>
     <key key0="м" key2="»" key3="."/>
-    <key width="2" key0="backspace" key2="delete"/>
+    <key role="action" width="2" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/cyrl_yqukeng_tj.xml
+++ b/srcs/layouts/cyrl_yqukeng_tj.xml
@@ -27,7 +27,7 @@
     <key key0="э" key7="\?" key3="/" />
   </row>
   <row scale="11">
-    <key width="1.22" key0="shift" key2="loc capslock" />
+    <key width="1.22" role="action" key0="shift" key2="loc capslock" />
     <key key0="я" key7="`" key8=";" />
     <key key0="ч" key7="*" key8=":" />
     <key key0="с"  key7="&amp;" key8="\#" />
@@ -37,6 +37,6 @@
     <key key0="ӣ" key3="&lt;" key2="&gt;" />
     <key key0="б" key7="ъ" key8="ы" />
     <key key0="ю" key7="&quot;" key8="'"/>
-    <key width="1.22" key0="." key7="," />
+    <key width="1.22" role="action" key0="." key7="," />
   </row>
 </keyboard>

--- a/srcs/layouts/cyrl_yxukeng_os.xml
+++ b/srcs/layouts/cyrl_yxukeng_os.xml
@@ -27,7 +27,7 @@
     <key key0="э" key7="/" key8="|" />
   </row>
   <row scale="11">
-    <key width="1.22" key0="shift" />
+    <key width="1.22" role="action" key0="shift" />
     <key key0="ꙗ" key7="combining_breve" key8=";" />
     <key key0="ч" key7="combining_pokrytie" key8=":" />
     <key key0="с" key7="combining_inverted_breve" key8="`" />

--- a/srcs/layouts/deva_alt.xml
+++ b/srcs/layouts/deva_alt.xml
@@ -24,6 +24,6 @@
     <key c="ं" nw="ॐ" ne="।" sw="ः" se="&quot;" anticircle="१" indication="१"/>
     <key c="्" nw="," ne=";" sw="!" se="\?" anticircle="२" indication="२"/>
     <key c="़" nw="॰" sw="-" se="॒" anticircle="३" indication="३"/>
-    <key width="2" c="backspace" ne="delete"/>
+    <key width="2" role="action" c="backspace" ne="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/deva_inscript.xml
+++ b/srcs/layouts/deva_inscript.xml
@@ -24,7 +24,7 @@
     <key key0="त" key1="थ" key2="ख़" key3="(" key4=")"/>
   </row>
   <row>
-    <key width="1.4" key0="shift" key2="loc capslock"/>
+    <key width="1.4" role="action" key0="shift" key2="loc capslock"/>
     <key shift="0.1" key0="ट" key1="ठ" key2="ड़" key3="\#" key4="*"/>
     <key key0="ं" key1="ँ" key3="ॐ" key4="\@"/>
     <key key0="म" key1="ण" key2="य" key3="य़" key4="%"/>
@@ -32,6 +32,6 @@
     <key key0="व" key2="ढ़" key3=";" key4="."/>
     <key key0="ल" key1="ळ" key2="फ़" key3="!" key4=","/>
     <key key0="स" key1="श" key2="ष" key3="\?"/>
-    <key shift="0.1" width="1.4" key0="backspace" key2="delete"/>
+    <key shift="0.1" width="1.4" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/deva_phonetic_in.xml
+++ b/srcs/layouts/deva_phonetic_in.xml
@@ -29,7 +29,7 @@
     <key key0="ल" key1="ऌ" key2="।" key3 ="ॢ" key4="॥"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="ज्ञ" key2="|" key3="\\" key4="ऍ"/>
     <key key0="ष" key1="क्ष" key3 ="ॅ" key4="ॉ"/>
     <key key0="च" key2="&lt;" key3=","/>
@@ -37,6 +37,6 @@
     <key key0="ब" key2="\?" key3="/"/>
     <key key0="न" key1="ङ" key2=":" key3=";" key4="ऽ"/>
     <key key0="म" key1="ॐ" key2="&quot;" key3="'" key4="ँ"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/georgian_mes.xml
+++ b/srcs/layouts/georgian_mes.xml
@@ -28,7 +28,7 @@
     <key key0="ჩ" key1="ჭ"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key  key0="ზ" key1="ჵ"/>
     <key key0="ხ" key1="ჴ" key2="loc †"/>
     <key key0="ც" key2="&lt;" key3="."/>
@@ -38,6 +38,6 @@
     <key key0="მ" key2="&quot;" key3="'"/>
     <key key0="ძ"/>
     <key key0="ჟ"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/georgian_qwerty.xml
+++ b/srcs/layouts/georgian_qwerty.xml
@@ -24,7 +24,7 @@
     <key key0="ლ" key1="₾" key2="|" key3="\\"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key  key0="ზ" key1="ძ" key2="ჵ"/>
     <key key0="ხ" key2="ჴ" key3="loc †"/>
     <key key0="ც" key1="ჩ" key3="&lt;" key4="."/>
@@ -32,7 +32,7 @@
     <key key0="ბ" key2="\?" key3="/"/>
     <key key0="ნ" key1="ჼ" key2="`" key3=":" key4=";"/>
     <key key0="მ" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
  </row>
 </keyboard>
   

--- a/srcs/layouts/grek_qwerty.xml
+++ b/srcs/layouts/grek_qwerty.xml
@@ -25,7 +25,7 @@
     <key key0="accent_aigu" key1="accent_trema" key3="accent_grave"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="ζ"/>
     <key key0="χ"/>
     <key key0="ψ" key2="&lt;" key3="."/>
@@ -33,6 +33,6 @@
     <key key0="β" key2="\?" key3="/"/>
     <key key0="ν" key2=":"/>
     <key key0="μ" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/guj_phonetic_in.xml
+++ b/srcs/layouts/guj_phonetic_in.xml
@@ -24,7 +24,7 @@
     <key key0="લ" key1="।" key2="|" key3="\\" key4="॥"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="ઞ" key1="જ્ઞ" key2="ૅ" key3="ઙ" key4="ઍ"/>
     <key key0="ષ" key1="ક્ષ" key2="ૉ" key3="઼" key4="ઑ"/>
     <key key0="ચ" key2="&lt;" key3="."/>
@@ -32,6 +32,6 @@
     <key key0="બ" key2="\?" key3="/"/>
     <key key0="ન" key2=":" key3=";"/>
     <key key0="મ" key1="ૐ" key2="&quot;" key3="'" key4="॑" key6="ઽ"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/hang_dubeolsik_kr.xml
+++ b/srcs/layouts/hang_dubeolsik_kr.xml
@@ -24,7 +24,7 @@
     <key key0="ㅣ" key2="|" key3="\\"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="ㅋ"/>
     <key key0="ㅌ" key1="ㄾ" key3="&lt;" key4="&gt;"/>
     <key key0="ㅊ" key3="."/>
@@ -32,6 +32,6 @@
     <key key0="ㅠ" key1="ㅞ" key2="ㅝ" key3="/" key4="\?"/>
     <key key0="ㅜ" key2="ㅟ" key3=";" key4=":"/>
     <key key0="ㅡ" key2="ㅢ" key3="'" key4="&quot;"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/hebr_1_il.xml
+++ b/srcs/layouts/hebr_1_il.xml
@@ -12,7 +12,7 @@
     <key key0="ן" key2="8" key3="*"/>
     <key key0="ם" key2="9" key3="b(" key4="lrm"/>
     <key key0="פ" key2="0" key3="b)" key4="rlm"/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
   <row scale="11">
     <key key0="ש" key2="`" key1="loc tab" key3="sindot_placeholder" key4="shindot_placeholder" width="1.30"/>

--- a/srcs/layouts/hebr_2_il.xml
+++ b/srcs/layouts/hebr_2_il.xml
@@ -35,6 +35,6 @@
     <key key0="מ" key1="blt" key2=","/>
     <key key0="צ" key1="bgt" key2="."/>
     <key key0="/" key1="\?"/>
-    <key key0="backspace" key2="delete" width="1.333"/>
+    <key role="action" key0="backspace" key2="delete" width="1.333"/>
   </row>
 </keyboard>

--- a/srcs/layouts/kann_kannada.xml
+++ b/srcs/layouts/kann_kannada.xml
@@ -25,6 +25,6 @@
     <key key0="।" key1="'" key2="&quot;" key3="." key4="," key6="॥"/>
     <key key0="೦" key1=":" key2=";" key3="-" key4="_"/>
     <key key0="೫" key1="೧" key2="೩" key3="೭" key4="೯" key5="೪" key6="೬" key7="೨" key8="೮"/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latin_kbdtuf_tr.xml
+++ b/srcs/layouts/latin_kbdtuf_tr.xml
@@ -30,7 +30,7 @@
 <key key0="ş" key1="x"/>
 </row>
 <row>
-<key width="1.5" key0="shift" key2="loc capslock"/>
+<key role="action" width="1.5" key0="shift" key2="loc capslock"/>
 <key key0="j" key2="«"/>
 <key key0="ö" key2="»"/>
 <key key0="v" key2="&lt;" key3="."/>
@@ -39,6 +39,6 @@
 <key key0="z" key2=":" key3=";"/>
 <key key0="s" key2="&quot;" key3="'"/>
 <key key0="b" key2="×"/>
-<key width="1.5" key0="backspace" key2="delete"/>
+<key role="action" width="1.5" key0="backspace" key2="delete"/>
 </row>
     </keyboard>

--- a/srcs/layouts/latn_azerty_be.xml
+++ b/srcs/layouts/latn_azerty_be.xml
@@ -26,13 +26,13 @@
     <key key0="m" key1="£" key3="µ"/>
   </row>
   <row>
-    <key width="2.0" key0="shift" key2="loc capslock"/>
+    <key width="2.0" role="action" key0="shift" key2="loc capslock"/>
     <key key0="w" key1="\\" key2="`" key3="&lt;" key4="&gt;"/>
     <key key0="x" key1="loc †"/>
     <key key0="c" key2="\?" key3=","/>
     <key key0="v" key2="." key3=";"/>
     <key key0="b" key2="/" key3=":"/>
     <key key0="n" key2="+" key3="="/>
-    <key width="2.0" key0="backspace" key2="delete"/>
+    <key width="2.0" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_azerty_fr.xml
+++ b/srcs/layouts/latn_azerty_fr.xml
@@ -27,13 +27,13 @@
     <key key0="m" key3="*"/>
   </row>
   <row>
-    <key width="2.0" key0="shift" key2="loc capslock"/>
+    <key width="2.0" role="action" key0="shift" key2="loc capslock"/>
     <key key0="w" key3="&lt;" key4="&gt;"/>
     <key key0="x" key1="loc †"/>
     <key key0="c" key1="loc accent_cedille" key2="ç" key3="," key4="\?"/>
     <key key0="v" key3=";" key4="."/>
     <key key0="b" key3=":" key4="/"/>
     <key key0="n" key1="loc accent_tilde" key2="§" key4="!"/>
-    <key width="2.0" key0="backspace" key2="delete"/>
+    <key width="2.0" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_bepo_fr.xml
+++ b/srcs/layouts/latn_bepo_fr.xml
@@ -26,7 +26,7 @@
     <key key0="m" key2="&quot;"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock" key3="&lt;"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock" key3="&lt;"/>
     <key key0="y" key4="%"/>
     <key key0="x" key4="\@"/>
     <key key0="k" key4="~"/>
@@ -35,6 +35,6 @@
     <key key0="g" key3="/" key4="\\"/>
     <key key0="h"/>
     <key key0="f"/>
-    <key width="1.5" key0="backspace" key2="delete" key3=">"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete" key3=">"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_bone.xml
+++ b/srcs/layouts/latn_bone.xml
@@ -114,7 +114,7 @@
 	-->
 	<row>
 		<!--left side-->
-		<key width="1.5" key0="shift" ne="loc capslock"
+		<key width="1.5" role="action" key0="shift" ne="loc capslock"
 		              se="\#"/>
 		<key key0="f" se="$"/>
 		<key key0="v" se="|"/>
@@ -125,7 +125,7 @@
 		<key key0="y" sw="%"/>
 		<key key0="z" sw="," nw="&quot;"/>
 		<key key0="k" sw="." nw="&apos;"/>
-		<key width="1.5" key0="backspace"
+		<key width="1.5" role="action" key0="backspace"
 		              sw=";" nw="delete"/>
 	</row>
 </keyboard>

--- a/srcs/layouts/latn_colemak.xml
+++ b/srcs/layouts/latn_colemak.xml
@@ -27,7 +27,7 @@
 
   </row>
   <row>
-    <key key0="shift" key2="loc capslock" width="1.5" />
+    <key key0="shift" key2="loc capslock" width="1.5" role="action"/>
     <key key0="z"         key1=","    key2="."/>
     <key key0="x"         key1="&gt;" key2="&lt;"/>
     <key key0="c"         key1="{"    key2="}" key3="loc accent_cedille"/>
@@ -35,7 +35,6 @@
     <key key0="b"         key1="("    key2=")"/>
     <key key0="k"         key1=";"    key2=":"/>
     <key key0="m"         key1="!"    key2="\?" />
-    <key key0="backspace" key1="delete" shift="0.25" width="1.25"/>
-
+    <key key0="backspace" key1="delete" shift="0.25" width="1.25" role="action"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_dvorak.xml
+++ b/srcs/layouts/latn_dvorak.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <keyboard name="Dvorak" script="latin">
   <row>
-    <key key0="shift" width="1.5" key2="loc esc" key4="loc tab"/>
+    <key role="action" key0="shift" width="1.5" key2="loc esc" key4="loc tab"/>
     <key key0="p" key1="loc accent_ring" key2="." key3="&lt;"/>
     <key key0="y" key1="loc accent_grave" key2="," key3="&gt;"/>
     <key key0="f" key4="loc €"/>
@@ -9,7 +9,7 @@
     <key key0="c" key1="loc accent_trema" key2="loc accent_circonflexe" key3="{" key4="}"/>
     <key key0="r" key3="[" key4="]"/>
     <key key0="l" key2="=" key3="+" key4="loc £"/>
-    <key key0="backspace" key2="delete" width="1.5"/>
+    <key role="action" key0="backspace" key2="delete" width="1.5"/>
   </row>
   <row>
     <key key0="a" key2="1" key3="loc å" key4="!"/>

--- a/srcs/layouts/latn_neo2.xml
+++ b/srcs/layouts/latn_neo2.xml
@@ -29,7 +29,7 @@
     <key key0="y" key3="\@"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key1="loc esc" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key1="loc esc" key2="loc capslock"/>
     <key key0="ü" key4="\#"/>
     <key key0="ö" key4="$"/>
     <key key0="ä" key4="|"/>
@@ -38,14 +38,14 @@
     <key key0="b" key4="+"/>
     <key key0="m" key4="%"/>
     <key key0="." key1="," key3="&quot;" key4="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
   <row height="0.95">
-    <key width="1.7" key0="ctrl" key1="loc switch_greekmath" key2="loc meta" key4="switch_numeric"/>
-    <key width="1.1" key0="fn" key1="loc alt" key2="loc change_method" key3="switch_emoji" key4="config"/>
-    <key width="4.4" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right"/>
-    <key width="1.1" key0="loc compose" key7="up" key6="right" key5="left" key8="down" key1="loc home" key2="loc page_up" key3="loc end" key4="loc page_down"/>
+    <key width="1.7" role="action" key0="ctrl" key1="loc switch_greekmath" key2="loc meta" key4="switch_numeric"/>
+    <key width="1.1" role="action" key0="fn" key1="loc alt" key2="loc change_method" key3="switch_emoji" key4="config"/>
+    <key width="4.4" role="space_bar" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right"/>
+    <key width="1.1" role="action" key0="loc compose" key7="up" key6="right" key5="left" key8="down" key1="loc home" key2="loc page_up" key3="loc end" key4="loc page_down"/>
     <key key0="j" key4=";"/>
-    <key width="1.7" key0="enter" key1="loc voice_typing" key2="action"/>
+    <key width="1.7" role="action" key0="enter" key1="loc voice_typing" key2="action"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_apl.xml
+++ b/srcs/layouts/latn_qwerty_apl.xml
@@ -37,7 +37,7 @@
     <key c=";"         n="⋄"                  s=","/>
   </row>
   <row>
-    <key c="shift" e="loc capslock"/>
+    <key role="action" c="shift" e="loc capslock"/>
     <key c="z" nw="⊂"               se="⍝"/>
     <key c="x" nw="⊃"/>
     <key c="c" nw="∩" ne="⍛"                  sw="." se=":"/>
@@ -45,6 +45,6 @@
     <key c="b" nw="⊥" ne="⍎" sw="⌿" se="⍀"/>
     <key c="n" nw="⊤" ne="⍕"                  sw="/" se="\\"/>
     <key c="m" nw="≡" ne="≢" sw="∥" se="⍠"/>
-    <key width="2" c="backspace" e="delete"/>
+    <key role="action" width="2" c="backspace" e="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_az.xml
+++ b/srcs/layouts/latn_qwerty_az.xml
@@ -31,7 +31,7 @@
     <key key0="ə"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key2="&lt;" key3="." key4="ç"/>
@@ -40,6 +40,6 @@
     <key key0="n" key2=":" key3=";"/>
     <key key0="m" key2="&quot;" key3="'" key4="₼"/>
     <key key0="ş"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_bqn.xml
+++ b/srcs/layouts/latn_qwerty_bqn.xml
@@ -37,7 +37,7 @@
     <key c=";"  w="·"  n="⋄"                  s=","/>
   </row>
   <row>
-    <key c="shift" e="loc capslock"/>
+    <key role="action" c="shift" e="loc capslock"/>
     <key c="z" nw="⥊" ne="⋈"/>
     <key c="x" nw="𝕩"/>
     <key c="c" nw="↓" ne="˙"                  sw="." se=":"/>
@@ -45,6 +45,6 @@
     <key c="b"  s="⌊"  n="⌈"/>
     <key c="n" nw="≤" ne="≥"  n="≠"           sw="&lt;" se="&gt;" s="="/>
     <key c="m" nw="≡" ne="≢"                  sw="/" se="?"/>
-    <key width="2" c="backspace" e="delete"/>
+    <key role="action" width="2" c="backspace" e="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_br.xml
+++ b/srcs/layouts/latn_qwerty_br.xml
@@ -26,7 +26,7 @@
     <key key0="ç" key1="|"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c"/>
@@ -34,6 +34,6 @@
     <key key0="b"/>
     <key key0="n" key1="&lt;" key2="&gt;" key3="," key4="."/>
     <key key0="m" key1=":" key2=";" key3="/" key4="\?"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_cy.xml
+++ b/srcs/layouts/latn_qwerty_cy.xml
@@ -25,7 +25,7 @@
     <key key0="accent_circonflexe" key2="accent_trema" key3="accent_grave" />
   </row>
   <row>
-    <key key0="shift" key2="loc capslock"/>
+    <key role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key2="&lt;" key3="."/>
@@ -34,6 +34,6 @@
     <key key0="n" key2=":" key3=";"/>
     <key key0="m" key2="&quot;"/>
     <key key0="'" key2="accent_aigu"  key3="£"/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_cz.xml
+++ b/srcs/layouts/latn_qwerty_cz.xml
@@ -24,7 +24,7 @@
     <key key0="l" key1="&quot;" key2="'" key3="$" key4="!"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z" key4="ž"/>
     <key key0="x" key1="loc †" key3="\#"/>
     <key key0="c" key3="&amp;" key4="č"/>
@@ -32,6 +32,6 @@
     <key key0="b" key1="&lt;" key2="&gt;" key3="{" key4="}"/>
     <key key0="n" key1="\?" key2="." key3="," key4="ň"/>
     <key key0="m" key1=":" key2="*" key3="-" key4="_"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_da.xml
+++ b/srcs/layouts/latn_qwerty_da.xml
@@ -27,7 +27,7 @@
     <key key0="ø" key1="'" key3="&quot;"/>
   </row>
   <row>
-    <key shift="0.5" width="1.5" key0="shift" key2="loc capslock"/>
+    <key shift="0.5" width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c"/>
@@ -35,7 +35,7 @@
     <key key0="b" key2=";" key4=","/>
     <key key0="n" key2=":" key4="."/>
     <key key0="m" key2="-" key4="_"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 
 </keyboard>

--- a/srcs/layouts/latn_qwerty_es.xml
+++ b/srcs/layouts/latn_qwerty_es.xml
@@ -25,7 +25,7 @@
     <key key0="ñ" key1="·" key3="ç" />
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key1="loc †"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="."/>
@@ -33,6 +33,6 @@
     <key key0="b" key2="\?" key3="/" key4="¿"/>
     <key key0="n" key1="accent_tilde" key2=":" key3=";"/>
     <key key0="m" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_et.xml
+++ b/srcs/layouts/latn_qwerty_et.xml
@@ -27,7 +27,7 @@
     <key key0="ä"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z" key4="ž"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key2="&lt;" key3="."/>
@@ -36,6 +36,6 @@
     <key key0="n" key2=":" key3=";"/>
     <key key0="m" key2="&quot;" key3="'"/>
     <key key0="õ"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_fi.xml
+++ b/srcs/layouts/latn_qwerty_fi.xml
@@ -27,7 +27,7 @@
     <key key0="ä" key1="'" key3="&quot;"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key role="action" width="1.5" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c"/>
@@ -36,7 +36,7 @@
     <key key0="n" key2=":"/>
     <key key0="m" key2="-" key4="_"/>
     <key key0="." key1="!" key2="\?"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key role="action" width="1.5" key0="backspace" key2="delete"/>
   </row>
   <modmap>
     <fn a="s" b="š"/>

--- a/srcs/layouts/latn_qwerty_ga.xml
+++ b/srcs/layouts/latn_qwerty_ga.xml
@@ -25,7 +25,7 @@
     <key key0="accent_aigu" key2="accent_dot_above" key3="€" key4="£"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key2="&lt;" key3="."/>
@@ -33,6 +33,6 @@
     <key key0="b" key2="\?" key3="/"/>
     <key key0="n" key2=":" key3=";"/>
     <key key0="m" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_gb.xml
+++ b/srcs/layouts/latn_qwerty_gb.xml
@@ -24,7 +24,7 @@
     <key key0="l" key1="\#" key2="~" key3="'" key4="\@"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z" key2="|" key3="\\"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;"/>
@@ -32,6 +32,6 @@
     <key key0="b" key2="\?" key3="/"/>
     <key key0="n" key2=":" key3="," key4=";"/>
     <key key0="m" key3="."/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_haw.xml
+++ b/srcs/layouts/latn_qwerty_haw.xml
@@ -25,7 +25,7 @@
     <key key0="ʻ"/>
   </row>
   <row>
-    <key key0="shift" key2="loc capslock"/>
+    <key role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key2="&lt;" key3="."/>
@@ -34,6 +34,6 @@
     <key key0="n" key2=":" key3=";"/>
     <key key0="m" key2="&quot;" key3="'"/>
     <key key0="accent_macron"/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_hu.xml
+++ b/srcs/layouts/latn_qwerty_hu.xml
@@ -24,7 +24,7 @@
     <key key0="l" key1="$" key3="/"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z" key3="&lt;" key4="&gt;"/>
     <key key0="x" key1="loc †" key4="\#"/>
     <key key0="c" key4="&amp;"/>
@@ -32,6 +32,6 @@
     <key key0="b" key1="\?" key3="," key4=";"/>
     <key key0="n" key1=":" key3="."/>
     <key key0="m" key1="_" key3="-"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_is.xml
+++ b/srcs/layouts/latn_qwerty_is.xml
@@ -28,7 +28,7 @@
     <key c="ö" nw="ø"/>
   </row>
   <row>
-    <key c="shift" ne="loc capslock"/>
+    <key role="action" c="shift" ne="loc capslock"/>
     <key c="z"/>
     <key c="x" ne="loc †"/>
     <key c="c" ne="&lt;" sw="."/>
@@ -38,6 +38,6 @@
     <key c="m" ne="&quot;" sw="'"/>
     <key c="accent_aigu" ne="accent_trema" nw="accent_grave" sw="accent_circonflexe" se="accent_ring"/>
     <key c="þ"/>
-    <key c="backspace" ne="delete"/>
+    <key role="action" c="backspace" ne="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_jp.xml
+++ b/srcs/layouts/latn_qwerty_jp.xml
@@ -24,7 +24,7 @@
     <key key0="l" key2="|" key3="¥"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key2="&lt;" key3=","/>
@@ -32,6 +32,6 @@
     <key key0="b" key2="\?" key3="/"/>
     <key key0="n" key2="_" key3="\\"/>
     <key key0="m" key2="`" key3="\@"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_kk.xml
+++ b/srcs/layouts/latn_qwerty_kk.xml
@@ -38,7 +38,7 @@
     <key key0="l" key2="|" key3="\\"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key2="&lt;" key3="." key4="ç"/>
@@ -46,7 +46,7 @@
     <key key0="b" key2="\?" key3="/"/>
     <key key0="n" key2=":" key3=";"/>
     <key key0="m" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>
 

--- a/srcs/layouts/latn_qwerty_lt.xml
+++ b/srcs/layouts/latn_qwerty_lt.xml
@@ -25,7 +25,7 @@
     <key key0="ė" key4="€"/>
   </row>
   <row>
-    <key key0="shift" key2="loc capslock"/>
+    <key role="action" key0="shift" key2="loc capslock"/>
     <key key0="z" key4="ž"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key2="&lt;" key3="." key4="č"/>
@@ -34,7 +34,7 @@
     <key key0="n" key2=":" key3=";"/>
     <key key0="m" key2="&quot;" key3="'"/>
     <key key0="ų"/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>
 

--- a/srcs/layouts/latn_qwerty_lv.xml
+++ b/srcs/layouts/latn_qwerty_lv.xml
@@ -24,7 +24,7 @@
     <key key0="l" key1="ļ" key2="|" key3="/" key4="\\"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z" key1="ž"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key1="č"/>
@@ -32,6 +32,6 @@
     <key key0="b" key2="\?" key3="&lt;" key4="&gt;"/>
     <key key0="n" key1="ņ" key2="`" key3=":" key4=";"/>
     <key key0="m" key1="'" key2="&quot;" key3="," key4="."/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_mt.xml
+++ b/srcs/layouts/latn_qwerty_mt.xml
@@ -27,7 +27,7 @@
     <key c="ż"/>
   </row>
   <row>
-    <key width="1.5" c="shift" ne="loc capslock"/>
+    <key width="1.5" role="action" c="shift" ne="loc capslock"/>
     <key c="z"/>
     <key c="x" ne="loc †"/>
     <key c="c" ne="&lt;" sw="."/>
@@ -36,7 +36,7 @@
     <key c="n" ne=":" sw=";"/>
     <key c="m" ne="&quot;" sw="'"/>
     <key c="ċ"/>
-    <key width="1.5" c="backspace" ne="delete"/>
+    <key width="1.5" role="action" c="backspace" ne="delete"/>
   </row>
 </keyboard>
 

--- a/srcs/layouts/latn_qwerty_no.xml
+++ b/srcs/layouts/latn_qwerty_no.xml
@@ -24,7 +24,7 @@
     <key key0="l" key2="|" key3="\\"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="."/>
@@ -32,6 +32,6 @@
     <key key0="b" key2="\?" key3="/"/>
     <key key0="n" key1="loc accent_tilde" key2=":" key3=";"/>
     <key key0="m" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_pl.xml
+++ b/srcs/layouts/latn_qwerty_pl.xml
@@ -24,7 +24,7 @@
     <key key0="l" key2="|" key3="\\" key4="ł"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z" key4="ż"/>
     <key key0="x" key2="loc †" key4="ź"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="." key4="ć"/>
@@ -32,6 +32,6 @@
     <key key0="b" key2="\?" key3="/"/>
     <key key0="n" key1="loc accent_tilde" key2=":" key3=";" key4="ń"/>
     <key key0="m" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_ro.xml
+++ b/srcs/layouts/latn_qwerty_ro.xml
@@ -24,7 +24,7 @@
     <key key0="l" key2="|" key3="\\"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key1="loc accent_cedille" key2="&lt;" key3="."/>
@@ -32,6 +32,6 @@
     <key key0="b" key2="\?" key3="/"/>
     <key key0="n" key1="loc accent_tilde" key2=":" key3=";"/>
     <key key0="m" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_se.xml
+++ b/srcs/layouts/latn_qwerty_se.xml
@@ -27,7 +27,7 @@
     <key key0="ä" key1="'" key3="&quot;"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c"/>
@@ -36,6 +36,6 @@
     <key key0="n" key2=":"/>
     <key key0="m" key2="-" key4="_"/>
     <key key0="." key1="!" key2="\?"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_sk.xml
+++ b/srcs/layouts/latn_qwerty_sk.xml
@@ -24,7 +24,7 @@
     <key key0="l" key1="(" key2=")" key3="ĺ" key4="ľ"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z" key4="ž"/>
     <key key0="x" key1="loc †" key2="\#"/>
     <key key0="c" key4="č"/>
@@ -32,6 +32,6 @@
     <key key0="b" key1="&lt;" key2="&gt;" key3=";" key4=":"/>
     <key key0="n" key3="_" key4="ň"/>
     <key key0="m" key1="!" key2="\?" key3="," key4="."/>
-    <key width="1.5" key0="backspace" key3="delete"/>
+    <key width="1.5" role="action" key0="backspace" key3="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_sr.xml
+++ b/srcs/layouts/latn_qwerty_sr.xml
@@ -33,7 +33,7 @@
     <key key0="č" ne="`" sw="|"/>    
   </row>
   <row>
-    <key width="1.5" key0="shift" nw="loc superscript" ne="loc capslock" sw="loc subscript"/>
+    <key width="1.5" role="action" key0="shift" nw="loc superscript" ne="loc capslock" sw="loc subscript"/>
     <key key0="z" nw="loc undo" ne="ž"/>
     <key key0="x" nw="loc cut"/>
     <key key0="c" nw="loc copy" ne="ć"/>
@@ -41,6 +41,6 @@
     <key key0="b" nw="!" ne="\?" sw="/"/>
     <key key0="n" ne=";" sw=","/>
     <key key0="m" ne=":" sw="."/>    
-    <key width="1.5" key0="backspace" ne="delete"/>
+    <key width="1.5" role="action" key0="backspace" ne="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_tly.xml
+++ b/srcs/layouts/latn_qwerty_tly.xml
@@ -28,7 +28,7 @@
     <key key0="â" key3="\@"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x"/>
     <key key0="j" key2="&lt;" key3="."/>
@@ -38,6 +38,6 @@
     <key key0="m" key2="&quot;" key3="'"/>
     <key key0="c" key4="ç"/>
     <key key0="š" key4="ş"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_tr.xml
+++ b/srcs/layouts/latn_qwerty_tr.xml
@@ -28,7 +28,7 @@
     <key key0="l" key2="|" key3="\\"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key1="ç" key2="&lt;" key3="."/>
@@ -36,6 +36,6 @@
     <key key0="b" key2="\?" key3="/"/>
     <key key0="n" key2=":" key3=";"/>
     <key key0="m" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_us.xml
+++ b/srcs/layouts/latn_qwerty_us.xml
@@ -62,7 +62,7 @@ Useful links.
     <key c="l" ne="|" sw="\\"/>
   </row>
   <row>
-    <key width="1.5" c="shift" ne="loc capslock"/>
+    <key width="1.5" role="action" c="shift" ne="loc capslock"/>
     <key c="z"/>
     <key c="x" ne="loc †"/>
     <key c="c" ne="&lt;" sw="."/>
@@ -70,6 +70,6 @@ Useful links.
     <key c="b" ne="\?" sw="/"/>
     <key c="n" ne=":" sw=";"/>
     <key c="m" ne="&quot;" sw="'"/>
-    <key width="1.5" c="backspace" ne="delete"/>
+    <key width="1.5" role="action" c="backspace" ne="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwerty_uz.xml
+++ b/srcs/layouts/latn_qwerty_uz.xml
@@ -25,7 +25,7 @@
     <key key0="ʻ"/>
   </row>
   <row>
-    <key key0="shift" key2="loc capslock"/>
+    <key role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="c" key2="&lt;" key3="."/>
@@ -34,7 +34,7 @@
     <key key0="n" key2=":" key3=";"/>
     <key key0="m" key2="&quot;" key3="'"/>
     <key key0="ʼ"/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>
 

--- a/srcs/layouts/latn_qwerty_vi.xml
+++ b/srcs/layouts/latn_qwerty_vi.xml
@@ -25,7 +25,7 @@
     <key key0="l" key2="|" key3="\\"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key1="accent_tilde" key2="loc †"/>
     <key key0="c" key2="&lt;" key3="."/>
@@ -33,6 +33,6 @@
     <key key0="b" key2="\?" key3="/"/>
     <key key0="n" key2=":" key3=";"/>
     <key key0="m" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwertz.xml
+++ b/srcs/layouts/latn_qwertz.xml
@@ -25,7 +25,7 @@
     <key key0="l" key1="'" key3="\#"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="y" key1="&gt;" key2="|" key3="&lt;"/>
     <key key0="x" key1="loc †"/>
     <key key0="c"/>
@@ -33,6 +33,6 @@
     <key key0="b" key1=";" key3=","/>
     <key key0="n" key1=":" key3="."/>
     <key key0="m" key1="_" />
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwertz_cz.xml
+++ b/srcs/layouts/latn_qwertz_cz.xml
@@ -24,7 +24,7 @@
     <key key0="l" key1="&quot;" key2="'" key3="$" key4="!"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="y" key2="ý"/>
     <key key0="x" key1="loc †" key3="\#"/>
     <key key0="c" key3="&amp;" key4="č"/>
@@ -32,6 +32,6 @@
     <key key0="b" key1="&lt;" key2="&gt;" key3="{" key4="}"/>
     <key key0="n" key1="\?" key2="." key3="," key4="ň"/>
     <key key0="m" key1=":" key2="*" key3="-" key4="_"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwertz_cz_diacritics.xml
+++ b/srcs/layouts/latn_qwertz_cz_diacritics.xml
@@ -25,7 +25,7 @@
     <key key0="accent_aigu" key1="accent_trema"/>
   </row>
   <row>
-    <key key0="shift" key2="loc capslock"/>
+    <key role="action" key0="shift" key2="loc capslock"/>
     <key key0="y" key2="ý"/>
     <key key0="x" key1="loc †" key3="\#"/>
     <key key0="c" key3="&amp;" key4="č"/>
@@ -34,6 +34,6 @@
     <key key0="n" key1="\?" key2="." key3="," key4="ň"/>
     <key key0="m" key1=":" key2="*" key3="-" key4="_"/>
     <key key0="accent_caron" key1="accent_circonflexe"/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwertz_cz_multifunctional.xml
+++ b/srcs/layouts/latn_qwertz_cz_multifunctional.xml
@@ -24,7 +24,7 @@
     <key key0="l" key2="ľ" key3="\\" key4="ĺ"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="y" key1="÷" key2="ý"/>
     <key key0="x" key1="∙" key3="×" key4="loc †"/>
     <key key0="c" key1="\#" key2="γ" key3="&amp;" key4="č"/>
@@ -32,6 +32,6 @@
     <key key0="b" key1=";" key2="♭" key3=":" key4="β"/>
     <key key0="n" key1="," key3="." key4="ň"/>
     <key key0="m" key1="&quot;" key3="\'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwertz_de.xml
+++ b/srcs/layouts/latn_qwertz_de.xml
@@ -28,7 +28,7 @@
     <key key0="ä"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key shift="0.5" key0="y" key1="&gt;" key2="|" key3="&lt;"/>
     <key key0="x" key1="loc †"/>
     <key key0="c"/>
@@ -36,6 +36,6 @@
     <key key0="b" key1=";" key3=","/>
     <key key0="n" key1=":" key3="."/>
     <key key0="m" key1="_"/>
-    <key shift="0.5" width="1.5" key0="backspace" key2="delete"/>
+    <key shift="0.5" width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwertz_fr_ch.xml
+++ b/srcs/layouts/latn_qwertz_fr_ch.xml
@@ -28,7 +28,7 @@
     <key key0="à" key1="ï" key2="ä"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="y" key1="&gt;" key2="|" key3="&lt;"/>
     <key key0="x"/>
     <key key0="c" key3="ç"/>
@@ -37,6 +37,6 @@
     <key key0="n" key1=":" key3="."/>
     <key key0="m" key1="_" key3="-"/>
     <key key0="ê" key1="â" key2="î" key3="ô" key4="û"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qwertz_hu.xml
+++ b/srcs/layouts/latn_qwertz_hu.xml
@@ -24,7 +24,7 @@
     <key key0="l" key1="$" key3="/"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="y" key3="&lt;" key4="&gt;"/>
     <key key0="x" key1="loc †" key4="\#"/>
     <key key0="c" key4="&amp;"/>
@@ -32,7 +32,7 @@
     <key key0="b" key1="\?" key3="," key4=";"/>
     <key key0="n" key1=":" key3="."/>
     <key key0="m" key1="_" key3="-"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>
 

--- a/srcs/layouts/latn_qwertz_sk.xml
+++ b/srcs/layouts/latn_qwertz_sk.xml
@@ -22,10 +22,10 @@
     <key key0="j" key1="{" key2="}" key3="|" key4="+"/>
     <key key0="k" key1="[" key2="]" key3="'" key4="&quot;"/>
     <key key0="l" key1="(" key2=")" key3="ĺ" key4="ľ"/>
-    <key key0="backspace" key3="delete"/>
+    <key role="action" key0="backspace" key3="delete"/>
   </row>
   <row>
-    <key key0="shift" key2="loc capslock"/>
+    <key role="action" key0="shift" key2="loc capslock"/>
     <key key0="y" key1="$" key3="ý"/>
     <key key0="x" key1="loc †"/>
     <key key0="c" key4="č"/>

--- a/srcs/layouts/latn_qwertz_sq.xml
+++ b/srcs/layouts/latn_qwertz_sq.xml
@@ -25,7 +25,7 @@
     <key key0="ë" key1="¤"/>
   </row>
   <row>
-    <key key0="shift" key2="loc capslock"/>
+    <key role="action" key0="shift" key2="loc capslock"/>
     <key key0="y" key1="&gt;" key2="|" key3="&lt;"/>
     <key key0="x" key1="loc †"/>
     <key key0="c"/>
@@ -34,6 +34,6 @@
     <key key0="n" key1=":" key3="."/>
     <key key0="m" key1="_" />
     <key key0="ç" key1="×" key3="÷"/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_qzerty_it.xml
+++ b/srcs/layouts/latn_qzerty_it.xml
@@ -25,13 +25,13 @@
     <key c="m" ne="·" sw="*"/>
   </row>
   <row>
-    <key width="2" c="shift" ne="loc capslock"/>
+    <key role="action" width="2" c="shift" ne="loc capslock"/>
     <key c="w" sw="&lt;" se="&gt;"/>
     <key c="x"/>
     <key c="c" ne="ç" sw="," se="\?"/>
     <key c="v" sw=";" se="."/>
     <key c="b" sw=":" se="/"/>
     <key c="n" nw="loc accent_tilde" ne="|" se="!"/>
-    <key width="2" c="backspace" ne="delete"/>
+    <key role="action" width="2" c="backspace" ne="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/latn_workman_us.xml
+++ b/srcs/layouts/latn_workman_us.xml
@@ -25,7 +25,7 @@
     <key key0="i" key2="|" key3="\\"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="z"/>
     <key key0="x" key2="loc †"/>
     <key key0="m"/>
@@ -33,6 +33,6 @@
     <key key0="v" key2="&gt;" key3=","/>
     <key key0="k" key2="\?" key3="/"/>
     <key key0="l" key2="&quot;" key3="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/shaw_imperial_en.xml
+++ b/srcs/layouts/shaw_imperial_en.xml
@@ -47,6 +47,6 @@
     <key key0="𐑒" key2="\?" key3="/"/>
     <key key0="𐑢" key2=":" key3=";"/>
     <key key0="𐑛" key2="&quot;" key3="'"/>
-    <key key0="backspace" key2="delete"/>
+    <key role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/sinhala_phonetic.xml
+++ b/srcs/layouts/sinhala_phonetic.xml
@@ -28,7 +28,7 @@ Based on XKB Sinhala (phonetic) layout.
     <key nw="|" c="ල" sw="\\" ne="ළ" />
   </row>
   <row>
-    <key width="1.5" c="shift" ne="loc capslock" />
+    <key role="action" width="1.5" c="shift" ne="loc capslock" />
     <key c="ඤ" ne="ඥ" />
     <key nw="loc †" c="ඳ" ne="ඬ" />
     <key nw="&lt;" c="ච" sw="." ne="ඡ" />
@@ -36,7 +36,7 @@ Based on XKB Sinhala (phonetic) layout.
     <key nw="\?" c="බ" sw="/" ne="භ" />
     <key nw=":" c="න" sw=";" ne="ණ" />
     <key nw="&quot;" c="ම" sw="'" se="zwj" ne="ඹ" />
-    <key width="1.5" c="backspace" ne="delete" />
+    <key role="action" width="1.5" c="backspace" ne="delete" />
   </row>
   <modmap>
     <shift a="ඍ" b="&#x0DD8;" />

--- a/srcs/layouts/tamil_default.xml
+++ b/srcs/layouts/tamil_default.xml
@@ -25,7 +25,7 @@
     <key key0="இ" key3="ஈ"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="ண"/>
     <key key0="ஒ" key3="ஓ"/>
     <key key0="உ" key2="&lt;" key3="ஊ" key4="."/>
@@ -33,7 +33,7 @@
     <key width="1.05" key0="ெ" key2="\?" key3="ே" key4="/"/>
     <key width="1.3" key0="ஔ" key2=":" key3="ௌ" key4=";"/>
     <key key0="அ" key2="&quot;" key3="ஆ" key4="'"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 
   <modmap>

--- a/srcs/layouts/urdu_phonetic_ur.xml
+++ b/srcs/layouts/urdu_phonetic_ur.xml
@@ -24,7 +24,7 @@
     <key width="1.15" key0="ل" key1="َ" key3="." key5="ْ" key7="ُ" key8="ِ"/>
   </row>
   <row>
-    <key width="1.5" key0="shift" key2="loc capslock"/>
+    <key width="1.5" role="action" key0="shift" key2="loc capslock"/>
     <key key0="ز" key2="ذ"/>
     <key key0="ش" key2="ژ"/>
     <key key0="چ" key2="ث" key3="۔" key4="چھ"/>
@@ -32,6 +32,6 @@
     <key key0="ب" key2="بھ" key3="/" key4="\\"/>
     <key key0="ن" key2="ں" key3=";" key4=":"/>
     <key key0="م" key5="ّ" key6="ً" key7="ٌ" key8="ٍ"/>
-    <key width="1.5" key0="backspace" key2="delete"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
   </row>
 </keyboard>


### PR DESCRIPTION
This changes the colors of the bottom row keys and of the shift and delete keys. The intention is to make the keyboard feel less complicated. I hope this can make the keyboard more readable by making some keys easier to ignore.

Feedback welcome.

Here's how it looks:
![shot](https://github.com/user-attachments/assets/a04a4a9d-0974-4d09-bfab-96aed2fb2850)
