### PR TITLE
Fix extra bottom margin when navbar buttons absent

### DIFF
--- a/res/values/values.xml
+++ b/res/values/values.xml
@@ -6,9 +6,6 @@
   <dimen name="emoji_text_size">28dp</dimen>
   <dimen name="clipboard_view_height">300dp</dimen>
   <dimen name="pref_button_size">28dp</dimen>
-  <!-- Margin needed to accomodate the gesture nav bar on Android 15. Found in
-  [core/res/res/values/dimens.xml]. -->
-  <dimen name="bottom_inset_min">48dp</dimen>
   <!-- Will be overwritten automatically by Gradle for the debug build variant -->
   <bool name="debug_logs">false</bool>
 </resources>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -81,7 +81,6 @@ public final class Config
   int current_layout_landscape;
   int current_layout_unfolded_portrait;
   int current_layout_unfolded_landscape;
-  public int bottomInsetMin;
 
   private Config(SharedPreferences prefs, Resources res, IKeyEventHandler h, Boolean foldableUnfolded)
   {
@@ -176,8 +175,6 @@ public final class Config
     current_layout_unfolded_landscape = _prefs.getInt("current_layout_unfolded_landscape", 0);
     circle_sensitivity = Integer.valueOf(_prefs.getString("circle_sensitivity", "2"));
     clipboard_history_enabled = _prefs.getBoolean("clipboard_history_enabled", false);
-    bottomInsetMin = Utils.is_navigation_bar_gestural(res) ?
-      (int)res.getDimension(R.dimen.bottom_inset_min) : 0;
   }
 
   public int get_current_layout()

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -267,20 +267,8 @@ public class Keyboard2View extends View
   public void onMeasure(int wSpec, int hSpec)
   {
     int width;
-    // LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS is set in [Keyboard2#updateSoftInputWindowLayoutParams].
-    // and keyboard is allowed do draw behind status/navigation bars
-    if (VERSION.SDK_INT >= 35)
-    {
-      WindowMetrics metrics =
-        ((WindowManager)getContext().getSystemService(Context.WINDOW_SERVICE))
-        .getCurrentWindowMetrics();
-      width = metrics.getBounds().width();
-    }
-    else
-    {
-      DisplayMetrics dm = getContext().getResources().getDisplayMetrics();
-      width = dm.widthPixels;
-    }
+    DisplayMetrics dm = getContext().getResources().getDisplayMetrics();
+    width = dm.widthPixels;
     _marginLeft = Math.max(_config.horizontal_margin, _insets_left);
     _marginRight = Math.max(_config.horizontal_margin, _insets_right);
     _marginBottom = _config.margin_bottom + _insets_bottom;
@@ -332,7 +320,6 @@ public class Keyboard2View extends View
     _insets_left = insets.left;
     _insets_right = insets.right;
     _insets_bottom = insets.bottom;
-    // insets_bottom = Math.max(insets.bottom, _config.bottomInsetMin);
     return WindowInsets.CONSUMED;
   }
 

--- a/srcs/juloo.keyboard2/Utils.java
+++ b/srcs/juloo.keyboard2/Utils.java
@@ -49,14 +49,4 @@ public final class Utils
       out.append(buff, 0, l);
     return out.toString();
   }
-
-  /** Whether the thin gesture-navigation bar is used.
-      https://stackoverflow.com/questions/36514167/how-to-really-get-the-navigation-bar-height-in-android
-       */
-  public static boolean is_navigation_bar_gestural(Resources res)
-  {
-    // core/java/android/view/WindowManagerPolicyConstants.java
-    int res_id = res.getIdentifier("config_navBarInteractionMode", "integer", "android");
-    return (res_id > 0 && res.getInteger(res_id) == 2);
-  }
 }


### PR DESCRIPTION
Fix the extra space that was appearing when the gesture-navigation bar didn't contain the "switch IME" or "close IME" buttons.
This was found on OneUI 7 with the two "keyboard key" related options turned off.