### PR TITLE
Remove symbols from the number row by default

### DIFF
--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -18,6 +18,9 @@
     <string name="pref_layouts_item">Rozložení %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">Odebrat rozložení</string>
     <string name="pref_custom_layout_title">Vlastní rozložení</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">Zobrazit NumPad</string>
     <string name="pref_show_numpad_never">Nikdy</string>
     <string name="pref_show_numpad_landscape">Pouze v režimu na šířku</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -18,6 +18,9 @@
     <string name="pref_layouts_item">Layout %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">Layout entfernen</string>
     <string name="pref_custom_layout_title">Eigenes Layout</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">Ziffernblock anzeigen</string>
     <string name="pref_show_numpad_never">Nie</string>
     <string name="pref_show_numpad_landscape">Nur im Querformat</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -18,6 +18,9 @@
     <string name="pref_layouts_item">Diseño %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">Quitar diseño</string>
     <string name="pref_custom_layout_title">Diseño personalizado</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">Mostrar teclado numérico</string>
     <string name="pref_show_numpad_never">Nunca</string>
     <string name="pref_show_numpad_landscape">Solo en modo horizontal</string>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -18,6 +18,9 @@
     <!-- <string name="pref_layouts_item">Layout %1$d: %2$s</string> -->
     <!-- <string name="pref_layouts_remove_custom">Remove layout</string> -->
     <string name="pref_custom_layout_title">طرح شخصی</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">نمایش پد شماره‌ها</string>
     <string name="pref_show_numpad_never">هرگز</string>
     <string name="pref_show_numpad_landscape">فقط در حالت افقی</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -18,6 +18,9 @@
     <string name="pref_layouts_item">Disposition %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">Supprimer</string>
     <string name="pref_custom_layout_title">Disposition personnalisée</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">Afficher le pavé numérique</string>
     <string name="pref_show_numpad_never">Jamais</string>
     <string name="pref_show_numpad_landscape">Seulement en mode paysage</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -18,6 +18,9 @@
     <!-- <string name="pref_layouts_item">Layout %1$d: %2$s</string> -->
     <!-- <string name="pref_layouts_remove_custom">Remove layout</string> -->
     <!-- <string name="pref_custom_layout_title">Custom layout</string> -->
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <!-- <string name="pref_show_numpad_title">Show NumPad</string> -->
     <!-- <string name="pref_show_numpad_never">Never</string> -->
     <!-- <string name="pref_show_numpad_landscape">Only in landscape mode</string> -->

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -18,6 +18,9 @@
     <string name="pref_layouts_item">レイアウト %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">レイアウトを削除</string>
     <string name="pref_custom_layout_title">カスタムレイアウト</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">テンキーを表示</string>
     <string name="pref_show_numpad_never">表示しない</string>
     <string name="pref_show_numpad_landscape">横向きの時は表示</string>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -18,6 +18,9 @@
     <string name="pref_layouts_item">레이아웃 %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">레이아웃 제거</string>
     <string name="pref_custom_layout_title">사용자 정의 레이아웃</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">NumPad 표시</string>
     <string name="pref_show_numpad_never">안 함</string>
     <string name="pref_show_numpad_landscape">가로 모드에서만</string>

--- a/res/values-lv/strings.xml
+++ b/res/values-lv/strings.xml
@@ -18,6 +18,9 @@
     <string name="pref_layouts_item">Izkārtojums %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">Noņemt izkārtojumu</string>
     <string name="pref_custom_layout_title">Pielāgots izkārtojums</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">Rādīt ciparnīcu</string>
     <string name="pref_show_numpad_never">Nekad</string>
     <string name="pref_show_numpad_landscape">Tikai guleniskajā skatā</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -18,6 +18,9 @@
     <string name="pref_layouts_item">Układ %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">Usuń układ</string>
     <string name="pref_custom_layout_title">Własny układ</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">Pokaż klawiaturę numeryczną</string>
     <string name="pref_show_numpad_never">Nigdy</string>
     <string name="pref_show_numpad_landscape">Tylko w orientacji poziomej</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -18,6 +18,9 @@
     <string name="pref_layouts_item">Layout %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">Remover layout</string>
     <string name="pref_custom_layout_title">Layout personalizado</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">Mostrar Teclado Numérico</string>
     <string name="pref_show_numpad_never">Nunca</string>
     <string name="pref_show_numpad_landscape">Somente no modo paisagem</string>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -18,6 +18,9 @@
     <!-- <string name="pref_layouts_item">Layout %1$d: %2$s</string> -->
     <!-- <string name="pref_layouts_remove_custom">Remove layout</string> -->
     <string name="pref_custom_layout_title">Aranjament personalizat</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">Arată NumPad</string>
     <string name="pref_show_numpad_never">Niciodată</string>
     <string name="pref_show_numpad_landscape">Doar în mod panoramă</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -18,6 +18,9 @@
     <string name="pref_layouts_item">Раскладка %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">Удалить раскладку</string>
     <string name="pref_custom_layout_title">Пользовательская раскладка</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">Показывать цифровой блок</string>
     <string name="pref_show_numpad_never">Никогда</string>
     <string name="pref_show_numpad_landscape">Только в ландшафтном режиме</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -18,6 +18,9 @@
     <string name="pref_layouts_item">Tuş düzeni %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">Tuş düzenini kaldır</string>
     <string name="pref_custom_layout_title">Özel tuş düzeni</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">NumPadi göster</string>
     <string name="pref_show_numpad_never">Asla</string>
     <string name="pref_show_numpad_landscape">Sadece manzara modunda</string>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -18,6 +18,9 @@
     <string name="pref_layouts_item">Макет %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">Видалити макет</string>
     <string name="pref_custom_layout_title">Власний макет</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">Показувати числову клавіатуру</string>
     <string name="pref_show_numpad_never">Ніколи</string>
     <string name="pref_show_numpad_landscape">Тільки в альбомному режимі</string>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -18,6 +18,9 @@
     <!-- <string name="pref_layouts_item">Layout %1$d: %2$s</string> -->
     <!-- <string name="pref_layouts_remove_custom">Remove layout</string> -->
     <string name="pref_custom_layout_title">Tùy chỉnh bố cục</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">Hiện NumPad</string>
     <string name="pref_show_numpad_never">Không bao giờ</string>
     <string name="pref_show_numpad_landscape">Chỉ trong chế độ phong cảnh</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -18,6 +18,9 @@
     <string name="pref_layouts_item">布局 %1$d：%2$s</string>
     <string name="pref_layouts_remove_custom">移除布局</string>
     <string name="pref_custom_layout_title">自定义布局</string>
+    <!-- <string name="pref_show_number_row_no_number_row">No number row</string> -->
+    <!-- <string name="pref_show_number_row_no_symbols">Number row without symbols</string> -->
+    <!-- <string name="pref_show_number_row_symbols">Number row with symbols</string> -->
     <string name="pref_show_numpad_title">显示数字小键盘</string>
     <string name="pref_show_numpad_never">从不</string>
     <string name="pref_show_numpad_landscape">只在横屏显示</string>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -3,10 +3,12 @@
   <string-array name="pref_show_number_row_values">
     <item>symbols</item>
     <item>no_symbols</item>
+    <item>no_number_row</item>
   </string-array>
   <string-array name="pref_show_number_row_entries">
     <item>@string/pref_show_number_row_symbols</item>
     <item>@string/pref_show_number_row_no_symbols</item>
+    <item>@string/pref_show_number_row_no_number_row</item>
   </string-array>
   <string-array name="pref_show_numpad_values">
     <item>never</item>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -2,13 +2,13 @@
 <resources>
   <string-array name="pref_show_number_row_values">
     <item>no_number_row</item>
-    <item>symbols</item>
     <item>no_symbols</item>
+    <item>symbols</item>
   </string-array>
   <string-array name="pref_show_number_row_entries">
     <item>@string/pref_show_number_row_no_number_row</item>
-    <item>@string/pref_show_number_row_symbols</item>
     <item>@string/pref_show_number_row_no_symbols</item>
+    <item>@string/pref_show_number_row_symbols</item>
   </string-array>
   <string-array name="pref_show_numpad_values">
     <item>never</item>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string-array name="pref_show_number_row_values">
+    <item>no_number_row</item>
     <item>symbols</item>
     <item>no_symbols</item>
-    <item>no_number_row</item>
   </string-array>
   <string-array name="pref_show_number_row_entries">
+    <item>@string/pref_show_number_row_no_number_row</item>
     <item>@string/pref_show_number_row_symbols</item>
     <item>@string/pref_show_number_row_no_symbols</item>
-    <item>@string/pref_show_number_row_no_number_row</item>
   </string-array>
   <string-array name="pref_show_numpad_values">
     <item>never</item>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <string-array name="pref_show_number_row_values">
+    <item>symbols</item>
+    <item>no_symbols</item>
+  </string-array>
+  <string-array name="pref_show_number_row_entries">
+    <item>@string/pref_show_number_row_symbols</item>
+    <item>@string/pref_show_number_row_no_symbols</item>
+  </string-array>
   <string-array name="pref_show_numpad_values">
     <item>never</item>
     <item>landscape</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -18,9 +18,9 @@
     <string name="pref_layouts_item">Layout %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">Remove layout</string>
     <string name="pref_custom_layout_title">Custom layout</string>
+    <string name="pref_show_number_row_no_number_row">Don't show Number row</string>
     <string name="pref_show_number_row_symbols">Show Number row with symbols</string>
     <string name="pref_show_number_row_no_symbols">Show Number row without symbols</string>
-    <string name="pref_show_number_row_no_number_row">Don't show Number row</string>
     <string name="pref_show_numpad_title">Show NumPad</string>
     <string name="pref_show_numpad_never">Never</string>
     <string name="pref_show_numpad_landscape">Only in landscape mode</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="pref_custom_layout_title">Custom layout</string>
     <string name="pref_show_number_row_symbols">Show Number row with symbols</string>
     <string name="pref_show_number_row_no_symbols">Show Number row without symbols</string>
+    <string name="pref_show_number_row_no_number_row">Don't show Number row</string>
     <string name="pref_show_numpad_title">Show NumPad</string>
     <string name="pref_show_numpad_never">Never</string>
     <string name="pref_show_numpad_landscape">Only in landscape mode</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -18,6 +18,8 @@
     <string name="pref_layouts_item">Layout %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">Remove layout</string>
     <string name="pref_custom_layout_title">Custom layout</string>
+    <string name="pref_show_number_row_symbols">Show Number row with symbols</string>
+    <string name="pref_show_number_row_no_symbols">Show Number row without symbols</string>
     <string name="pref_show_numpad_title">Show NumPad</string>
     <string name="pref_show_numpad_never">Never</string>
     <string name="pref_show_numpad_landscape">Only in landscape mode</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -18,9 +18,9 @@
     <string name="pref_layouts_item">Layout %1$d: %2$s</string>
     <string name="pref_layouts_remove_custom">Remove layout</string>
     <string name="pref_custom_layout_title">Custom layout</string>
-    <string name="pref_show_number_row_no_number_row">Don't show Number row</string>
-    <string name="pref_show_number_row_symbols">Show Number row with symbols</string>
-    <string name="pref_show_number_row_no_symbols">Show Number row without symbols</string>
+    <string name="pref_show_number_row_no_number_row">No number row</string>
+    <string name="pref_show_number_row_no_symbols">Number row without symbols</string>
+    <string name="pref_show_number_row_symbols">Number row with symbols</string>
     <string name="pref_show_numpad_title">Show NumPad</string>
     <string name="pref_show_numpad_never">Never</string>
     <string name="pref_show_numpad_landscape">Only in landscape mode</string>

--- a/res/xml/number_row.xml
+++ b/res/xml/number_row.xml
@@ -1,3 +1,5 @@
+<!-- See [number_row_no_symbols.xml] for the number row with no symbols. -->
+
 <?xml version="1.0" encoding="utf-8"?>
 <row height="0.75">
     <key key0="1" se="!"/>
@@ -11,3 +13,6 @@
     <key key0="9" sw="("/>
     <key key0="0" sw=")"/>
 </row>
+
+
+

--- a/res/xml/number_row.xml
+++ b/res/xml/number_row.xml
@@ -1,18 +1,14 @@
-<!-- See [number_row_no_symbols.xml] for the number row with no symbols. -->
-
 <?xml version="1.0" encoding="utf-8"?>
+<!-- See [number_row_no_symbols.xml] for the number row with no symbols. -->
 <row height="0.75">
-    <key key0="1" se="!"/>
-    <key key0="2" se="@"/>
-    <key key0="3" se="#"/>
-    <key key0="4" se="$"/>
-    <key key0="5" se="%"/>
-    <key key0="6" sw="^"/>
-    <key key0="7" sw="&amp;"/>
-    <key key0="8" sw="*"/>
-    <key key0="9" sw="("/>
-    <key key0="0" sw=")"/>
+  <key key0="1" se="!"/>
+  <key key0="2" se="@"/>
+  <key key0="3" se="#"/>
+  <key key0="4" se="$"/>
+  <key key0="5" se="%"/>
+  <key key0="6" sw="^"/>
+  <key key0="7" sw="&amp;"/>
+  <key key0="8" sw="*"/>
+  <key key0="9" sw="("/>
+  <key key0="0" sw=")"/>
 </row>
-
-
-

--- a/res/xml/number_row_no_symbols.xml
+++ b/res/xml/number_row_no_symbols.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <row height="0.75">
-    <key key0="1"/>
-    <key key0="2"/>
-    <key key0="3"/>
-    <key key0="4"/>
-    <key key0="5"/>
-    <key key0="6"/>
-    <key key0="7"/>
-    <key key0="8"/>
-    <key key0="9"/>
-    <key key0="0"/>
+  <key key0="1"/>
+  <key key0="2"/>
+  <key key0="3"/>
+  <key key0="4"/>
+  <key key0="5"/>
+  <key key0="6"/>
+  <key key0="7"/>
+  <key key0="8"/>
+  <key key0="9"/>
+  <key key0="0"/>
 </row>

--- a/res/xml/number_row_no_symbols.xml
+++ b/res/xml/number_row_no_symbols.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<row height="0.75">
+    <key key0="1"/>
+    <key key0="2"/>
+    <key key0="3"/>
+    <key key0="4"/>
+    <key key0="5"/>
+    <key key0="6"/>
+    <key key0="7"/>
+    <key key0="8"/>
+    <key key0="9"/>
+    <key key0="0"/>
+</row>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -8,7 +8,7 @@
       </PreferenceCategory>
       <juloo.keyboard2.prefs.ExtraKeysPreference android:title="@string/pref_extra_keys_internal"/>
     </PreferenceScreen>
-    <ListPreference android:key="number_row" android:title="@string/pref_number_row_title" android:summary="%s" android:defaultValue="no_symbols" android:entries="@array/pref_show_number_row_entries" android:entryValues="@array/pref_show_number_row_values"/>
+    <ListPreference android:key="number_row" android:title="@string/pref_number_row_title" android:summary="%s" android:defaultValue="no_number_row" android:entries="@array/pref_show_number_row_entries" android:entryValues="@array/pref_show_number_row_values"/>
     <ListPreference android:key="show_numpad" android:title="@string/pref_show_numpad_title" android:summary="%s" android:defaultValue="1" android:entries="@array/pref_show_numpad_entries" android:entryValues="@array/pref_show_numpad_values"/>
     <ListPreference android:key="numpad_layout" android:title="@string/pref_numpad_layout" android:summary="%s" android:defaultValue="high_first" android:entries="@array/pref_numpad_layout_entries" android:entryValues="@array/pref_numpad_layout_values"/>
   </PreferenceCategory>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -8,7 +8,7 @@
       </PreferenceCategory>
       <juloo.keyboard2.prefs.ExtraKeysPreference android:title="@string/pref_extra_keys_internal"/>
     </PreferenceScreen>
-    <CheckBoxPreference android:key="number_row" android:title="@string/pref_number_row_title" android:summary="@string/pref_number_row_summary" android:defaultValue="false"/>
+    <ListPreference android:key="number_row" android:title="@string/pref_number_row_title" android:summary="%s" android:defaultValue="no_symbols" android:entries="@array/pref_show_number_row_entries" android:entryValues="@array/pref_show_number_row_values"/>
     <ListPreference android:key="show_numpad" android:title="@string/pref_show_numpad_title" android:summary="%s" android:defaultValue="1" android:entries="@array/pref_show_numpad_entries" android:entryValues="@array/pref_show_numpad_values"/>
     <ListPreference android:key="numpad_layout" android:title="@string/pref_numpad_layout" android:summary="%s" android:defaultValue="high_first" android:entries="@array/pref_numpad_layout_entries" android:entryValues="@array/pref_numpad_layout_values"/>
   </PreferenceCategory>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -122,7 +122,7 @@ public final class Config
     }
     layouts = LayoutsPreference.load_from_preferences(res, _prefs);
     inverse_numpad = _prefs.getString("numpad_layout", "default").equals("low_first");
-    add_number_row = _prefs.getBoolean("number_row", false);
+    add_number_row = _prefs.getString("number_row", "default").equals("symbols");
     // The baseline for the swipe distance correspond to approximately the
     // width of a key in portrait mode, as most layouts have 10 columns.
     // Multipled by the DPI ratio because most swipes are made in the diagonals.

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -272,7 +272,7 @@ public final class Config
 
   /** Config migrations. */
 
-  private static int CONFIG_VERSION = 1;
+  private static int CONFIG_VERSION = 2;
 
   public static void migrate(SharedPreferences prefs)
   {

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -30,6 +30,7 @@ public final class Config
   // From the 'numpad_layout' option, also apply to the numeric pane.
   public boolean inverse_numpad = false;
   public boolean add_number_row;
+  public boolean number_row_symbols;
   public float swipe_dist_px;
   public float slide_step_px;
   // Let the system handle vibration when false.
@@ -122,7 +123,9 @@ public final class Config
     }
     layouts = LayoutsPreference.load_from_preferences(res, _prefs);
     inverse_numpad = _prefs.getString("numpad_layout", "default").equals("low_first");
-    add_number_row = _prefs.getString("number_row", "default").equals("no_number_row");
+    String number_row = _prefs.getString("number_row", "no_number_row");
+    add_number_row = !number_row.equals("no_number_row");
+    number_row_symbols = number_row.equals("symbols");
     // The baseline for the swipe distance correspond to approximately the
     // width of a key in portrait mode, as most layouts have 10 columns.
     // Multipled by the DPI ratio because most swipes are made in the diagonals.
@@ -284,7 +287,7 @@ public final class Config
     e.putInt("version", CONFIG_VERSION);
     // Migrations might run on an empty [prefs] for new installs, in this case
     // they set the default values of complex options.
-    switch (saved_version) // Fallback switch
+    switch (saved_version)
     {
       case 0:
         // Primary, secondary and custom layout options are merged into the new
@@ -298,7 +301,12 @@ public final class Config
         if (custom_layout != null && !custom_layout.equals(""))
           l.add(LayoutsPreference.CustomLayout.parse(custom_layout));
         LayoutsPreference.save_to_preferences(e, l);
+        // Fallthrough
       case 1:
+        boolean add_number_row = prefs.getBoolean("number_row", false);
+        e.putString("number_row", add_number_row ? "no_symbols" : "no_number_row");
+        // Fallthrough
+      case 2:
       default: break;
     }
     e.apply();

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -122,7 +122,7 @@ public final class Config
     }
     layouts = LayoutsPreference.load_from_preferences(res, _prefs);
     inverse_numpad = _prefs.getString("numpad_layout", "default").equals("low_first");
-    add_number_row = _prefs.getString("number_row", "default").equals("symbols");
+    add_number_row = _prefs.getString("number_row", "default").equals("no_number_row");
     // The baseline for the swipe distance correspond to approximately the
     // width of a key in portrait mode, as most layouts have 10 columns.
     // Multipled by the DPI ratio because most swipes are made in the diagonals.

--- a/srcs/juloo.keyboard2/KeyboardData.java
+++ b/srcs/juloo.keyboard2/KeyboardData.java
@@ -177,14 +177,9 @@ public final class KeyboardData
 
   private static Map<Integer, KeyboardData> _layoutCache = new HashMap<Integer, KeyboardData>();
 
-  public static Row load_bottom_row(Resources res) throws Exception
+  public static Row load_row(Resources res, int res_id) throws Exception
   {
-    return parse_row(res.getXml(R.xml.bottom_row));
-  }
-
-  public static Row load_number_row(Resources res) throws Exception
-  {
-    return parse_row(res.getXml(R.xml.number_row));
+    return parse_row(res.getXml(res_id));
   }
 
   public static KeyboardData load_num_pad(Resources res) throws Exception

--- a/srcs/juloo.keyboard2/LayoutModifier.java
+++ b/srcs/juloo.keyboard2/LayoutModifier.java
@@ -11,7 +11,8 @@ public final class LayoutModifier
 {
   static Config globalConfig;
   static KeyboardData.Row bottom_row;
-  static KeyboardData.Row number_row;
+  static KeyboardData.Row number_row_no_symbols;
+  static KeyboardData.Row number_row_symbols;
   static KeyboardData num_pad;
 
   /** Update the layout according to the configuration.
@@ -44,7 +45,7 @@ public final class LayoutModifier
     }
     else if (globalConfig.add_number_row && !kw.embedded_number_row) // The numpad removes the number row
     {
-      added_number_row = modify_number_row(number_row, kw);
+      added_number_row = modify_number_row(globalConfig.number_row_symbols ? number_row_symbols : number_row_no_symbols, kw);
       remove_keys.addAll(added_number_row.getKeys(0).keySet());
     }
     // Add the bottom row before computing the extra keys
@@ -204,8 +205,9 @@ public final class LayoutModifier
     globalConfig = globalConfig_;
     try
     {
-      number_row = KeyboardData.load_number_row(res);
-      bottom_row = KeyboardData.load_bottom_row(res);
+      number_row_no_symbols = KeyboardData.load_row(res, R.xml.number_row_no_symbols);
+      number_row_symbols = KeyboardData.load_row(res, R.xml.number_row);
+      bottom_row = KeyboardData.load_row(res, R.xml.bottom_row);
       num_pad = KeyboardData.load_num_pad(res);
     }
     catch (Exception e)


### PR DESCRIPTION
Fix https://github.com/Julow/Unexpected-Keyboard/issues/945 and https://github.com/Julow/Unexpected-Keyboard/issues/947
Thanks @Jaoheah for starting the work in https://github.com/Julow/Unexpected-Keyboard/pull/957