### PR TITLE
doc: Massage section on "Escape codes"

### DIFF
--- a/doc/Possible-key-values.md
+++ b/doc/Possible-key-values.md
@@ -25,8 +25,8 @@ Key values can be any of the following:
   + `⏯:keyevent:85` A play/pause key (which has no effect in most apps).
   + `my@:'my.email@domain.com'` A key that sends an arbitrary string
 
-- A macro, `symbol:key_def1,key_def2,...`.
-  This results in a key that behaves as if the sequence of `key_def` had been pressed in order.
+- A macro, `legend:key_def1,key_def2,...`.
+  This results in a key with legend `legend` that behaves as if the sequence of `key_def` had been pressed in order.
 
   Examples:
   + `CA:ctrl,a,ctrl,c` A key with legend CA that sends the sequence `ctrl+a`, `ctrl+c`.
@@ -34,25 +34,19 @@ Key values can be any of the following:
 
 ### Escape codes
 
-When defining a key value, several characters have special effects. If you want a character not to have its usual effect but to be taken literally, you should "escape" it by typing it in a special way:
+When defining a key value, several characters have special effects. If you want a character not to have its usual effect but to be taken literally, you should "escape" it in the usual way for XML:
 
 To get this character... | ...you can type
 :---- | :------
-`?` | `\?`
-`#` | `\#`
-`@` | `\@`
 A literal newline character, which is different from `enter` and `action` in certain apps. | `\n`
 A literal tab character, which is different from `tab` in certain apps. | `\t`
 `\` | `\\`
-
-Certain other characters have special effects in the XML language. To have these characters taken literally, you can escape them in the usual way for XML:
-
-To get this character... | ...you can type
-:------- | :------
 `&` | `&amp;`
 `<` | `&lt;`
 `>` | `&gt;`
 `"` | `&quot;`
+
+The characters `?`, `#`, and `@` do not need to be escaped when writing custom layouts. Internally, they can be escaped by prepending backslash (by typing `\?`, `\#`, and `\@`).
 
 For simplicity, there is no escape for `,` or `:`.
 

--- a/doc/Possible-key-values.md
+++ b/doc/Possible-key-values.md
@@ -48,7 +48,7 @@ A literal tab character, which is different from `tab` in certain apps. | `\t`
 
 The characters `?`, `#`, and `@` do not need to be escaped when writing custom layouts. Internally, they can be escaped by prepending backslash (by typing `\?`, `\#`, and `\@`).
 
-For simplicity, there is no escape for `,` or `:`.
+The characters `,` and `:` can be escaped in a key value, using single quotes. For example, this macro defines a key with legend `http` that sends a string containing `:`: `<key c="http:home,'https://'" />` For simplicity, `,` and `:` cannot be escaped in the key legend.
 
 ## Modifiers
 System modifiers are sent to the app, which can take app-specific action.

--- a/doc/Possible-key-values.md
+++ b/doc/Possible-key-values.md
@@ -32,7 +32,10 @@ Key values can be any of the following:
   + `CA:ctrl,a,ctrl,c` A key with legend CA that sends the sequence `ctrl+a`, `ctrl+c`.
   + `Cd:ctrl,backspace` A key with legend Cd that sends the shortcut `ctrl+backspace`.
 
-## Escape codes
+### Escape codes
+
+When defining a key value, several characters have special effects. If you want a character not to have its usual effect but to be taken literally, you should "escape" it by typing it in a special way:
+
 Value | Escape code for
 :---- | :------
 `\?`  | `?`
@@ -42,7 +45,7 @@ Value | Escape code for
 `\t`  | Literal tab character. This is different from `tab` in certain apps.
 `\\`  | `\`
 
-XML escape codes also work, including:
+Certain other characters have special effects in the XML language. To have these characters taken literally, you can escape them in the usual way for XML:
 
 Value    | Escape code for
 :------- | :------
@@ -50,6 +53,8 @@ Value    | Escape code for
 `&lt;`   | `<`
 `&gt;`   | `>`
 `&quot;` | `"`
+
+For simplicity, there is no escape for `,` or `:`.
 
 ## Modifiers
 System modifiers are sent to the app, which can take app-specific action.

--- a/doc/Possible-key-values.md
+++ b/doc/Possible-key-values.md
@@ -36,23 +36,23 @@ Key values can be any of the following:
 
 When defining a key value, several characters have special effects. If you want a character not to have its usual effect but to be taken literally, you should "escape" it by typing it in a special way:
 
-Value | Escape code for
+To get this character... | ...you can type
 :---- | :------
-`\?`  | `?`
-`\#`  | `#`
-`\@`  | `@`
-`\n`  | Literal newline character. This is different from `enter` and `action` in certain apps.
-`\t`  | Literal tab character. This is different from `tab` in certain apps.
-`\\`  | `\`
+`?` | `\?`
+`#` | `\#`
+`@` | `\@`
+A literal newline character, which is different from `enter` and `action` in certain apps. | `\n`
+A literal tab character, which is different from `tab` in certain apps. | `\t`
+`\` | `\\`
 
 Certain other characters have special effects in the XML language. To have these characters taken literally, you can escape them in the usual way for XML:
 
-Value    | Escape code for
+To get this character... | ...you can type
 :------- | :------
-`&amp;`  | `&`
-`&lt;`   | `<`
-`&gt;`   | `>`
-`&quot;` | `"`
+`&` | `&amp;`
+`<` | `&lt;`
+`>` | `&gt;`
+`"` | `&quot;`
 
 For simplicity, there is no escape for `,` or `:`.
 


### PR DESCRIPTION
Other queries:

- In your example of a key that sends an email address, `@` isn't quoted at all. If items in the first table aren't mandatory, the doc should say so, or remove the items altogether.
- Possible helpful sentence: "If you revise a custom layout but Unexpected Keyboard gives a pop-up reporting a syntax error, look for characters you added that could be escaped."