### PR TITLE
feat: Split keyboard layout

### DIFF
--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -247,15 +247,14 @@ public class Keyboard2View extends View
     float x = _marginLeft;
     if (row == null || tx < x)
       return null;
+    
     for (KeyboardData.Key key : row.keys)
     {
-      float xLeft = x + key.shift * _keyWidth;
-      float xRight = xLeft + key.width * _keyWidth;
-      if (tx < xLeft)
-        return null;
-      if (tx < xRight)
+      x += key.shift * _keyWidth;
+      float keyW = key.width * _keyWidth;
+      if (tx >= x && tx < x + keyW)
         return key;
-      x = xRight;
+      x += keyW;
     }
     return null;
   }
@@ -275,6 +274,7 @@ public class Keyboard2View extends View
     _marginRight = Math.max(_config.horizontal_margin, _insets_right);
     _marginBottom = _config.margin_bottom + _insets_bottom;
     width += _insets_left + _insets_right;
+
     _keyWidth = (width - _marginLeft - _marginRight) / _keyboard.keysWidth;
     _tc = new Theme.Computed(_theme, _config, _keyWidth, _keyboard);
     // Compute the size of labels based on the width or the height of keys. The
@@ -350,6 +350,7 @@ public class Keyboard2View extends View
       y += row.shift * _tc.row_height;
       float x = _marginLeft + _tc.margin_left;
       float keyH = row.height * _tc.row_height - _tc.vertical_margin;
+
       for (KeyboardData.Key k : row.keys)
       {
         x += k.shift * _keyWidth;
@@ -359,10 +360,10 @@ public class Keyboard2View extends View
         drawKeyFrame(canvas, x, y, keyW, keyH, tc_key);
         if (k.keys[0] != null)
           drawLabel(canvas, k.keys[0], keyW / 2f + x, y, keyH, isKeyDown, tc_key);
-        for (int i = 1; i < 9; i++)
+        for (int j = 1; j < 9; j++)
         {
-          if (k.keys[i] != null)
-            drawSubLabel(canvas, k.keys[i], x, y, keyW, keyH, i, isKeyDown, tc_key);
+          if (k.keys[j] != null)
+            drawSubLabel(canvas, k.keys[j], x, y, keyW, keyH, j, isKeyDown, tc_key);
         }
         drawIndication(canvas, k, x, y, keyW, keyH, _tc);
         x += _keyWidth * k.width;

--- a/srcs/juloo.keyboard2/LayoutModifier.java
+++ b/srcs/juloo.keyboard2/LayoutModifier.java
@@ -25,6 +25,11 @@ public final class LayoutModifier
    */
   public static KeyboardData modify_layout(KeyboardData kw)
   {
+
+
+    if (globalConfig.split_keyboard && globalConfig.wide_screen)
+      kw = split_layout(kw);
+
     // Extra keys are removed from the set as they are encountered during the
     // first iteration then automatically added.
     final TreeMap<KeyValue, KeyboardData.PreferredPos> extra_keys = new TreeMap<KeyValue, KeyboardData.PreferredPos>();
@@ -82,6 +87,7 @@ public final class LayoutModifier
     // Avoid adding extra keys to the number row
     if (added_number_row != null)
       kw = kw.insert_row(added_number_row, 0);
+
     return kw;
   }
 
@@ -214,5 +220,52 @@ public final class LayoutModifier
     {
       throw new RuntimeException(e.getMessage()); // Not recoverable
     }
+  }
+
+
+
+  static KeyboardData split_layout(KeyboardData kw)
+  {
+    java.util.ArrayList<KeyboardData.Row> newRows = new java.util.ArrayList<KeyboardData.Row>();
+    for (KeyboardData.Row row : kw.rows)
+    {
+      java.util.ArrayList<KeyboardData.Key> newKeys = new java.util.ArrayList<KeyboardData.Key>();
+      int size = row.keys.size();
+      int middle = size / 2;
+      boolean isOdd = size % 2 != 0;
+      
+      for (int i = 0; i < size; i++)
+      {
+        KeyboardData.Key key = row.keys.get(i);
+        
+        // Split only the space key (or keys defined as space)
+        boolean isSpace = key.hasValue(KeyValue.getKeyByName("space"));
+
+        if (isOdd && i == middle && isSpace)
+        {
+          KeyboardData.Key left = key.scaleWidth(0.5f);
+          KeyboardData.Key right = key.scaleWidth(0.5f).withShift(globalConfig.split_gap);
+          newKeys.add(left);
+          newKeys.add(right);
+        }
+        else
+        {
+          boolean addGap = false;
+          if (isOdd) {
+              addGap = (i == middle + 1);
+          } else {
+              addGap = (i == middle);
+          }
+
+          if (addGap)
+          {
+            key = key.withShift(key.shift + globalConfig.split_gap);
+          }
+          newKeys.add(key);
+        }
+      }
+      newRows.add(new KeyboardData.Row(newKeys, row.height, row.shift));
+    }
+    return new KeyboardData(kw, newRows);
   }
 }


### PR DESCRIPTION
Adds a split keyboard layout option for landscape mode on wide screens.

Features:
- Split layout with adjustable gap.
- Dual space bars.

Screenshots:
![Screenshot_20260204_215711_Unexpected Keyboard (Debug)](https://github.com/user-attachments/assets/5184f957-348c-4495-a293-e2eaf8533eab)
