### PR TITLE
Fix label color when keys are pressed

### DIFF
--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -417,8 +417,8 @@ public class Keyboard2View extends View
       {
         if ((flags & Pointers.FLAG_P_LOCKED) != 0)
           return _theme.lockedColor;
-        return _theme.activatedColor;
       }
+      return _theme.activatedColor;
     }
     if (k.hasFlagsAny(KeyValue.FLAG_SECONDARY | KeyValue.FLAG_GREYED))
     {


### PR DESCRIPTION
Fix https://github.com/Julow/Unexpected-Keyboard/issues/1169

The color of labels on a pressed key that were not the label being activated (eg. the labels on the corners when activating the label in the centre) was not correct.