### PR TITLE
Fix unwanted bottom margin on Samsung OneUI 7 

### DIFF
--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -315,6 +315,7 @@ public class Keyboard2 extends InputMethodService
         WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
       // Allow to draw behind system bars
       wattrs.setFitInsetsTypes(0);
+      window.setDecorFitsSystemWindows(false);
     }
     updateLayoutHeightOf(window, ViewGroup.LayoutParams.MATCH_PARENT);
     final View inputArea = window.findViewById(android.R.id.inputArea);

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -277,10 +277,9 @@ public class Keyboard2View extends View
       width = metrics.getBounds().width();
       WindowInsets wi = metrics.getWindowInsets();
       int insets_types =
-          WindowInsets.Type.statusBars()
+          WindowInsets.Type.systemBars()
           | WindowInsets.Type.displayCutout()
-          | WindowInsets.Type.mandatorySystemGestures()
-          | WindowInsets.Type.navigationBars();
+          | WindowInsets.Type.mandatorySystemGestures();
       Insets insets = wi.getInsets(insets_types);
       insets_left = insets.left;
       insets_right = insets.right;

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -284,21 +284,7 @@ public class Keyboard2View extends View
       Insets insets = wi.getInsets(insets_types);
       insets_left = insets.left;
       insets_right = insets.right;
-      // On API 35, the keyboard is allowed to draw under the
-      // button-navigation bar but on lower APIs, it must be discounted from
-      // the width.
-      if (VERSION.SDK_INT < 35)
-      {
-        Insets nav_insets = wi.getInsets(WindowInsets.Type.navigationBars());
-        width -= nav_insets.left + nav_insets.right;
-        insets_left -= nav_insets.left;
-        insets_right -= nav_insets.right;
-      }
-      // [insets.bottom] doesn't take into account the buttons that appear in
-      // the gesture navigation bar when the IME is showing so ensure a minimum
-      // of margin is added.
-      if (VERSION.SDK_INT >= 35)
-        insets_bottom = Math.max(insets.bottom, _config.bottomInsetMin);
+      insets_bottom = Math.max(insets.bottom, _config.bottomInsetMin);
     }
     else
     {


### PR DESCRIPTION
Fix https://github.com/Julow/Unexpected-Keyboard/issues/946, https://github.com/Julow/Unexpected-Keyboard/issues/993, https://github.com/Julow/Unexpected-Keyboard/issues/1006 and https://github.com/Julow/Unexpected-Keyboard/issues/1017

This fixes the unwanted bottom margin appearing on OneUI 7 and perhaps other Android 15 based systems. 