### PR TITLE
Improve recognizability of latn_dvorak.xml

### DIFF
--- a/srcs/layouts/latn_dvorak.xml
+++ b/srcs/layouts/latn_dvorak.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <keyboard name="Dvorak" script="latin">
   <row>
-    <key key0="shift" width="1.5" key2="loc esc" key4="loc tab"/>
-    <key key0="p" key1="loc accent_ring" key2="." key3="&lt;"/>
-    <key key0="y" key1="loc accent_grave" key2="," key3="&gt;"/>
+    <key shift="0.5" key0="," key2="'" key3="&quot;"/>
+    <key key0="." key3="&lt;" key4="&gt;"/>
+    <key key0="p" key1="loc accent_tilde" key2="`" key3="~"/>
+    <key key0="y" key1="loc accent_grave"/>
     <key key0="f" key4="loc €"/>
-    <key key0="g" key2="\\" key3="|"/>
+    <key key0="g" key1="loc accent_ring"/>
     <key key0="c" key1="loc accent_trema" key2="loc accent_circonflexe" key3="{" key4="}"/>
     <key key0="r" key3="[" key4="]"/>
-    <key key0="l" key2="=" key3="+" key4="loc £"/>
-    <key key0="backspace" key2="delete" width="1.5"/>
+    <key key0="l" key2="/" key3="\?" key4="loc £"/>
+    <key key0="backspace" key2="delete"/>
   </row>
   <row>
     <key key0="a" key2="1" key3="loc å" key4="!"/>
@@ -21,17 +22,18 @@
     <key key0="h" key2="7" key3="&amp;"/>
     <key key0="t" key2="8" key3="*"/>
     <key key0="n" key2="9" key3="(" key4=")"/>
-    <key key0="s" key2="0" key3="loc ß"/>
+    <key key0="s" key1="loc ß" key2="0" key3="-"/>
   </row>
   <row>
-    <key key0="q" shift="0.5" key1="loc accent_tilde" key2="`" key3="~"/>
-    <key key0="j" key1="loc accent_aigu" key2="'" key3="&quot;"/>
-    <key key0="k" key1="loc ø" key2=";" key3=":"/>
+    <key width="1.5" key0="shift" key2="loc esc" key4="loc tab"/>
+    <key key0="q" key1="loc accent_aigu" key2=";" key3=":"/>
+    <key key0="j"/>
+    <key key0="k" key1="loc ø"/>
     <key key0="x" key1="loc accent_cedille"/>
     <key key0="b"/>
-    <key key0="m" key2="/" key3="\?"/>
-    <key key0="w"/>
-    <key key0="v"/>
-    <key key0="z" key2="-" key3="_"/>
+    <key key0="m"/>
+    <key key0="w" key2="\\" key3="|"/>
+    <key key0="v" key2="=" key3="+"/>
+    <key key0="z" key3="_"/>
   </row>
 </keyboard>


### PR DESCRIPTION
<img width="1080" height="624" alt="Screenshot_20251212-222633_DuckDuckGo" src="https://github.com/user-attachments/assets/0986cb05-c33f-4e42-b361-4d21a568b1dc" />
The old layout had a 1.5-unit stagger left on the top row, harming recognizability and muscle memory. It also had the . and , in the opposite order than expected.

<img width="1080" height="615" alt="Screenshot_20251212-222513_DuckDuckGo" src="https://github.com/user-attachments/assets/2e67e7db-f72c-4e98-86a9-952777983ccd" />
My modified Dvorak places keys and common symbols in their expected positions with a 0.5-unit stagger.