### PR TITLE
Python script encoding fix

### DIFF
--- a/check_layout.py
+++ b/check_layout.py
@@ -116,7 +116,7 @@ def check_layout(layout):
 # Fill 'known_keys', which is used for some checks
 def parse_known_keys():
     global known_keys
-    with open("srcs/juloo.keyboard2/KeyValue.java", "r") as f:
+    with open("srcs/juloo.keyboard2/KeyValue.java", "r", encoding="utf-8") as f:
         known_keys = set(
                 ( m.group(1) for m in re.finditer('case "([^"]+)":', f.read()) )
                 )
@@ -134,6 +134,6 @@ for fname in sorted(glob.glob("srcs/layouts/*.xml")):
     else:
         check_layout(layout)
 
-with open("check_layout.output", "w") as out:
+with open("check_layout.output", "w", encoding="utf-8") as out:
     for w in warnings:
         print(w, file=out)

--- a/gen_layouts.py
+++ b/gen_layouts.py
@@ -57,8 +57,8 @@ def generate_arrays(out, layouts):
     root.append(mk_array("string-array", "pref_layout_entries", entries_items))
     root.append(mk_array("integer-array", "layout_ids", ids_items))
     XML.indent(root)
-    XML.ElementTree(element=root).write(out, encoding="unicode", xml_declaration=True)
+    XML.ElementTree(element=root).write(out, encoding="utf-8", xml_declaration=True)
 
 layouts = sort_layouts(read_layouts(glob.glob("srcs/layouts/*.xml")))
-with open("res/values/layouts.xml", "w") as out:
+with open("res/values/layouts.xml", "wb") as out:
     generate_arrays(out, layouts)

--- a/res/values/layouts.xml
+++ b/res/values/layouts.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <resources>
   <!-- DO NOT EDIT. This file is generated, run 'gradle genLayoutsList'. -->
   <string-array name="pref_layout_values">


### PR DESCRIPTION
Whilst I was trying to add a keyboard layout I encountered issues with the python scripts used to generate the layout lists.

On my setup the open() and xml.elementtree(),write() defaulted to using CP1252, explicitly stating the encoding as UTF-8 in the scripts fixed this.