### PR TITLE
Fix selection mode not exited when selection cleared

### DIFF
--- a/srcs/juloo.keyboard2/Pointers.java
+++ b/srcs/juloo.keyboard2/Pointers.java
@@ -108,7 +108,10 @@ public final class Pointers implements Handler.Callback
     {
       // No existing pointer, latch the key.
       if (latched)
+      {
         add_fake_pointer(key, kv, lock);
+        _handler.onPointerFlagsChanged(false);
+      }
     }
     else if ((ptr.flags & FLAG_P_FAKE) == 0)
     {} // Key already latched but not by a fake ptr, do nothing.
@@ -118,6 +121,7 @@ public final class Pointers implements Handler.Callback
       removePtr(ptr);
       if (latched)
         add_fake_pointer(key, kv, lock);
+      _handler.onPointerFlagsChanged(false);
     }
     else if ((ptr.flags & FLAG_P_LOCKED) != 0)
     {} // Existing ptr is locked but [lock] is false, do not continue.


### PR DESCRIPTION
The bug was mentioned in https://github.com/Julow/Unexpected-Keyboard/issues/954#issuecomment-2975478282

The selection mode was not exited when the selection was cleared with, for example, ctrl+x.