### PR TITLE
Better support for foldable devices

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,16 @@
 plugins {
-  id 'com.android.application' version '8.1.1'
+  id 'com.android.application' version '8.6.0'
 }
 
 dependencies {
+  implementation "androidx.window:window-java:1.3.0"
+  implementation "androidx.core:core:1.16.0"
   testImplementation "junit:junit:4.13.2"
 }
 
 android {
   namespace 'juloo.keyboard2'
-  compileSdk 34
+  compileSdk 35
 
   defaultConfig {
     applicationId "juloo.keyboard2"
@@ -82,8 +84,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_7
-    targetCompatibility JavaVersion.VERSION_1_7
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
   }
 
   lintOptions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
-android.useAndroidX=false
+android.useAndroidX=true
 android.nonTransitiveRClass=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Aug 21 18:13:41 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Nenáročná virtuální klávesnice pro vývojáře.</string>
     <string name="store_description">Hlavní funkcí je možnost psát více znaků posunutím kláves směrem k rohům.\n\nTato aplikace byla původně navržena pro programátory používající Termux.\nNyní je ideální pro každodenní použití.\n\nTato aplikace neobsahuje žádné reklamy, nevyužívá připojení k síti a je Open Source.</string>
     <string name="pref_portrait">V režimu na výšku</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">V režimu na šířku</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">Rozvržení</string>
     <string name="pref_label_brightness">Upravit jas nápisu</string>
     <string name="pref_keyboard_opacity">Upravit průhlednost pozadí klávesnice</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Eine schlanke, datenschutzfreundliche Bildschirmtastatur für Android.</string>
     <string name="store_description">Diese Tastatur zeichnet sich dadurch aus, dass man zusätzliche Zeichen durch Wischgesten in Richtung der Tastenecken eingeben kann.\n\nDie Anwendung wurde ursprünglich für das Programmieren in Termux entwickelt.\nMittlerweile ist sie auch für den täglichen Gebrauch perfekt geeignet.\n\nDiese App enthält keine Werbung, benötigt keinen Netzwerkzugriff und ist quelloffen.</string>
     <string name="pref_portrait">Im Hochformatmodus</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">Im Querformatmodus</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">Layout</string>
     <string name="pref_label_brightness">Helligkeit der Beschriftung anpassen</string>
     <string name="pref_keyboard_opacity">Deckkraft des Tastaturhintergrunds anpassen</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Un teclado virtual ligero para Android consciente de su privacidad.</string>
     <string name="store_description">La característica principal es que hay acceso a más caractéres deslizando hacia las esquinas de las teclas.\n\nEsta aplicación fue originalmente diseñada para programadores que usaran Termux.\nAhora es perfecta para uso cotidiano.\n\nLa misma no contiene ningún anuncio/publicidad, no realiza peticiones de red y es de Fuente Abierta.</string>
     <string name="pref_portrait">En modo vertical</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">En modo horizontal</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">Distribución</string>
     <string name="pref_label_brightness">Ajustar brillo de etiqueta</string>
     <string name="pref_keyboard_opacity">Ajustar opacidad del fondo del teclado</string>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -5,7 +5,9 @@
     <!-- <string name="short_description">Lightweight and privacy-conscious virtual keyboard for Android.</string> -->
     <!-- <string name="store_description">The main feature is that you can type more characters by swiping the keys towards the corners.\n\nThis application was originally designed for programmers using Termux.\nNow perfect for everyday use.\n\nThis application contains no ads, doesn\'t make any network requests and is Open Source.</string> -->
     <string name="pref_portrait">در حالت عمودی</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">در حالت افقی</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">طرح</string>
     <string name="pref_label_brightness">تنظیم برچسب روشنایی</string>
     <string name="pref_keyboard_opacity">تنظیم کدر بودن پس‌زمینه صفحه کلید</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Clavier virtuel léger et respectueux de la vie privée pour Android.</string>
     <string name="store_description">La fonctionnalité principale est l\'accès rapide à plus de caractères en balayant les touches vers les coins.\n\nCette application a été conçue à l\'origine pour les programmeurs utilisant Termux.\nElle est maintenant parfaite pour une utilisation quotidienne.\n\nCette application ne contient pas de publicité, n\'accède pas au réseau et est Open Source.</string>
     <string name="pref_portrait">En mode portrait</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">En mode landscape</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">Disposition</string>
     <string name="pref_label_brightness">Luminosité des symboles</string>
     <string name="pref_keyboard_opacity">Transparence du clavier</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Una Tastiera Virtuale Leggera Per La Programmazione</string>
     <!-- <string name="store_description">The main feature is that you can type more characters by swiping the keys towards the corners.\n\nThis application was originally designed for programmers using Termux.\nNow perfect for everyday use.\n\nThis application contains no ads, doesn\'t make any network requests and is Open Source.</string> -->
     <!-- <string name="pref_portrait">In portrait mode</string> -->
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <!-- <string name="pref_landscape">In landscape mode</string> -->
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">Layout</string>
     <!-- <string name="pref_label_brightness">Adjust label brightness</string> -->
     <!-- <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string> -->

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">軽量でプライバシーに配慮したAndroid用仮想キーボード</string>
     <string name="store_description">このキーボードは、キーの角をスワイプすることで様々なキーを入力できます。\n\nこのアプリは元々はTermuxでのプログラミング用に設計されました。\nしかし、今では普段の入力にも適しています。\nPCキーボードでの半角入力を再現しています。日本語入力、変換は出来ません。\n\nこのアプリは広告を含まず、インターネットに接続せず、そしてオープンソースです。</string>
     <string name="pref_portrait">縦向き</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">横向き</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">レイアウト</string>
     <string name="pref_label_brightness">文字の明るさ</string>
     <string name="pref_keyboard_opacity">背景の不透明度</string>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">개발자들을 위한 가벼운 가상 키보드.</string>
     <string name="store_description">주요 기능은 모서리 방향으로 키를 스와이프하여 더 많은 문자를 입력할 수 있다는 것입니다.\n\n이 앱은 처음에는 Termux를 사용하는 프로그래머들을 위한 것으로 개발되었습니다.\n지금은 일상적인 용도로도 완벽합니다.\n\n이 응용 프로그램에는 광고가 없으며 네트워크 요청을 하지 않고 오픈 소스입니다.</string>
     <string name="pref_portrait">세로 화면</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">가로 화면</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">레이아웃</string>
     <string name="pref_label_brightness">라벨 밝기 조절</string>
     <string name="pref_keyboard_opacity">키보드 배경 불투명도 조절</string>

--- a/res/values-lv/strings.xml
+++ b/res/values-lv/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Mazizmēra un privātumu ievērojoša virtuālā Android tastatūra.</string>
     <string name="store_description">Galvenā iezīme ir iespēja ievadīt vairāk rakstzīmju ar pavilkšanu uz taustiņu stūriem.\n\nŠī lietotne sākotnēji tika izstrādāta programmētājiem, kas izmanto Termux.\nTagad lieliski piemērota izmantošanai ikdienā.\n\nŠī lietotne nesatur reklāmas, neveic nekādus tīkla pieprasījumus, un tās pirmkods ir pieejams visiem.</string>
     <string name="pref_portrait">Stateniski</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">Guleniski</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">Izkārtojums</string>
     <string name="pref_label_brightness">Pielāgot iezīmju spilgtumu</string>
     <string name="pref_keyboard_opacity">Pielāgot tastatūras fona necaurredzamību</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Lekka i dbająca o prywatność klawiatura wirtualna dla Androida.</string>
     <string name="store_description">Główną cechą tej klawiatury jest możliwość wprowadzania więcej znaków poprzez przesuwanie po klawiszach do ich rogów.\n\nTa aplikacja została pierwotnie zaprojektowana z myślą o programistach używających Termuxa.\nObecnie nadaje się doskonale do codziennego użytku.\n\nAplikacja nie zawiera reklam, nie żąda dostępu do internetu, a jej kod źródłowy jest dostępny publicznie.</string>
     <string name="pref_portrait">W widoku pionowym</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">W widoku poziomym</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">Układ</string>
     <string name="pref_label_brightness">Dostosuj jasność znaków</string>
     <string name="pref_keyboard_opacity">Nieprzezroczystość tła klawiatury</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Um teclado virtual leve para desenvolvedores.</string>
     <string name="store_description">A principal característica é que você pode digitar mais caracteres deslizando as teclas para os cantos.\n\nO app foi criado originalmente para desenvolvedores que usam Termux.\nAgora aperfeiçoado para o uso diário.\n\nEste aplicativo não contém anúncios, não faz nenhuma solicitação de rede e é Open Source.</string>
     <string name="pref_portrait">No modo retrato</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">No modo paisagem</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">Layout</string>
     <string name="pref_label_brightness">Ajustar brilho dos rótulos</string>
     <string name="pref_keyboard_opacity">Ajustar opacidade do fundo do teclado</string>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Tastatură virtuală pentru Android, ușoară și respectuoasă cu viața privată.</string>
     <string name="store_description">Funcționalitatea principală este accesul rapid la o mulțime de caractere ASCII prin glisarea către colțurile tastelor.\n\nAceastă aplicație a fost concepută inițial pentru programatori care folosec Termux.\nEste perfectă pentru uzul cotidian.\n\nAceastă aplicație nu conține publicitate, nu folosește rețeaua deloc și e Open Source.</string>
     <string name="pref_portrait">În mod portret</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">În mod panoramă</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">Aspect</string>
     <string name="pref_label_brightness">Modifică luminozitatea denumirii</string>
     <string name="pref_keyboard_opacity">Modifică opacitatea fundalului tastaturii</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Легкая клавиатура для пользователей, заботящихся о конфиденциальности.</string>
     <string name="store_description">Главная особенность клавиатуры — это возможность легко напечатать любой ASCII-символ жестами в углы клавиш.\n\nПриложение изначально было разработано для использования с Termux.\nНа данный момент оно также удобно в повседневном использовании.\n\nПриложение не содержит рекламы, не осуществляет никаких запросов в сеть и имеет открытый исходный код.</string>
     <string name="pref_portrait">В портретном режиме</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">В ландшафтном режиме</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">Расположение</string>
     <string name="pref_label_brightness">Изменить яркость клавиатуры</string>
     <string name="pref_keyboard_opacity">Изменить прозрачность фона</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Android için hafif ve güvenlik odaklı bir sanal klavye uygulaması.</string>
     <string name="store_description">Bu uygulama özünde tuşların kenarlarından kaydırarak daha fazla karakter yazabilmek amacıyla geliştirildi.\n\nBu uygulama aslında Termux kullanıcıları için geliştirildi.\nArtık gündelik kullanım için de uygun.\n\nBu uygulama açık kaynaklıdır. Reklam içermez ve internete bağlanmaz.</string>
     <string name="pref_portrait">Portre modunda</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">Manzara modunda</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">Tuş düzeni</string>
     <string name="pref_label_brightness">Adjust label brightness</string>
     <string name="pref_keyboard_opacity">Klavye arkaplanı opaklığını ayarla</string>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Легка та конфіденційна віртуальна клавіатура для Android.</string>
     <string name="store_description">Головна особливість полягає в тому, що ви можете вводити більше символів, проводячи клавіші до кутів.\n\nЦя програма спочатку була розроблена для програмістів, які використовують Termux.\nТепер ідеально підходить для щоденного використання.\n\nЦя програма не містить реклами, не надсилає жодних мережевих запитів і має відкритий код.</string>
     <string name="pref_portrait">У портретному режимі</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">У альбомному режимі</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">Макет</string>
     <string name="pref_label_brightness">Налаштувати яскравість символів</string>
     <string name="pref_keyboard_opacity">Налаштувати прозорість фону клавіатури</string>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Bàn phím ảo gọn nhẹ và tôn trọng quyền riêng tư cho Android.</string>
     <string name="store_description">Chức năng chính là dễ dàng gõ nhiều ký tự bằng cách kéo phím về góc của nó.\n\nỨng dụng này ban đầu được thiết kế cho các lập trình viên dùng Termux.\nBây giờ đã hoàn hảo cho việc sử dụng hàng ngày.\n\nỨng dụng này không chứa quảng cáo, không cần đến mạng, và có mã nguồn mở.</string>
     <string name="pref_portrait">Trong chế độ chân dung</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">Trong chế độ phong cảnh</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">Bố cục</string>
     <string name="pref_label_brightness">Tùy chỉnh độ sáng của phím</string>
     <string name="pref_keyboard_opacity">Tùy chỉnh độ trong suốt của bàn phím</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">适用于 Android 的轻量级、注重隐私的虚拟键盘。</string>
     <string name="store_description">此应用的主要功能是，通过将按键沿四角滑动，您可以输入更多字符。\n\n此应用最初是为使用 Termux 的程序员而设计的。\n现在对于日常使用来说也很完美。\n\n此应用没有广告，不会发送任何网络请求，而且是开源的。</string>
     <string name="pref_portrait">在竖屏模式下</string>
+    <!-- <string name="pref_portrait_unfolded">In portrait mode unfolded</string> -->
     <string name="pref_landscape">在横屏模式下</string>
+    <!-- <string name="pref_landscape_unfolded">In landscape mode unfolded</string> -->
     <string name="pref_category_layout">布局</string>
     <string name="pref_label_brightness">调整字母亮度</string>
     <string name="pref_keyboard_opacity">调整键盘背景透明度</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -5,7 +5,9 @@
     <string name="short_description">Lightweight and privacy-conscious virtual keyboard for Android.</string>
     <string name="store_description">The main feature is that you can type more characters by swiping the keys towards the corners.\n\nThis application was originally designed for programmers using Termux.\nNow perfect for everyday use.\n\nThis application contains no ads, doesn\'t make any network requests and is Open Source.</string>
     <string name="pref_portrait">In portrait mode</string>
+    <string name="pref_portrait_unfolded">In portrait mode unfolded</string>
     <string name="pref_landscape">In landscape mode</string>
+    <string name="pref_landscape_unfolded">In landscape mode unfolded</string>
     <string name="pref_category_layout">Layout</string>
     <string name="pref_label_brightness">Adjust label brightness</string>
     <string name="pref_keyboard_opacity">Adjust keyboard background opacity</string>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -36,6 +36,8 @@
     <PreferenceScreen android:title="@string/pref_margin_bottom_title">
       <juloo.keyboard2.prefs.IntSlideBarPreference android:key="margin_bottom_portrait" android:title="@string/pref_portrait" android:summary="%sdp" android:defaultValue="7" min="0" max="100"/>
       <juloo.keyboard2.prefs.IntSlideBarPreference android:key="margin_bottom_landscape" android:title="@string/pref_landscape" android:summary="%sdp" android:defaultValue="3" min="0" max="100"/>
+      <juloo.keyboard2.prefs.IntSlideBarPreference android:key="margin_bottom_portrait_unfolded" android:title="@string/pref_portrait_unfolded" android:summary="%sdp" android:defaultValue="7" min="0" max="100"/>
+      <juloo.keyboard2.prefs.IntSlideBarPreference android:key="margin_bottom_landscape_unfolded" android:title="@string/pref_landscape_unfolded" android:summary="%sdp" android:defaultValue="3" min="0" max="100"/>
     </PreferenceScreen>
     <PreferenceScreen android:title="@string/pref_keyboard_height_title">
       <juloo.keyboard2.prefs.IntSlideBarPreference android:key="keyboard_height" android:title="@string/pref_portrait" android:summary="%s%%" android:defaultValue="35" min="10" max="50"/>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -42,6 +42,8 @@
     <PreferenceScreen android:title="@string/pref_keyboard_height_title">
       <juloo.keyboard2.prefs.IntSlideBarPreference android:key="keyboard_height" android:title="@string/pref_portrait" android:summary="%s%%" android:defaultValue="35" min="10" max="50"/>
       <juloo.keyboard2.prefs.IntSlideBarPreference android:key="keyboard_height_landscape" android:title="@string/pref_landscape" android:summary="%s%%" android:defaultValue="50" min="20" max="65"/>
+      <juloo.keyboard2.prefs.IntSlideBarPreference android:key="keyboard_height_unfolded" android:title="@string/pref_portrait_unfolded" android:summary="%s%%" android:defaultValue="35" min="10" max="50"/>
+      <juloo.keyboard2.prefs.IntSlideBarPreference android:key="keyboard_height_landscape_unfolded" android:title="@string/pref_landscape_unfolded" android:summary="%s%%" android:defaultValue="50" min="20" max="65"/>
     </PreferenceScreen>
     <PreferenceScreen android:title="@string/pref_horizontal_margin_title">
       <juloo.keyboard2.prefs.IntSlideBarPreference android:key="horizontal_margin_portrait" android:title="@string/pref_portrait" android:summary="%sdp" android:defaultValue="3" min="0" max="30"/>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -46,6 +46,8 @@
     <PreferenceScreen android:title="@string/pref_horizontal_margin_title">
       <juloo.keyboard2.prefs.IntSlideBarPreference android:key="horizontal_margin_portrait" android:title="@string/pref_portrait" android:summary="%sdp" android:defaultValue="3" min="0" max="30"/>
       <juloo.keyboard2.prefs.IntSlideBarPreference android:key="horizontal_margin_landscape" android:title="@string/pref_landscape" android:summary="%sdp" android:defaultValue="28" min="0" max="200"/>
+      <juloo.keyboard2.prefs.IntSlideBarPreference android:key="horizontal_margin_portrait_unfolded" android:title="@string/pref_portrait_unfolded" android:summary="%sdp" android:defaultValue="3" min="0" max="30"/>
+      <juloo.keyboard2.prefs.IntSlideBarPreference android:key="horizontal_margin_landscape_unfolded" android:title="@string/pref_landscape_unfolded" android:summary="%sdp" android:defaultValue="28" min="0" max="200"/>
     </PreferenceScreen>
     <juloo.keyboard2.prefs.SlideBarPreference android:key="character_size" android:title="@string/pref_character_size_title" android:summary="@string/pref_character_size_summary" android:defaultValue="1.15" min="0.75" max="1.5"/>
     <juloo.keyboard2.prefs.SlideBarPreference android:key="key_vertical_margin" android:title="@string/pref_key_vertical_space" android:summary="%s%%" android:defaultValue="1.5" min="0" max="5"/>

--- a/shell.nix
+++ b/shell.nix
@@ -5,11 +5,11 @@
 
 let
   jdk = pkgs.openjdk17;
-  build_tools_version = "33.0.1";
+  build_tools_version = "34.0.0";
 
   android = pkgs.androidenv.composeAndroidPackages {
     buildToolsVersions = [ build_tools_version ];
-    platformVersions = [ "34" ];
+    platformVersions = [ "35" ];
     abiVersions = [ "armeabi-v7a" ];
     inherit repoJson;
   };

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -16,7 +16,6 @@ import juloo.keyboard2.prefs.LayoutsPreference;
 public final class Config
 {
   private final SharedPreferences _prefs;
-  private final FoldStateTracker _foldStateTracker;
 
   // From resources
   public final float marginTop;
@@ -83,17 +82,16 @@ public final class Config
   int current_layout_unfolded_landscape;
   public int bottomInsetMin;
 
-  private Config(SharedPreferences prefs, Resources res, IKeyEventHandler h, FoldStateTracker foldStateTracker)
+  private Config(SharedPreferences prefs, Resources res, IKeyEventHandler h, Boolean foldableUnfolded)
   {
     _prefs = prefs;
-    _foldStateTracker = foldStateTracker;
     // static values
     marginTop = res.getDimension(R.dimen.margin_top);
     keyPadding = res.getDimension(R.dimen.key_padding);
     labelTextSize = 0.33f;
     sublabelTextSize = 0.22f;
     // from prefs
-    refresh(res);
+    refresh(res, foldableUnfolded);
     // initialized later
     shouldOfferVoiceTyping = false;
     actionLabel = null;
@@ -106,11 +104,11 @@ public final class Config
   /*
    ** Reload prefs
    */
-  public void refresh(Resources res)
+  public void refresh(Resources res, Boolean foldableUnfolded)
   {
     DisplayMetrics dm = res.getDisplayMetrics();
     orientation_landscape = res.getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
-    foldable_unfolded = _foldStateTracker.isUnfolded();
+    foldable_unfolded = foldableUnfolded;
 
     // The height of the keyboard is relative to the height of the screen.
     // This is the height of the keyboard if it have 4 rows.
@@ -280,10 +278,10 @@ public final class Config
   private static Config _globalConfig = null;
 
   public static void initGlobalConfig(SharedPreferences prefs, Resources res,
-      IKeyEventHandler handler, FoldStateTracker foldStateTracker)
+      IKeyEventHandler handler, Boolean foldableUnfolded)
   {
     migrate(prefs);
-    _globalConfig = new Config(prefs, res, handler, foldStateTracker);
+    _globalConfig = new Config(prefs, res, handler, foldableUnfolded);
     LayoutModifier.init(_globalConfig, res);
   }
 

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -238,7 +238,13 @@ public final class Config
   /** [get_dip_pref] depending on orientation. */
   float get_dip_pref_oriented(DisplayMetrics dm, String pref_base_name, float def_port, float def_land)
   {
-    String suffix = orientation_landscape ? "_landscape" : "_portrait";
+    final String suffix;
+    if (foldable_unfolded) {
+      suffix = orientation_landscape ? "_landscape_unfolded" : "_portrait_unfolded";
+    } else {
+      suffix = orientation_landscape ? "_landscape" : "_portrait";
+    }
+    
     float def = orientation_landscape ? def_land : def_port;
     return get_dip_pref(dm, pref_base_name + suffix, def);
   }

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -122,12 +122,12 @@ public final class Config
     {
       if ("landscape".equals(show_numpad_s))
         show_numpad = true;
-      keyboardHeightPercent = _prefs.getInt("keyboard_height_landscape", 50);
+      keyboardHeightPercent = _prefs.getInt(foldable_unfolded ? "keyboard_height_landscape_unfolded" : "keyboard_height_landscape", 50);
       characterSizeScale = 1.25f;
     }
     else
     {
-      keyboardHeightPercent = _prefs.getInt("keyboard_height", 35);
+      keyboardHeightPercent = _prefs.getInt(foldable_unfolded ? "keyboard_height_unfolded" : "keyboard_height", 35);
     }
     layouts = LayoutsPreference.load_from_preferences(res, _prefs);
     inverse_numpad = _prefs.getString("numpad_layout", "default").equals("low_first");
@@ -244,7 +244,7 @@ public final class Config
     } else {
       suffix = orientation_landscape ? "_landscape" : "_portrait";
     }
-    
+
     float def = orientation_landscape ? def_land : def_port;
     return get_dip_pref(dm, pref_base_name + suffix, def);
   }

--- a/srcs/juloo.keyboard2/FoldStateTracker.java
+++ b/srcs/juloo.keyboard2/FoldStateTracker.java
@@ -12,22 +12,19 @@ import androidx.core.util.Consumer;
 
 
 public class FoldStateTracker {
-    private final Context _context;
     private final Consumer<WindowLayoutInfo> _innerListener;
     private final WindowInfoTrackerCallbackAdapter _windowInfoTracker;
     private FoldingFeature _foldingFeature = null;
     private Runnable _changedCallback = null;
     public FoldStateTracker(Context context) {
-        this._context = context;
-
         _windowInfoTracker =
                 new WindowInfoTrackerCallbackAdapter(WindowInfoTracker.getOrCreate(context));
         _innerListener = new LayoutStateChangeCallback();
         _windowInfoTracker.addWindowLayoutInfoListener(context, Runnable::run, _innerListener);
     }
 
-    public boolean isFoldableDevice() {
-        return _context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_SENSOR_HINGE_ANGLE);
+    public static boolean isFoldableDevice(Context context) {
+        return context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_SENSOR_HINGE_ANGLE);
     }
 
     public boolean isUnfolded() {

--- a/srcs/juloo.keyboard2/FoldStateTracker.java
+++ b/srcs/juloo.keyboard2/FoldStateTracker.java
@@ -1,0 +1,65 @@
+package juloo.keyboard2;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import androidx.window.java.layout.WindowInfoTrackerCallbackAdapter;
+import androidx.window.layout.DisplayFeature;
+import androidx.window.layout.FoldingFeature;
+import androidx.window.layout.WindowInfoTracker;
+import androidx.window.layout.WindowLayoutInfo;
+
+import androidx.core.util.Consumer;
+
+
+public class FoldStateTracker {
+    private final Context _context;
+    private final Consumer<WindowLayoutInfo> _innerListener;
+    private final WindowInfoTrackerCallbackAdapter _windowInfoTracker;
+    private FoldingFeature _foldingFeature = null;
+    private Runnable _changedCallback = null;
+    public FoldStateTracker(Context context) {
+        this._context = context;
+
+        _windowInfoTracker =
+                new WindowInfoTrackerCallbackAdapter(WindowInfoTracker.getOrCreate(context));
+        _innerListener = new LayoutStateChangeCallback();
+        _windowInfoTracker.addWindowLayoutInfoListener(context, Runnable::run, _innerListener);
+    }
+
+    public boolean isFoldableDevice() {
+        return _context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_SENSOR_HINGE_ANGLE);
+    }
+
+    public boolean isUnfolded() {
+        // FoldableFeature is only present when the device is unfolded. Otherwise, it's removed.
+        // A weird decision from Google, but that's how it works:
+        // https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:window/window/src/main/java/androidx/window/layout/adapter/sidecar/SidecarAdapter.kt;l=187?q=SidecarAdapter
+
+        return _foldingFeature != null;
+    }
+
+    public void close() {
+        _windowInfoTracker.removeWindowLayoutInfoListener(_innerListener);
+    }
+
+    public void setChangedCallback(Runnable _changedCallback) {
+        this._changedCallback = _changedCallback;
+    }
+
+    class LayoutStateChangeCallback implements Consumer<WindowLayoutInfo> {
+        @Override
+        public void accept(WindowLayoutInfo newLayoutInfo) {
+            FoldingFeature old = _foldingFeature;
+            _foldingFeature = null;
+            for (DisplayFeature feature: newLayoutInfo.getDisplayFeatures()) {
+                if (feature instanceof FoldingFeature) {
+                    _foldingFeature = (FoldingFeature) feature;
+                }
+            }
+
+            if (old != _foldingFeature && _changedCallback != null) {
+                _changedCallback.run();
+            }
+        }
+    }
+}

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -43,6 +43,8 @@ public class Keyboard2 extends InputMethodService
 
   private Config _config;
 
+  private FoldStateTracker _foldStateTracker;
+
   /** Layout currently visible before it has been modified. */
   KeyboardData current_layout_unmodified()
   {
@@ -111,13 +113,22 @@ public class Keyboard2 extends InputMethodService
     SharedPreferences prefs = DirectBootAwarePreferences.get_shared_preferences(this);
     _handler = new Handler(getMainLooper());
     _keyeventhandler = new KeyEventHandler(this.new Receiver());
-    Config.initGlobalConfig(prefs, getResources(), _keyeventhandler);
+    _foldStateTracker = new FoldStateTracker(this);
+    Config.initGlobalConfig(prefs, getResources(), _keyeventhandler, _foldStateTracker);
     prefs.registerOnSharedPreferenceChangeListener(this);
     _config = Config.globalConfig();
     _keyboardView = (Keyboard2View)inflate_view(R.layout.keyboard);
     _keyboardView.reset();
     Logs.set_debug_logs(getResources().getBoolean(R.bool.debug_logs));
     ClipboardHistoryService.on_startup(this, _keyeventhandler);
+    _foldStateTracker.setChangedCallback(() -> { refresh_config(); });
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+
+    _foldStateTracker.close();
   }
 
   private List<InputMethodSubtype> getEnabledSubtypes(InputMethodManager imm)

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -114,7 +114,7 @@ public class Keyboard2 extends InputMethodService
     _handler = new Handler(getMainLooper());
     _keyeventhandler = new KeyEventHandler(this.new Receiver());
     _foldStateTracker = new FoldStateTracker(this);
-    Config.initGlobalConfig(prefs, getResources(), _keyeventhandler, _foldStateTracker);
+    Config.initGlobalConfig(prefs, getResources(), _keyeventhandler, _foldStateTracker.isUnfolded());
     prefs.registerOnSharedPreferenceChangeListener(this);
     _config = Config.globalConfig();
     _keyboardView = (Keyboard2View)inflate_view(R.layout.keyboard);
@@ -245,7 +245,7 @@ public class Keyboard2 extends InputMethodService
   private void refresh_config()
   {
     int prev_theme = _config.theme;
-    _config.refresh(getResources());
+    _config.refresh(getResources(), _foldStateTracker.isUnfolded());
     refreshSubtypeImm();
     // Refreshing the theme config requires re-creating the views
     if (prev_theme != _config.theme)

--- a/srcs/juloo.keyboard2/SettingsActivity.java
+++ b/srcs/juloo.keyboard2/SettingsActivity.java
@@ -24,7 +24,7 @@ public class SettingsActivity extends PreferenceActivity
     catch (Exception _e) { fallbackEncrypted(); return; }
     addPreferencesFromResource(R.xml.settings);
 
-    boolean foldableDevice = new FoldStateTracker(this).isFoldableDevice();
+    boolean foldableDevice = FoldStateTracker.isFoldableDevice(this);
     findPreference("margin_bottom_portrait_unfolded").setEnabled(foldableDevice);
     findPreference("margin_bottom_landscape_unfolded").setEnabled(foldableDevice);
     findPreference("horizontal_margin_portrait_unfolded").setEnabled(foldableDevice);

--- a/srcs/juloo.keyboard2/SettingsActivity.java
+++ b/srcs/juloo.keyboard2/SettingsActivity.java
@@ -27,6 +27,8 @@ public class SettingsActivity extends PreferenceActivity
     boolean foldableDevice = new FoldStateTracker(this).isFoldableDevice();
     findPreference("margin_bottom_portrait_unfolded").setEnabled(foldableDevice);
     findPreference("margin_bottom_landscape_unfolded").setEnabled(foldableDevice);
+    findPreference("horizontal_margin_portrait_unfolded").setEnabled(foldableDevice);
+    findPreference("horizontal_margin_landscape_unfolded").setEnabled(foldableDevice);
   }
 
   void fallbackEncrypted()

--- a/srcs/juloo.keyboard2/SettingsActivity.java
+++ b/srcs/juloo.keyboard2/SettingsActivity.java
@@ -23,6 +23,10 @@ public class SettingsActivity extends PreferenceActivity
     }
     catch (Exception _e) { fallbackEncrypted(); return; }
     addPreferencesFromResource(R.xml.settings);
+
+    boolean foldableDevice = new FoldStateTracker(this).isFoldableDevice();
+    findPreference("margin_bottom_portrait_unfolded").setEnabled(foldableDevice);
+    findPreference("margin_bottom_landscape_unfolded").setEnabled(foldableDevice);
   }
 
   void fallbackEncrypted()

--- a/srcs/juloo.keyboard2/SettingsActivity.java
+++ b/srcs/juloo.keyboard2/SettingsActivity.java
@@ -29,6 +29,8 @@ public class SettingsActivity extends PreferenceActivity
     findPreference("margin_bottom_landscape_unfolded").setEnabled(foldableDevice);
     findPreference("horizontal_margin_portrait_unfolded").setEnabled(foldableDevice);
     findPreference("horizontal_margin_landscape_unfolded").setEnabled(foldableDevice);
+    findPreference("keyboard_height_unfolded").setEnabled(foldableDevice);
+    findPreference("keyboard_height_landscape_unfolded").setEnabled(foldableDevice);
   }
 
   void fallbackEncrypted()


### PR DESCRIPTION
PR adds separate layouts and separate layout settings for folded and unfolded state of the device.

Unfortunately, the only way to get fold state at the moment is through AndroidX WindowManager. Native Android APIs are internal. So I had to update some dependencies, raise java version and raise compile SDK to include AndroidX in the project.

this fixes #754