### PR TITLE
Swapping the default placement of ! and | on the Colemak layout.

### DIFF
--- a/srcs/layouts/latn_colemak.xml
+++ b/srcs/layouts/latn_colemak.xml
@@ -6,7 +6,7 @@
     <key key0="w" key1="loc accent_grave"       key2=" ́"              key3="~"            />
     <key key0="f" key1="`"                  key2="-"              key3="+" />
     <key key0="p"                           key2="="              key3="%"/>
-    <key key0="g" key1="!"                  key2="/"              key3="\\"/>
+    <key key0="g" key1="|"                  key2="/"              key3="\\"/>
     <key key0="j" key1="loc accent_caron"       key2="loc accent_trema"            />
     <key key0="l"/>
     <key key0="u" key1="loc accent_double_aigu" key2="loc accent_ring"    />
@@ -34,7 +34,7 @@
     <key key0="v"         key1="["    key2="]"/>
     <key key0="b"         key1="("    key2=")"/>
     <key key0="k"         key1=";"    key2=":"/>
-    <key key0="m"         key1="|"    key2="\?" />
+    <key key0="m"         key1="!"    key2="\?" />
     <key key0="backspace" key1="delete" shift="0.25" width="1.25"/>
 
   </row>


### PR DESCRIPTION
I swapped the placement of ! and | on the Colemak layout to make it more reasonable. It makes more sense to group | with the slashes since it's usually grouped with \ on a physical keyboard, and it makes more sense to have ! next to ? as they are both punctuation marks. 