### PR TITLE
Some slider changes

### DIFF
--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -847,18 +847,24 @@ public final class KeyValue implements Comparable<KeyValue>
 
   public static enum Slider implements Describe
   {
-    Cursor_left(0xE008),
-    Cursor_right(0xE006),
-    Cursor_up(0xE005),
-    Cursor_down(0xE007),
-    Selection_cursor_left(0xE008),
-    Selection_cursor_right(0xE006);
+    Cursor_left(0xE008, false),
+    Cursor_right(0xE006, false),
+    Cursor_up(0xE005, true),
+    Cursor_down(0xE007, true),
+    Selection_cursor_left(0xE008, false),
+    Selection_cursor_right(0xE006, false);
 
     final String symbol;
+    final boolean vertical;
 
-    Slider(int symbol_)
+    Slider(int symbol_, boolean vertical)
     {
       symbol = String.valueOf((char)symbol_);
+      this.vertical = vertical;
+    }
+    
+    public boolean isVertical() {
+      return vertical;
     }
 
     @Override

--- a/srcs/juloo.keyboard2/Pointers.java
+++ b/srcs/juloo.keyboard2/Pointers.java
@@ -625,9 +625,13 @@ public final class Pointers implements Handler.Callback
           return;
         last_move_ms = System.currentTimeMillis();
       }
-      d += ((x - last_x) * speed * direction_x
-          + (y - last_y) * speed * SPEED_VERTICAL_MULT * direction_y)
-        / _config.slide_step_px;
+      float current_speed = speed / _config.slide_step_px;
+      if (slider.isVertical()) {
+        d += (y - last_y) * current_speed * direction_y * SPEED_VERTICAL_MULT;
+      } else {
+        d += (x - last_x) * current_speed * direction_x;
+      }
+
       update_speed(travelled, x, y);
       // Send an event when [abs(d)] exceeds [1].
       int d_ = (int)d;

--- a/srcs/juloo.keyboard2/Pointers.java
+++ b/srcs/juloo.keyboard2/Pointers.java
@@ -612,6 +612,9 @@ public final class Pointers implements Handler.Callback
         slider slower, as we have less visibility and do smaller movements in
         that direction. */
     static final float SPEED_VERTICAL_MULT = 0.5f;
+    /** Make horizontal sliders slower while ctrl is held (which typically
+        means movement happens by whole words instead of characters) */
+    static final float SPEED_WORD_MULT = 0.25f;
 
     public void onTouchMove(Pointer ptr, float x, float y)
     {
@@ -629,6 +632,8 @@ public final class Pointers implements Handler.Callback
       if (slider.isVertical()) {
         d += (y - last_y) * current_speed * direction_y * SPEED_VERTICAL_MULT;
       } else {
+        if (ptr.modifiers.has(KeyValue.Modifier.CTRL))
+          current_speed *= SPEED_WORD_MULT;
         d += (x - last_x) * current_speed * direction_x;
       }
 


### PR DESCRIPTION
Second commit is a general fix for sliders adding both axis movement to delta regardless of the current sliding direction (e.g. if you start sliding the horizontal space slider, but then move vertically, you get unexpected sideways movement). Especially confusing for a "joystick" key with all 4 sliders - if the initial slide is detected wrong, you start moving a lot but in an unexpected wrong direction. Also weird if you slide a bit off-axis.

Third commit is an opinionated change of slowing down horizontal sliding 4x while ctrl is held; intention being that for word selection (i.e what ctrl usually means) you want to be a lot more precise (also just balancing out a single movement being farther). I can remove it if it feels excessive.