### PR TITLE
gradle: Disable sync_translations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,8 +89,6 @@ android {
   }
 
   lintOptions {
-    // Translation are already checked by 'syncTranslations'
-    disable 'MissingTranslation'
   }
 }
 
@@ -121,7 +119,6 @@ tasks.register('genEmojis') {
 tasks.withType(Test).configureEach {
   dependsOn 'genLayoutsList'
   dependsOn 'checkKeyboardLayouts'
-  dependsOn 'syncTranslations'
   dependsOn 'compileComposeSequences'
 }
 
@@ -138,14 +135,6 @@ tasks.register('checkKeyboardLayouts') {
   exec {
     workingDir = projectDir
     commandLine("python", "check_layout.py")
-  }
-}
-
-tasks.register('syncTranslations') {
-  println "\nUpdating translations"
-  exec {
-    workingDir = projectDir
-    commandLine "python", "sync_translations.py"
   }
 }
 

--- a/sync_translations.py
+++ b/sync_translations.py
@@ -1,5 +1,5 @@
 import xml.etree.ElementTree as ET
-import glob, os
+import glob, os, sys
 
 # Edit every strings.xml files:
 # - Add missing translation as comments
@@ -86,6 +86,10 @@ def sync_metadata(value_dir, strings):
     sync_meta_file("title.txt", ("app_name_release", None))
     sync_meta_file("short_description.txt", ("short_description", None))
     sync_meta_file("full_description.txt", ("store_description", None))
+
+if len(sys.argv) < 2 or sys.argv[1] != "sync":
+    print("Syncing of translation files is no longer needed. Run with 'sync_translation.py sync' to do it anyway.")
+    exit(1)
 
 baseline = parse_strings_file("res/values/strings.xml")
 


### PR DESCRIPTION
The diffs created by sync_translations.py creates conflicts with the changes made on Weblate. It is disable to make merging translations from Weblate easier.