### PR TITLE
Add macron dead key to QWERTY (Japanese)

### DIFF
--- a/srcs/layouts/latn_qwerty_jp.xml
+++ b/srcs/layouts/latn_qwerty_jp.xml
@@ -9,7 +9,7 @@
     <key key0="y" key2="6" key3="&amp;"/>
     <key key0="u" key2="7" key3="'"/>
     <key key0="i" key2="8" key3="(" key4=")"/>
-    <key key0="o" key1="=" key2="9" key3="-"/>
+    <key key0="o" key1="=" key2="9" key3="-" key4="accent-macron"/>
     <key key0="p" key1="~" key2="0" key3="^"/>
   </row>
   <row>


### PR DESCRIPTION
Even though a Latin-script keyboard is borderline useless for Japanese, which uses kanji, hiragana, and katakana, I’ve added a dead key for the macron, used in rōmaji transcription for long vowels.