### PR TITLE
Avoid loops in modmaps

### DIFF
--- a/srcs/juloo.keyboard2/KeyEventHandler.java
+++ b/srcs/juloo.keyboard2/KeyEventHandler.java
@@ -420,7 +420,7 @@ public final class KeyEventHandler
   void evaluate_macro_loop(final KeyValue[] keys, int i, Pointers.Modifiers mods, final boolean autocap_paused)
   {
     boolean should_delay = false;
-    KeyValue kv = KeyModifier.modify(keys[i], mods);
+    KeyValue kv = KeyModifier.modify_no_modmap(keys[i], mods);
     if (kv != null)
     {
       if (kv.hasFlagsAny(KeyValue.FLAG_LATCH))

--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -29,6 +29,17 @@ public final class KeyModifier
     return r;
   }
 
+  /** Like [modify] but do not apply user modmaps. Used when evaluating macros
+      to avoid loops. */
+  public static KeyValue modify_no_modmap(KeyValue k, Pointers.Modifiers mods)
+  {
+    Modmap saved = _modmap;
+    _modmap = null;
+    KeyValue r = modify(k, mods);
+    _modmap = saved;
+    return r;
+  }
+
   public static KeyValue modify(KeyValue k, KeyValue mod)
   {
     switch (mod.getKind())


### PR DESCRIPTION
Fix https://github.com/Julow/Unexpected-Keyboard/issues/1166

It was possible to define a loop that would crash the app with the following modmap:

    <ctrl a="left" b="left:ctrl,left"/>

With this change, modmap are not taken into account while evaluating macros. The modmap above modifies ctrl+left into ctrl+left.