### PR TITLE
Make history duration configurable

### DIFF
--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">Jak bude klávesa pro přepnutí klávesnice reagovat</string>
     <string name="pref_vibrate_custom">Vlastní vibrace</string>
     <string name="pref_vibrate_duration_title">Síla vibrace</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">Odebrat ze schránky?</string>
     <string name="clipboard_remove_confirmed">Ano</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">Verhalten der Tastaturumschalttaste</string>
     <string name="pref_vibrate_custom">Benutzerdefinierte Vibration</string>
     <string name="pref_vibrate_duration_title">Vibrationsstärke</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <!-- <string name="clipboard_remove_confirm">Remove this clipboard item?</string> -->
     <string name="clipboard_remove_confirmed">Ja</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">Comportamiento de la tecla para cambiar diseño</string>
     <string name="pref_vibrate_custom">Vibración personalizada</string>
     <string name="pref_vibrate_duration_title">Intensidad de vibración</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">¿Sacar este portapapeles?</string>
     <string name="clipboard_remove_confirmed">Sí</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">رفتار کلید تغییردهنده صفحه کلید</string>
     <!-- <string name="pref_vibrate_custom">Custom vibration</string> -->
     <!-- <string name="pref_vibrate_duration_title">Vibration intensity</string> -->
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <!-- <string name="clipboard_remove_confirm">Remove this clipboard item?</string> -->
     <!-- <string name="clipboard_remove_confirmed">Yes</string> -->
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-fil/strings.xml
+++ b/res/values-fil/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">Ugali ng key sa pagpapalit ng keyboard</string>
     <string name="pref_vibrate_custom">Custom na vibration</string>
     <string name="pref_vibrate_duration_title">Lakas ng vibration</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">Tanggalin ito sa clipboard?</string>
     <string name="clipboard_remove_confirmed">Oo</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">Supprimer ce presse-papiers ?</string>
     <string name="clipboard_remove_confirmed">Oui</string>
     <string name="toast_no_voice_input">Pas d\'application de saisie vocale</string>
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -49,7 +49,7 @@
     <!-- <string name="pref_switch_input_immediate_summary">Behavior of the keyboard-switching key</string> -->
     <!-- <string name="pref_vibrate_custom">Custom vibration</string> -->
     <!-- <string name="pref_vibrate_duration_title">Vibration intensity</string> -->
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <!-- <string name="clipboard_remove_confirm">Remove this clipboard item?</string> -->
     <!-- <string name="clipboard_remove_confirmed">Yes</string> -->
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">Perilaku tombol penggantian keyboard</string>
     <string name="pref_vibrate_custom">Getaran kustom</string>
     <string name="pref_vibrate_duration_title">Intensitas getaran</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">Hapus clipboard ini?</string>
     <string name="clipboard_remove_confirmed">Ya</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">Comportamento del tasto di cambio tastiera</string>
     <string name="pref_vibrate_custom">Vibrazione personalizzata</string>
     <string name="pref_vibrate_duration_title">Intensita` della vibrazione</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">Eliminare questi appunti?</string>
     <string name="clipboard_remove_confirmed">Si</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">キーボード切替キーの挙動</string>
     <string name="pref_vibrate_custom">キーボード独自の振動設定</string>
     <string name="pref_vibrate_duration_title">振動の時間</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">クリップボードから削除しますか?</string>
     <string name="clipboard_remove_confirmed">はい</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">키보드 전환 키의 동작 방식입니다.</string>
     <string name="pref_vibrate_custom">사용자 정의 진동</string>
     <string name="pref_vibrate_duration_title">진동 강도</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">이 클립보드를 제거하시겠습니까?</string>
     <string name="clipboard_remove_confirmed">예</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-lv/strings.xml
+++ b/res/values-lv/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">Tastatūras pārslēgšanas taustiņa uzvedība</string>
     <string name="pref_vibrate_custom">Pielāgota trīcēšana</string>
     <string name="pref_vibrate_duration_title">Trīcēšanas stiprums</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">Noņemt šo starpliktuves vienumu?</string>
     <string name="clipboard_remove_confirmed">Jā</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">Gedrag van de toestsenbord-wissel-toets</string>
     <string name="pref_vibrate_custom">Aangepaste trilling</string>
     <string name="pref_vibrate_duration_title">Trillingsintensiteit</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">Verwijder dit klembord?</string>
     <string name="clipboard_remove_confirmed">Ja</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">Działanie klawisza przełączającego klawiaturę</string>
     <string name="pref_vibrate_custom">Własna wibracja</string>
     <string name="pref_vibrate_duration_title">Intensywność wibracji</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">Usunąć ten element ze schowka?</string>
     <string name="clipboard_remove_confirmed">Tak</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">Comportamento da tecla de troca de teclado</string>
     <string name="pref_vibrate_custom">Vibração personalizada</string>
     <string name="pref_vibrate_duration_title">Intensidade da vibração</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">Remover esta cópia?</string>
     <string name="clipboard_remove_confirmed">Sim</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">Comportamentul tastei pentru schimbarea tastaturii</string>
     <!-- <string name="pref_vibrate_custom">Custom vibration</string> -->
     <!-- <string name="pref_vibrate_duration_title">Vibration intensity</string> -->
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <!-- <string name="clipboard_remove_confirm">Remove this clipboard item?</string> -->
     <!-- <string name="clipboard_remove_confirmed">Yes</string> -->
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">Удалить этот буфер обмена?</string>
     <string name="clipboard_remove_confirmed">Да</string>
     <string name="toast_no_voice_input">Приложение для голосового ввода не установлено</string>
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">Klavye değistirme tuşunun davranışını belirler</string>
     <string name="pref_vibrate_custom">Özel titreşim</string>
     <string name="pref_vibrate_duration_title">Titreşim yoğunluğu</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">Bu panodan silinsin mi?</string>
     <string name="clipboard_remove_confirmed">Evet</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">Поведінка клавіші перемикання клавіатури</string>
     <string name="pref_vibrate_custom">Спеціальна вібрація</string>
     <string name="pref_vibrate_duration_title">Інтенсивність вібрації</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">Видалити цей буфер обміну?</string>
     <string name="clipboard_remove_confirmed">Так</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -49,7 +49,7 @@
     <!-- <string name="pref_switch_input_immediate_summary">Behavior of the keyboard-switching key</string> -->
     <!-- <string name="pref_vibrate_custom">Custom vibration</string> -->
     <!-- <string name="pref_vibrate_duration_title">Vibration intensity</string> -->
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <!-- <string name="clipboard_remove_confirm">Remove this clipboard item?</string> -->
     <!-- <string name="clipboard_remove_confirmed">Yes</string> -->
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_switch_input_immediate_summary">切换键盘按钮的行为</string>
     <string name="pref_vibrate_custom">自定义振动</string>
     <string name="pref_vibrate_duration_title">振动强度</string>
-    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates and phone numbers</string> -->
+    <!-- <string name="pref_number_entry_title">Layout when typing numbers, dates, and phone numbers</string> -->
     <!-- <string name="pref_number_entry_layout_pin">PIN Entry</string> -->
     <!-- <string name="pref_number_entry_layout_number">Number pane</string> -->
     <!-- <string name="pref_number_entry_layout_normal">Use the main layout</string> -->
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">确定移除此剪贴内容？</string>
     <string name="clipboard_remove_confirmed">确定</string>
     <!-- <string name="toast_no_voice_input">No voice typing app installed</string> -->
+    <!-- <string name="pref_category_clipboard">Clipboard</string> -->
+    <!-- <string name="pref_clipboard_history_duration">Clipboard memory duration</string> -->
+    <!-- <string name="pref_clipboard_history_duration_value">%s min</string> -->
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -135,4 +135,7 @@
     <string name="clipboard_remove_confirm">Remove this clipboard item?</string>
     <string name="clipboard_remove_confirmed">Yes</string>
     <string name="toast_no_voice_input">No voice typing app installed</string>
+    <string name="pref_category_clipboard">Clipboard</string>
+    <string name="pref_clipboard_history_duration">Clipboard memory duration</string>
+    <string name="pref_clipboard_history_duration_value">%s min</string>
 </resources>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -58,4 +58,7 @@
     <juloo.keyboard2.prefs.IntSlideBarPreference android:key="custom_border_radius" android:title="@string/pref_corners_radius_title" android:summary="%s%%" android:defaultValue="0" min="0" max="100" android:dependency="border_config"/>
     <juloo.keyboard2.prefs.SlideBarPreference android:key="custom_border_line_width" android:title="@string/pref_border_width_title" android:summary="%sdp" android:defaultValue="0" min="0" max="5" android:dependency="border_config"/>
   </PreferenceCategory>
+  <PreferenceCategory android:title="@string/pref_category_clipboard">
+    <juloo.keyboard2.prefs.IntSlideBarPreference android:key="clipboard_history_duration" android:title="@string/pref_clipboard_history_duration" android:summary="@string/pref_clipboard_history_duration_value" android:defaultValue="5" min="1" max="600" />
+   </PreferenceCategory>
 </PreferenceScreen>

--- a/srcs/juloo.keyboard2/ClipboardHistoryService.java
+++ b/srcs/juloo.keyboard2/ClipboardHistoryService.java
@@ -5,8 +5,10 @@ import android.content.ClipboardManager;
 import android.content.Context;
 import android.os.Build.VERSION;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public final class ClipboardHistoryService
 {
@@ -50,8 +52,6 @@ public final class ClipboardHistoryService
       gives a sense to the user that the history is not persisted and can be
       forgotten as soon as the app stops. */
   public static final int MAX_HISTORY_SIZE = 6;
-  /** Time in ms until history entries expire. */
-  public static final long HISTORY_TTL_MS = 5 * 60 * 1000;
 
   static ClipboardHistoryService _service = null;
   static ClipboardPasteCallback _paste_callback = null;
@@ -150,6 +150,10 @@ public final class ClipboardHistoryService
     }
   }
 
+  int get_history_ttl_minutes() {
+    return Config.globalConfig().clipboard_history_duration;
+  }
+
   final class SystemListener implements ClipboardManager.OnPrimaryClipChangedListener
   {
     public SystemListener() {}
@@ -171,7 +175,7 @@ public final class ClipboardHistoryService
     public HistoryEntry(String c)
     {
       content = c;
-      expiry_timestamp = System.currentTimeMillis() + HISTORY_TTL_MS;
+      expiry_timestamp = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(_service.get_history_ttl_minutes());
     }
   }
 

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -70,6 +70,7 @@ public final class Config
   public boolean borderConfig;
   public int circle_sensitivity;
   public boolean clipboard_history_enabled;
+  public int clipboard_history_duration;
 
   // Dynamically set
   public boolean shouldOfferVoiceTyping;
@@ -180,6 +181,7 @@ public final class Config
     current_layout_wide = _prefs.getInt("current_layout_landscape", 0);
     circle_sensitivity = Integer.valueOf(_prefs.getString("circle_sensitivity", "2"));
     clipboard_history_enabled = _prefs.getBoolean("clipboard_history_enabled", false);
+    clipboard_history_duration = _prefs.getInt("clipboard_history_duration", 5);
 
     float screen_width_dp = dm.widthPixels / dm.density;
     wide_screen = screen_width_dp >= WIDE_DEVICE_THRESHOLD;


### PR DESCRIPTION
PR adds a setting that makes clipboard history duration configurable, instead of using hardcoded value of 5 minutes