### PR TITLE
Allow smaller row height in custom layouts

### DIFF
--- a/srcs/juloo.keyboard2/KeyboardData.java
+++ b/srcs/juloo.keyboard2/KeyboardData.java
@@ -325,7 +325,7 @@ public final class KeyboardData
       float kw = 0.f;
       for (Key k : keys_) kw += k.width + k.shift;
       keys = keys_;
-      height = Math.max(h, 0.5f);
+      height = Math.max(h, keys_.size() == 0 ? 0.0f : 0.5f);
       shift = Math.max(s, 0f);
       keysWidth = kw;
     }


### PR DESCRIPTION
Fix https://github.com/Julow/Unexpected-Keyboard/issues/1098

The height of row set with `<row height="...">` cannot be lower than 0.5 to avoid rendering problems.
This restriction is not necessary when the row has no key and is lifted in this case.