### PR TITLE
Add <row scale=""> attribute

### DIFF
--- a/doc/Custom-layouts.md
+++ b/doc/Custom-layouts.md
@@ -52,8 +52,10 @@ The `<keyboard>`...`</keyboard>` pair follows the declaration tag and encloses t
 * `locale_extra_keys`: Whether Unexpected should add language-dependent extra keys from [method.xml](../res/xml/method.xml) to this layout. It accepts `true` or `false`, and defaults to `true`. To disable these automatic additions, specify `locale_extra_keys="false"`.
 
 ## Row
-The `<row>`...`</row>` pair encloses one row on the keyboard. It has only one optional property:
+The `<row>`...`</row>` pair encloses one row on the keyboard. It has the following optional property:
 * `height`: The height of the row: a positive floating-point value.
+
+* `scale`: A positive floating-point value. If present, scale the width of each key so that the total is equal to the specified value, in key width unit.
 
 A row's default height is 1.0 (one quarter of the keyboard height specified on the Settings menu). The `height` property makes the row taller or shorter than this. For example, if you define a 5-row keyboard but one row has `height="0.7"`, then the keyboard's total height is 4.7 units. If the total is different from 4.0, the keyboard will be taller or shorter than that specified in Settings.
 

--- a/srcs/juloo.keyboard2/KeyboardData.java
+++ b/srcs/juloo.keyboard2/KeyboardData.java
@@ -336,9 +336,13 @@ public final class KeyboardData
       int status;
       float h = attribute_float(parser, "height", 1f);
       float shift = attribute_float(parser, "shift", 0f);
+      float scale = attribute_float(parser, "scale", 0f);
       while (expect_tag(parser, "key"))
         keys.add(Key.parse(parser));
-      return new Row(keys, h, shift);
+      Row row = new Row(keys, h, shift);
+      if (scale > 0f)
+        row = row.updateWidth(scale);
+      return row;
     }
 
     public Row copy()

--- a/srcs/layouts/cyrl_jcuken_ru.xml
+++ b/srcs/layouts/cyrl_jcuken_ru.xml
@@ -26,17 +26,17 @@
     <key key0="ж" key2="=" key3="+"/>
     <key key0="э" key2="|" key3="\\"/>
   </row>
-  <row>
-    <key width="1.18" key0="shift" key2="loc capslock"/>
-    <key width="0.96" key0="я"/>
-    <key width="0.96" key0="ч"/>
-    <key width="0.96" key0="с"/>
-    <key width="0.96" key0="м"/>
-    <key width="0.96" key0="и" key1="loc і" key2="&lt;" key3="."/>
-    <key width="0.96" key0="т" key2="&gt;" key3=","/>
-    <key width="0.96" key0="ь" key1="ъ" key2="\?" key3="/"/>
-    <key width="0.96" key0="б" key2=":" key3=";"/>
-    <key width="0.96" key0="ю" key2="&quot;" key3="'"/>
-    <key width="1.18" key0="backspace" key2="delete"/>
+  <row scale="11">
+    <key width="1.22" key0="shift" key2="loc capslock"/>
+    <key key0="я"/>
+    <key key0="ч"/>
+    <key key0="с"/>
+    <key key0="м"/>
+    <key key0="и" key1="loc і" key2="&lt;" key3="."/>
+    <key key0="т" key2="&gt;" key3=","/>
+    <key key0="ь" key1="ъ" key2="\?" key3="/"/>
+    <key key0="б" key2=":" key3=";"/>
+    <key key0="ю" key2="&quot;" key3="'"/>
+    <key width="1.22" key0="backspace" key2="delete"/>
   </row>
 </keyboard>

--- a/srcs/layouts/cyrl_yqukeng_tj.xml
+++ b/srcs/layouts/cyrl_yqukeng_tj.xml
@@ -26,17 +26,17 @@
     <key key0="ж" key7="0" />
     <key key0="э" key7="\?" key3="/" />
   </row>
-  <row>
-    <key width="1.18" key0="shift" key2="loc capslock" />
-    <key width="0.96" key0="я" key7="`" key8=";" />
-    <key width="0.96" key0="ч" key7="*" key8=":" />
-    <key width="0.96" key0="с"  key7="&amp;" key8="\#" />
-    <key width="0.96" key0="м" key7="|" key8="\\" />
-    <key width="0.96" key0="и" key7="~" />
-    <key width="0.96" key0="т" key7="ц" />
-    <key width="0.96" key0="ӣ" key3="&lt;" key2="&gt;" />
-    <key width="0.96" key0="б" key7="ъ" key8="ы" />
-    <key width="0.96" key0="ю" key7="&quot;" key8="'"/>
-    <key width="1.18" key0="." key7="," />
+  <row scale="11">
+    <key width="1.22" key0="shift" key2="loc capslock" />
+    <key key0="я" key7="`" key8=";" />
+    <key key0="ч" key7="*" key8=":" />
+    <key key0="с"  key7="&amp;" key8="\#" />
+    <key key0="м" key7="|" key8="\\" />
+    <key key0="и" key7="~" />
+    <key key0="т" key7="ц" />
+    <key key0="ӣ" key3="&lt;" key2="&gt;" />
+    <key key0="б" key7="ъ" key8="ы" />
+    <key key0="ю" key7="&quot;" key8="'"/>
+    <key width="1.22" key0="." key7="," />
   </row>
 </keyboard>

--- a/srcs/layouts/cyrl_yxukeng_os.xml
+++ b/srcs/layouts/cyrl_yxukeng_os.xml
@@ -26,17 +26,17 @@
     <key key0="ж" key7="0" />
     <key key0="э" key7="/" key8="|" />
   </row>
-  <row>
-    <key width="1.18" key0="shift" />
-    <key width="0.96" key0="ꙗ" key7="combining_breve" key8=";" />
-    <key width="0.96" key0="ч" key7="combining_pokrytie" key8=":" />
-    <key width="0.96" key0="с" key7="combining_inverted_breve" key8="`" />
-    <key width="0.96" key0="м" key7="ѭ" />
-    <key width="0.96" key0="и" key7="combining_vertical_tilde" key8="-" />
-    <key width="0.96" key0="т" key7="\?" key8="\\" />
-    <key width="0.96" key0="ц" key3="&lt;" key2="&gt;" />
-    <key width="0.96" key0="б" key3="(" key2=")" />
-    <key width="0.96" key0="ю" key3="{" key2="}" />
-    <key width="1.18" key0="." key7="," key8="_" />
+  <row scale="11">
+    <key width="1.22" key0="shift" />
+    <key key0="ꙗ" key7="combining_breve" key8=";" />
+    <key key0="ч" key7="combining_pokrytie" key8=":" />
+    <key key0="с" key7="combining_inverted_breve" key8="`" />
+    <key key0="м" key7="ѭ" />
+    <key key0="и" key7="combining_vertical_tilde" key8="-" />
+    <key key0="т" key7="\?" key8="\\" />
+    <key key0="ц" key3="&lt;" key2="&gt;" />
+    <key key0="б" key3="(" key2=")" />
+    <key key0="ю" key3="{" key2="}" />
+    <key width="1.22" key0="." key7="," key8="_" />
   </row>
 </keyboard>

--- a/srcs/layouts/deva_alt.xml
+++ b/srcs/layouts/deva_alt.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <keyboard name="देवनागरी (हिंदी)-2" script="devanagari">
-  <row>
-    <key shift="0.35" width="0.9" c="क" nw="ख" ne="घ" sw="ङ"  se="ग"/>
-    <key              width="0.9" c="च" nw="छ" ne="झ" sw="ञ"  se="ज"/>
-    <key              width="0.9" c="ट" nw="ठ" ne="ढ" sw="ण"  se="ड" anticircle="७" indication="७"/>
-    <key              width="0.9" c="त" nw="थ" ne="ध" sw="न"  se="द" anticircle="८" indication="८"/>
-    <key              width="0.9" c="प" nw="फ" ne="भ" sw="म"  se="ब" anticircle="९" indication="९"/>
-    <key              width="0.9" c="र" nw="ज्ञ" ne="ल" sw="य"  se="व"/>
-    <key              width="0.9" c="ह" nw="श" ne="ळ" sw="स"  se="ष"/>
+  <row scale="6.6">
+    <key shift="0.35" c="क" nw="ख" ne="घ" sw="ङ"  se="ग"/>
+    <key              c="च" nw="छ" ne="झ" sw="ञ"  se="ज"/>
+    <key              c="ट" nw="ठ" ne="ढ" sw="ण"  se="ड" anticircle="७" indication="७"/>
+    <key              c="त" nw="थ" ne="ध" sw="न"  se="द" anticircle="८" indication="८"/>
+    <key              c="प" nw="फ" ne="भ" sw="म"  se="ब" anticircle="९" indication="९"/>
+    <key              c="र" nw="ज्ञ" ne="ल" sw="य"  se="व"/>
+    <key              c="ह" nw="श" ne="ळ" sw="स"  se="ष"/>
   </row>
-  <row>
-    <key shift="0.35" width="0.9" c="ा" nw="अ" ne="आ"/>
-    <key              width="0.9" c="ि" nw="इ"/>
-    <key              width="0.9" c="ी" nw="ई" anticircle="४" indication="४"/>
-    <key              width="0.9" c="ु" nw="उ" ne="ऊ" se="ू" anticircle="५" indication="५"/>
-    <key              width="0.9" c="े" nw="ए" ne="ऋ" se="ृ" anticircle="६" indication="६"/>
-    <key              width="0.9" c="ै" nw="ऐ" ne="ऌ" se="ॢ"/>
-    <key              width="0.9" c="ो" nw="ओ" ne="औ" se="ौ"/>
+  <row scale="6.6">
+    <key shift="0.35" c="ा" nw="अ" ne="आ"/>
+    <key              c="ि" nw="इ"/>
+    <key              c="ी" nw="ई" anticircle="४" indication="४"/>
+    <key              c="ु" nw="उ" ne="ऊ" se="ू" anticircle="५" indication="५"/>
+    <key              c="े" nw="ए" ne="ऋ" se="ृ" anticircle="६" indication="६"/>
+    <key              c="ै" nw="ऐ" ne="ऌ" se="ॢ"/>
+    <key              c="ो" nw="ओ" ne="औ" se="ौ"/>
   </row>
   <row>
     <key c="ऽ" se="\@"/>

--- a/srcs/layouts/hebr_1_il.xml
+++ b/srcs/layouts/hebr_1_il.xml
@@ -14,17 +14,17 @@
     <key key0="פ" key2="0" key3="b)" key4="rlm"/>
     <key key0="backspace" key2="delete"/>
   </row>
-  <row>
-    <key key0="ש" key2="`" key1="loc tab" key3="sindot_placeholder" key4="shindot_placeholder" width="1.333"/>
-    <key key0="ד" key1="~" width="1.0333"/>
-    <key key0="ג" key1="geresh" key2="gershayim" width="1.0333"/>
-    <key key0="כ" width="1.0333"/>
-    <key key0="ע" width="1.0333"/>
-    <key key0="י" key2="-" key3="_" key4="maqaf" width="1.0333"/>
-    <key key0="ח" key2="=" key3="+" width="1.0333"/>
-    <key key0="ל" key2="b[" key3="b{" width="1.0333"/>
-    <key key0="ך" key2="b]" key3="b}" width="1.0333"/>
-    <key key0="ף" key2="," key3="&quot;" key1=":" width="1.4006"/>
+  <row scale="11">
+    <key key0="ש" key2="`" key1="loc tab" key3="sindot_placeholder" key4="shindot_placeholder" width="1.30"/>
+    <key key0="ד" key1="~"/>
+    <key key0="ג" key1="geresh" key2="gershayim"/>
+    <key key0="כ"/>
+    <key key0="ע"/>
+    <key key0="י" key2="-" key3="_" key4="maqaf"/>
+    <key key0="ח" key2="=" key3="+"/>
+    <key key0="ל" key2="b[" key3="b{"/>
+    <key key0="ך" key2="b]" key3="b}"/>
+    <key key0="ף" key2="," key3="&quot;" key1=":" width="1.35"/>
   </row>
   <row>
     <key key0="\\" key1="|" key2="shift" key3="loc capslock"/>

--- a/srcs/layouts/latn_bepo_fr.xml
+++ b/srcs/layouts/latn_bepo_fr.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Inspired by the bépo layout, but adapted to smartphone -->
 <keyboard name="BEPO (Français)" script="latin">
-  <row>
-    <key width="1.1" key0="b" key1="loc esc" key2="1" key4="|"/>
-    <key width="1.1" key0="é" key2="2" key4="è"/>
-    <key width="1.1" key0="p" key2="3"/>
-    <key width="1.1" key0="o" key2="4" key4="accent_circonflexe"/>
-    <key width="1.1" key0="v" key2="5" key4="{"/>
-    <key width="1.1" key0="d" key2="6" key4="}"/>
-    <key width="1.1" key0="l" key2="7" key4="("/>
-    <key width="1.1" key0="j" key2="8" key4=")"/>
-    <key width="1.1" key0="z" key2="9" key4="["/>
-    <key width="1.1" key0="w" key2="0" key4="]"/>
+  <row scale="11">
+    <key key0="b" key1="loc esc" key2="1" key4="|"/>
+    <key key0="é" key2="2" key4="è"/>
+    <key key0="p" key2="3"/>
+    <key key0="o" key2="4" key4="accent_circonflexe"/>
+    <key key0="v" key2="5" key4="{"/>
+    <key key0="d" key2="6" key4="}"/>
+    <key key0="l" key2="7" key4="("/>
+    <key key0="j" key2="8" key4=")"/>
+    <key key0="z" key2="9" key4="["/>
+    <key key0="w" key2="0" key4="]"/>
   </row>
-  <row>
-    <key width="1.1" key0="a" key1="loc tab" key4="à"/>
-    <key width="1.1" key0="u" key1="$" key4="ù"/>
-    <key width="1.1" key0="i" key4="&amp;"/>
-    <key width="1.1" key0="e" key1="+" key2="accent_trema" key4="€"/>
-    <key width="1.1" key0="c" key1="=" key4="ç"/>
-    <key width="1.1" key0="t" key1="^" key4=";"/>
-    <key width="1.1" key0="s" key4="!"/>
-    <key width="1.1" key0="r" key4="\?"/>
-    <key width="1.1" key0="n" key1="`" key2="'" key4=":"/>
-    <key width="1.1" key0="m" key2="&quot;"/>
+  <row scale="11">
+    <key key0="a" key1="loc tab" key4="à"/>
+    <key key0="u" key1="$" key4="ù"/>
+    <key key0="i" key4="&amp;"/>
+    <key key0="e" key1="+" key2="accent_trema" key4="€"/>
+    <key key0="c" key1="=" key4="ç"/>
+    <key key0="t" key1="^" key4=";"/>
+    <key key0="s" key4="!"/>
+    <key key0="r" key4="\?"/>
+    <key key0="n" key1="`" key2="'" key4=":"/>
+    <key key0="m" key2="&quot;"/>
   </row>
   <row>
     <key width="1.5" key0="shift" key2="loc capslock" key3="&lt;"/>


### PR DESCRIPTION
Scale the width of the keys in the row to match a value. Useful to remove space on the right of the row without adding a 'width' attribute to each key.
Builtin layouts are changed to use the new attribute.