### PR TITLE
Fix very small label size on 11+ columns layouts

### DIFF
--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -276,11 +276,11 @@ public class Keyboard2View extends View
     _tc = new Theme.Computed(_theme, _config, _keyWidth, _keyboard);
     // Compute the size of labels based on the width or the height of keys. The
     // margin around keys is taken into account. Keys normal aspect ratio is
-    // assumed to be 3/2. It's generally more, the width computation is useful
-    // when the keyboard is unusually high.
+    // assumed to be 3/2 for a 10 columns layout. It's generally more, the
+    // width computation is useful when the keyboard is unusually high.
     float labelBaseSize = Math.min(
         _tc.row_height - _tc.vertical_margin,
-        _keyWidth * 3/2 - _tc.horizontal_margin
+        (width / 10 - _tc.horizontal_margin) * 3/2
         ) * _config.characterSize;
     _mainLabelSize = labelBaseSize * _config.labelTextSize;
     _subLabelSize = labelBaseSize * _config.sublabelTextSize;


### PR DESCRIPTION
Fix https://github.com/Julow/Unexpected-Keyboard/issues/1038

The label size was computed against the width of keys on the keyboard, which resulted in a different label size on different layouts. Notably, it made the labels very small on a 11 columns layout and relatively larger on the numpad.

The label size is now computed against a baseline of 1/10 of the width of the screen.