### PR TITLE
New Dvorak Layout

### DIFF
--- a/res/values/layouts.xml
+++ b/res/values/layouts.xml
@@ -42,6 +42,7 @@
     <item>latn_azerty_fr</item>
     <item>latn_bepo_fr</item>
     <item>latn_bone</item>
+    <item>latn_dvorak2</item>
     <item>latn_neo2</item>
     <item>latn_qwerty_apl</item>
     <item>latn_qwerty_az</item>
@@ -129,6 +130,7 @@
     <item>AZERTY (Français)</item>
     <item>BEPO (Français)</item>
     <item>Bone</item>
+    <item>Dvorak</item>
     <item>Neo 2</item>
     <item>QWERTY (APL)</item>
     <item>QWERTY (Azərbaycanca)</item>
@@ -216,6 +218,7 @@
     <item>@xml/latn_azerty_fr</item>
     <item>@xml/latn_bepo_fr</item>
     <item>@xml/latn_bone</item>
+    <item>@xml/latn_dvorak2</item>
     <item>@xml/latn_neo2</item>
     <item>@xml/latn_qwerty_apl</item>
     <item>@xml/latn_qwerty_az</item>

--- a/srcs/layouts/cyrl_yqukeng_tj.xml
+++ b/srcs/layouts/cyrl_yqukeng_tj.xml
@@ -33,7 +33,7 @@
     <key key0="с"  key7="&amp;" key8="\#" />
     <key key0="м" key7="|" key8="\\" />
     <key key0="и" key7="~" />
-    <key key0="т" key7="ц" />
+    <key key0="т" />
     <key key0="ӣ" key3="&lt;" key2="&gt;" />
     <key key0="б" key7="ъ" key8="ы" />
     <key key0="ю" key7="&quot;" key8="'"/>

--- a/srcs/layouts/latn_dvorak2.xml
+++ b/srcs/layouts/latn_dvorak2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<keyboard name="Dvorak" script="latin">
+  <row>
+    <key width="1.2" key0="shift" key7="esc" key4="delete"/>
+    <key width="0.9" key0="." key1="&quot;" key4="'" />
+    <key key0="p" key1="!" key2="loc accent_ring" key3="f11_placeholder" key4="," />
+    <key key0="y" key1="loc accent_grave" key3="f12_placeholder" key1="&lt;" key4="&gt;" />
+    <key key0="f" key3="loc €" key7="$" key8="%" />
+    <key key0="g" key7="=" key8="+" />
+    <key key0="c" key3="(" key2=")" key1="loc accent_trema" key4="loc accent_circonflexe" />
+    <key key0="r" key3="{" key2="}" />
+    <key key0="l" key4="loc £" key3="[" key2="]" />
+    <key width="0.9" key0="backspace" key7="\?" key3="/" />
+  </row>
+  <row>
+    <key key0="a" key2="loc accent_caron" key7="1" key3="loc å" key4="\#" />
+    <key key0="o" key2="loc accent_macron" key7="2" key3="loc accent_ogonek" />
+    <key key0="e" key7="3" key3="loc accent_dot_above" />
+    <key key0="u" key2="loc æ" key7="4" key3="loc accent_double_aigu" />
+    <key key0="i" key7="5" key8="|" />
+    <key key0="d" key7="6" key8="loc ð" />
+    <key key0="h" key7="7" key8="loc ȝ" />
+    <key key0="t" key7="8" key8="loc þ" />
+    <key key0="n" key7="9" key8="\\" />
+    <key key0="s" key7="0" key4="loc ß" key3="tab" />
+  </row>
+  <row>
+    <key key0=";" key7=":" />
+    <key key0="q" key1="loc accent_tilde" key7="~" key8="^" />
+    <key key0="j" key1="loc accent_aigu" />
+    <key key0="k" key1="loc ø" />
+    <key key0="x" key1="loc accent_cedille"/>
+    <key key0="b"/>
+    <key key0="m" key7="`" key8="&amp;" />
+    <key key0="w" key8="loc ƿ" />
+    <key key0="v" key8="\@" key7="*" />
+    <key key0="z" key7="-" key3="_"/>
+  </row>
+</keyboard>

--- a/srcs/layouts/latn_dvorak2.xml
+++ b/srcs/layouts/latn_dvorak2.xml
@@ -4,7 +4,7 @@
     <key width="1.2" key0="shift" key7="esc" key4="delete"/>
     <key width="0.9" key0="." key1="&quot;" key4="'" />
     <key key0="p" key1="!" key2="loc accent_ring" key3="f11_placeholder" key4="," />
-    <key key0="y" key1="loc accent_grave" key3="f12_placeholder" key1="&lt;" key4="&gt;" />
+    <key key0="y" key2="loc accent_grave" key3="f12_placeholder" key1="&lt;" key4="&gt;" />
     <key key0="f" key3="loc €" key7="$" key8="%" />
     <key key0="g" key7="=" key8="+" />
     <key key0="c" key3="(" key2=")" key1="loc accent_trema" key4="loc accent_circonflexe" />

--- a/srcs/layouts/latn_dvorak2.xml
+++ b/srcs/layouts/latn_dvorak2.xml
@@ -3,8 +3,8 @@
   <row>
     <key width="1.2" key0="shift" key7="esc" key4="delete"/>
     <key width="0.9" key0="." key1="&quot;" key4="'" />
-    <key key0="p" key1="!" key2="loc accent_ring" key3="f11_placeholder" key4="," />
-    <key key0="y" key2="loc accent_grave" key3="f12_placeholder" key1="&lt;" key4="&gt;" />
+    <key key0="p" key1="!" key2="loc accent_ring" key4="," />
+    <key key0="y" key2="loc accent_grave" key1="&lt;" key4="&gt;" />
     <key key0="f" key3="loc €" key7="$" key8="%" />
     <key key0="g" key7="=" key8="+" />
     <key key0="c" key3="(" key2=")" key1="loc accent_trema" key4="loc accent_circonflexe" />

--- a/srcs/layouts/latn_dvorak2.xml
+++ b/srcs/layouts/latn_dvorak2.xml
@@ -1,39 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <keyboard name="Dvorak" script="latin">
-  <row>
-    <key width="1.2" key0="shift" key7="esc" key4="delete"/>
-    <key width="0.9" key0="." key1="&quot;" key4="'" />
-    <key key0="p" key1="!" key2="loc accent_ring" key4="," />
-    <key key0="y" key2="loc accent_grave" key1="&lt;" key4="&gt;" />
-    <key key0="f" key3="loc €" key7="$" key8="%" />
-    <key key0="g" key7="=" key8="+" />
-    <key key0="c" key3="(" key2=")" key1="loc accent_trema" key4="loc accent_circonflexe" />
-    <key key0="r" key3="{" key2="}" />
-    <key key0="l" key4="loc £" key3="[" key2="]" />
-    <key width="0.9" key0="backspace" key7="\?" key3="/" />
-  </row>
-  <row>
-    <key key0="a" key2="loc accent_caron" key7="1" key3="loc å" key4="\#" />
-    <key key0="o" key2="loc accent_macron" key7="2" key3="loc accent_ogonek" />
-    <key key0="e" key7="3" key3="loc accent_dot_above" />
-    <key key0="u" key2="loc æ" key7="4" key3="loc accent_double_aigu" />
-    <key key0="i" key7="5" key8="|" />
-    <key key0="d" key7="6" key8="loc ð" />
-    <key key0="h" key7="7" key8="loc ȝ" />
-    <key key0="t" key7="8" key8="loc þ" />
-    <key key0="n" key7="9" key8="\\" />
-    <key key0="s" key7="0" key4="loc ß" key3="tab" />
-  </row>
-  <row>
-    <key key0=";" key7=":" />
-    <key key0="q" key1="loc accent_tilde" key7="~" key8="^" />
-    <key key0="j" key1="loc accent_aigu" />
-    <key key0="k" key1="loc ø" />
-    <key key0="x" key1="loc accent_cedille"/>
-    <key key0="b"/>
-    <key key0="m" key7="`" key8="&amp;" />
-    <key key0="w" key8="loc ƿ" />
-    <key key0="v" key8="\@" key7="*" />
-    <key key0="z" key7="-" key3="_"/>
-  </row>
+  <row>
+    <key width="1.2" key0="shift" key3="loc accent_tilde" key7="~" key4="esc" />
+    <key width="0.85" key0="," key1="&quot;" key4="'" />
+    <key width="0.85" key0="." key1="&lt;" key4="&gt;" />
+    <key key0="p" key7="!" key8="loc accent_ring" />
+    <key width="1.1" key0="y" key7="$" key8="loc accent_grave" />
+    <key width="1.1" key0="f" key7="loc €" key8="%" />
+    <key key0="g" key7="=" key8="+" />
+    <key key0="c" key3="(" key2=")" key1="loc accent_trema" key4="loc accent_circonflexe" />
+    <key key0="r" key3="{" key2="}" />
+    <key key0="l" key4="loc £" key3="[" key2="]" />
+    <key width="0.8" key0="/" key7="\?"  key3="^" />
+  </row>
+  <row>
+    <key width="1.02" key0="a" key2="loc accent_caron" key7="1" key3="loc å" key4="\#" />
+    <key width="1.02" key0="o" key2="loc accent_macron" key7="2" key3="loc accent_ogonek" key8="loc ø" />
+    <key width="1.02" key0="e" key7="3" key3="loc accent_dot_above" key8="loc ə" />
+    <key width="1.02" key0="u" key8="loc æ" key7="4" key3="loc accent_double_aigu" />
+    <key width="1.01" key0="i" key7="5" key8="loc ı" />
+    <key width="1.01" key0="d" key7="6" key8="loc ð" />
+    <key key0="h" key7="7" key8="ȝ" />
+    <key key0="t" key7="8" key8="loc þ" />
+    <key key0="n" key7="9" key8="\\" />
+    <key key0="s" key7="0" key4="loc ß" />
+    <key width="0.8" key0="-" key3="_" key7="tab" />
+  </row>
+  <row>
+    <key width="0.88" key0=";" key7=":" />
+    <key key0="q" key7="loc shareText" />
+    <key key0="j" key7="loc accent_aigu" />
+    <key key0="k" key7="|" />
+    <key width="0.98" key0="x" key7="loc accent_cedille"/>
+    <key width="0.98" key0="b" key7="&amp;" />
+    <key width="0.96" key0="m" key7="`" />
+    <key width="0.96" key0="w" key7="ƿ" />
+    <key width="0.96" key0="v" key7="*" />
+    <key width="0.96" key0="z" key7="\@" />
+    <key width="1.2" key0="backspace" key7="delete"/>
+  </row>
 </keyboard>


### PR DESCRIPTION
Yeah, so this new version of the Dvorak layout is a lot better. The alignment between the rows is way more natural and closer to how it is on actual keyboards. Certain punctuation keys are just more accessible this way too. I encourage _replacing_ the existing one with this one, but I prepared it as an alternate version instead for now, in case there's any reason to hold on to the old one. So they can exist side-by-side.