### PR TITLE
AZERTY: Make sure the accents are available

### DIFF
--- a/srcs/layouts/latn_azerty_fr.xml
+++ b/srcs/layouts/latn_azerty_fr.xml
@@ -17,11 +17,11 @@
   <row>
     <key key0="q" key2="loc tab"/>
     <key key0="s" key3="loc ß"/>
-    <key key0="d" key1="loc accent_grave" key2="é" key3="loc accent_aigu"/>
+    <key key0="d" key1="accent_grave" key2="é" key3="accent_aigu"/>
     <key key0="f" key3="{" key4="}"/>
-    <key key0="g" key3="[" key4="]"/>
+    <key key0="g" key2="ê" key3="[" key4="]"/>
     <key key0="h" key3="=" key4="+"/>
-    <key key0="j" key1="loc accent_trema" key2="loc accent_circonflexe" key3="^"/>
+    <key key0="j" key1="accent_trema" key2="accent_circonflexe" key3="^"/>
     <key key0="k" key1="è" key2="€" key3="$"/>
     <key key0="l" key2="%"/>
     <key key0="m" key3="*"/>


### PR DESCRIPTION
Remove the `loc` prefix for important accent dead keys and add ê.