### PR TITLE
Separate colors for pressed vs activated labels

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -9,6 +9,7 @@
     <attr name="colorKeyActivated" format="color"/>
     <!-- Label colors -->
     <attr name="colorLabel" format="color"/>
+    <attr name="colorLabelPressed" format="color"/> <!-- defaults to colorLabel -->
     <attr name="colorLabelActivated" format="color"/>
     <attr name="colorLabelLocked" format="color"/>
     <attr name="secondaryDimming" format="float"/>
@@ -282,6 +283,7 @@
     <item name="colorKeyActivated">#ffffff</item>
     <item name="colorLabel">#ffffff</item>
     <item name="colorLabelActivated">?colorKey</item>
+    <item name="colorLabelPressed">?colorKey</item>
     <item name="colorLabelLocked">#f5060b</item>
     <item name="colorSubLabel">?colorLabel</item>
     <item name="keyBorderWidth">1dp</item>

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -413,8 +413,9 @@ public class Keyboard2View extends View
       {
         if ((flags & Pointers.FLAG_P_LOCKED) != 0)
           return _theme.lockedColor;
+        return _theme.activatedColor;
       }
-      return _theme.activatedColor;
+      return _theme.pressedColor;
     }
     if (k.hasFlagsAny(KeyValue.FLAG_SECONDARY | KeyValue.FLAG_GREYED))
     {

--- a/srcs/juloo.keyboard2/Theme.java
+++ b/srcs/juloo.keyboard2/Theme.java
@@ -16,6 +16,7 @@ public class Theme
   // Label colors
   public final int lockedColor;
   public final int activatedColor;
+  public final int pressedColor;
   public final int labelColor;
   public final int subLabelColor;
   public final int secondaryLabelColor;
@@ -44,6 +45,7 @@ public class Theme
     isLightNavBar = s.getBoolean(R.styleable.keyboard_windowLightNavigationBar, false);
     labelColor = s.getColor(R.styleable.keyboard_colorLabel, 0);
     activatedColor = s.getColor(R.styleable.keyboard_colorLabelActivated, 0);
+    pressedColor = s.getColor(R.styleable.keyboard_colorLabelPressed, labelColor);
     lockedColor = s.getColor(R.styleable.keyboard_colorLabelLocked, 0);
     subLabelColor = s.getColor(R.styleable.keyboard_colorSubLabel, 0);
     secondaryLabelColor = adjustLight(labelColor,


### PR DESCRIPTION
Keeps the same color scheme as after #1173 for the ePaper Black theme, while preserving all other themes as they were before that PR.

As per #1169