### PR TITLE
Add a delay after a Keyevent key in a macro 

### DIFF
--- a/srcs/juloo.keyboard2/Autocapitalisation.java
+++ b/srcs/juloo.keyboard2/Autocapitalisation.java
@@ -1,7 +1,6 @@
 package juloo.keyboard2;
 
 import android.os.Handler;
-import android.os.Looper;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.view.inputmethod.EditorInfo;
@@ -27,9 +26,9 @@ public final class Autocapitalisation
     InputType.TYPE_TEXT_FLAG_CAP_SENTENCES |
     InputType.TYPE_TEXT_FLAG_CAP_WORDS;
 
-  public Autocapitalisation(Looper looper, Callback cb)
+  public Autocapitalisation(Handler h, Callback cb)
   {
-    _handler = new Handler(looper);
+    _handler = h;
     _callback = cb;
   }
 

--- a/srcs/juloo.keyboard2/KeyEventHandler.java
+++ b/srcs/juloo.keyboard2/KeyEventHandler.java
@@ -2,6 +2,7 @@ package juloo.keyboard2;
 
 import android.annotation.SuppressLint;
 import android.os.Looper;
+import android.os.Handler;
 import android.text.InputType;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
@@ -28,10 +29,10 @@ public final class KeyEventHandler
       [setSelection] could be used instead. */
   boolean _move_cursor_force_fallback = false;
 
-  public KeyEventHandler(Looper looper, IReceiver recv)
+  public KeyEventHandler(IReceiver recv)
   {
     _recv = recv;
-    _autocap = new Autocapitalisation(looper,
+    _autocap = new Autocapitalisation(recv.getHandler(),
         this.new Autocapitalisation_callback());
     _mods = Pointers.Modifiers.EMPTY;
   }
@@ -364,6 +365,7 @@ public final class KeyEventHandler
     public void set_shift_state(boolean state, boolean lock);
     public void set_compose_pending(boolean pending);
     public InputConnection getCurrentInputConnection();
+    public Handler getHandler();
   }
 
   class Autocapitalisation_callback implements Autocapitalisation.Callback

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.inputmethodservice.InputMethodService;
 import android.os.Build.VERSION;
+import android.os.Handler;
 import android.os.IBinder;
 import android.text.InputType;
 import android.util.Log;
@@ -38,6 +39,7 @@ public class Keyboard2 extends InputMethodService
   private ViewGroup _emojiPane = null;
   private ViewGroup _clipboard_pane = null;
   public int actionId; // Action performed by the Action key.
+  private Handler _handler;
 
   private Config _config;
 
@@ -107,7 +109,8 @@ public class Keyboard2 extends InputMethodService
   {
     super.onCreate();
     SharedPreferences prefs = DirectBootAwarePreferences.get_shared_preferences(this);
-    _keyeventhandler = new KeyEventHandler(getMainLooper(), this.new Receiver());
+    _handler = new Handler(getMainLooper());
+    _keyeventhandler = new KeyEventHandler(this.new Receiver());
     Config.initGlobalConfig(prefs, getResources(), _keyeventhandler);
     prefs.registerOnSharedPreferenceChangeListener(this);
     _config = Config.globalConfig();
@@ -480,6 +483,11 @@ public class Keyboard2 extends InputMethodService
     public InputConnection getCurrentInputConnection()
     {
       return Keyboard2.this.getCurrentInputConnection();
+    }
+
+    public Handler getHandler()
+    {
+      return _handler;
     }
   }
 


### PR DESCRIPTION
Fix https://github.com/Julow/Unexpected-Keyboard/issues/915

Add a delay before sending the next key to avoid race conditions causing
keys to be handled in the wrong order. Notably, KeyEvent keys handling
is scheduled differently than the other edit functions.
