### PR TITLE
Fix alternate keyboard layouts rendering behind navbar on some devices.

### DIFF
--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -295,6 +295,7 @@ public class Keyboard2 extends InputMethodService
       ((ViewGroup)parent).removeView(v);
     super.setInputView(v);
     updateSoftInputWindowLayoutParams();
+    v.requestApplyInsets();
   }
 
 


### PR DESCRIPTION
When switching keyboard layouts to emoji or clipboard, for some reason, the insets are not always dispatched, which causes the keyboard to render behind the IME buttons.
In my testing this happens on Android 16 and 15 QPR2, but not on Android 12. Not sure if it's an Android bug or not.

The fix however is simple enough on the app side - just request an inset dispatch every time the IME view changes, so it shouldn't cause any issues on other devices.

| <img width="864" height="1920" alt="Screenshot_20250727-005409" src="https://github.com/user-attachments/assets/5af5f4ef-6a92-4fff-a1db-325975ac6400" /> | <img width="864" height="1920" alt="Screenshot_20250727-005424" src="https://github.com/user-attachments/assets/6fa0c521-66fb-43b6-86a6-eb1ec911fc5d" /> |
|--|--|
