### PR TITLE
Avoid the selection being empty in selection mode

### DIFF
--- a/srcs/juloo.keyboard2/KeyEventHandler.java
+++ b/srcs/juloo.keyboard2/KeyEventHandler.java
@@ -320,10 +320,16 @@ public final class KeyEventHandler
     {
       int sel_start = et.selectionStart;
       int sel_end = et.selectionEnd;
-      if (sel_left == (sel_start <= sel_end))
-        sel_start += d;
-      else
-        sel_end += d;
+      boolean modify_sel_start = sel_left == (sel_start <= sel_end);
+      do
+      {
+        if (modify_sel_start)
+          sel_start += d;
+        else
+          sel_end += d;
+        // Move the cursor twice if moving it once would make the selection
+        // empty and stop selection mode.
+      } while (sel_start == sel_end);
       if (conn.setSelection(sel_start, sel_end))
         return; // Fallback to sending key events if [setSelection] failed
     }


### PR DESCRIPTION
Fix https://github.com/Julow/Unexpected-Keyboard/issues/954

Emptying the selection with the spacebar slider puts the selection mode in an unexpected state. This checks that this doesn't happen.

For example, moving the right end of the selection (by going right then left in a single stroke) after it reached the left end will push it with every steps to keep the selection of size 1.