### PR TITLE
Add the `<gesture/>` modmap

### DIFF
--- a/doc/Custom-layouts.md
+++ b/doc/Custom-layouts.md
@@ -134,7 +134,12 @@ This means that when the Fn modifier is on, the key `before` is changed into `af
 ```
 This means that when the Ctrl modifier is on, the key `before` is changed into `after`. The `<ctrl />` mapping is special in that the Ctrl modifier is applied to `after` after the mapping.
 
-The clockwise circle and the round-trip gestures are affected by both `<shift />` and `<fn />` mappings. The Shift mappings are used first and if that did not modify the key, the Fn mappings are used instead.
+```xml
+  <gesture a="before" b="after"/>
+```
+Change the result of the clockwise circle and the round-trip gestures for the key denoted by `before`.
+
+The clockwise circle and the round-trip gestures are also affected by `<shift />` and `<fn />` mappings. If no `<gesture />` mappings are set, the Shift mappings are used first and if that did not modify the key, the Fn mappings are used instead.
 
 ### Examples
 ① Turkish keyboards use the Latin alphabet, but when "i" is shifted, it should produce "İ". This is achieved with the following mapping: 

--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -367,7 +367,14 @@ public final class KeyModifier
   /** Modify a key affected by a round-trip or a clockwise circle gesture. */
   private static KeyValue apply_gesture(KeyValue k)
   {
-    KeyValue modified = apply_shift(k);
+    KeyValue modified;
+    if (_modmap != null)
+    {
+      modified = _modmap.get(Modmap.M.Gesture, k);
+      if (modified != null)
+        return modified;
+    }
+    modified = apply_shift(k);
     if (modified != null && !modified.equals(k))
       return modified;
     modified = apply_fn(k);

--- a/srcs/juloo.keyboard2/KeyboardData.java
+++ b/srcs/juloo.keyboard2/KeyboardData.java
@@ -570,8 +570,9 @@ public final class KeyboardData
         case "shift": m = Modmap.M.Shift; break;
         case "fn": m = Modmap.M.Fn; break;
         case "ctrl": m = Modmap.M.Ctrl; break;
+        case "gesture": m = Modmap.M.Gesture; break;
         default:
-          throw error(parser, "Expecting tag <shift> or <fn>, got <" +
+          throw error(parser, "Expecting tag <shift>, <fn> or <gesture> but got <" +
               parser.getName() + ">");
       }
       parse_modmap_mapping(parser, mm, m);

--- a/srcs/juloo.keyboard2/Modmap.java
+++ b/srcs/juloo.keyboard2/Modmap.java
@@ -7,7 +7,7 @@ import java.util.TreeMap;
 /** Stores key combinations that are applied by [KeyModifier]. */
 public final class Modmap
 {
-  public enum M { Shift, Fn, Ctrl }
+  public enum M { Shift, Fn, Ctrl, Gesture }
 
   Map<KeyValue, KeyValue>[] _map;
 


### PR DESCRIPTION
Fix https://github.com/Julow/Unexpected-Keyboard/issues/1082

It allows overriding the result of the circle and round-trip gestures without modifying the Shift and Fn modmaps.