### PR TITLE
add Everforest Light theme

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -42,6 +42,7 @@
     <item>@string/pref_theme_e_monetlight</item>
     <item>@string/pref_theme_e_monetdark</item>
     <item>@string/pref_theme_e_rosepine</item>
+    <item>@string/pref_theme_e_everforestlight</item>
   </string-array>
   <string-array name="pref_theme_values">
     <item>system</item>
@@ -57,6 +58,7 @@
     <item>monetlight</item>
     <item>monetdark</item>
     <item>rosepine</item>
+    <item>everforestlight</item>
   </string-array>
   <string-array name="pref_swipe_dist_entries">
     <item>@string/pref_swipe_dist_e_very_short</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="pref_theme_e_monetlight">Monet (Light)</string>
     <string name="pref_theme_e_monetdark">Monet (Dark)</string>
     <string name="pref_theme_e_rosepine">Rosé Pine</string>
+    <string name="pref_theme_e_everforestlight">Everforest Light</string>
     <string name="pref_swipe_dist_e_very_short">Very short</string>
     <string name="pref_swipe_dist_e_short">Short</string>
     <string name="pref_swipe_dist_e_default">Normal</string>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -222,4 +222,19 @@
     <item name="emoji_button_bg">#26233a</item>
     <item name="emoji_color">#e0def4</item>
   </style>
+  <style name="EverforestLight" parent="BaseTheme">
+    <item name="android:isLightTheme">true</item>
+    <item name="colorKeyboard">#f8f5e4</item>
+    <item name="colorKey">#e5e2d1</item>
+    <item name="colorKeyActivated">#dbe0b6</item>
+    <item name="colorLabel">#5c6a72</item>
+    <item name="colorLabelActivated">#828812</item>
+    <item name="colorLabelLocked">#325e64</item>
+    <item name="colorSubLabel">#7b8478</item>
+    <item name="keyBorderWidth">0.0dip</item>
+    <item name="keyBorderWidthActivated">0.0dip</item>
+    <item name="emoji_button_bg">?colorKeyActivated</item>
+    <item name="emoji_color">?colorLabel</item>
+    <item name="clipboard_divider_color">?colorKey</item>
+ </style>
 </resources>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -255,6 +255,7 @@ public final class Config
           return R.style.MonetLight;
         return R.style.MonetDark;
       case "rosepine": return R.style.RosePine;
+      case "everforestlight": return R.style.EverforestLight;
       default:
       case "system":
         if ((night_mode & Configuration.UI_MODE_NIGHT_NO) != 0)


### PR DESCRIPTION
Why this theme specifically?
Because it is a soothing light theme available on the helix editor.
For Light mode editing having both editor and keyboard on the same thing makes ux more soothing.