### PR TITLE
Use the `<fn />` mappings first when typing a gesture

### DIFF
--- a/doc/Custom-layouts.md
+++ b/doc/Custom-layouts.md
@@ -134,7 +134,7 @@ This means that when the Fn modifier is on, the key `before` is changed into `af
 ```
 This means that when the Ctrl modifier is on, the key `before` is changed into `after`. The `<ctrl />` mapping is special in that the Ctrl modifier is applied to `after` after the mapping.
 
-The clockwise circle and the round-trip gestures are affected by both `<shift />` and `<fn />` mappings. The Shift mappings are used first and if that did not modify the key, the Fn mappings are used instead.
+The clockwise circle and the round-trip gestures are affected by the `<fn />` mappings. Otherwise, they are defined by the Shift mappings (including the `<shift />` mappings), then, if that did not modify the key, the builtin Fn mappings are used instead.
 
 ### Examples
 ① Turkish keyboards use the Latin alphabet, but when "i" is shifted, it should produce "İ". This is achieved with the following mapping: 

--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -368,6 +368,13 @@ public final class KeyModifier
   private static KeyValue apply_gesture(KeyValue k)
   {
     KeyValue modified = apply_shift(k);
+    if (_modmap != null)
+    {
+      modified = _modmap.get(Modmap.M.Fn, k);
+      if (modified != null)
+        return modified;
+    }
+    modified = apply_shift(k);
     if (modified != null && !modified.equals(k))
       return modified;
     modified = apply_fn(k);


### PR DESCRIPTION
Alternative fix for https://github.com/Julow/Unexpected-Keyboard/issues/1082

This allows assigning mappings to letters without changing the Shift mappings and making uppercase impossible to type.

For gestures, the Shift modifier is still applied first, unless a custom mapping for <fn/> is set for the key.