### PR TITLE
Making dictionaries compatible with 16 KB devices.

### DIFF
--- a/vendor/Android.mk
+++ b/vendor/Android.mk
@@ -8,5 +8,6 @@ LOCAL_CFLAGS +=
 LOCAL_SRC_FILES := cdict/libcdict/libcdict.c cdict/java/jni/juloo_cdict_Cdict.c
 LOCAL_MODULE := libcdict_java
 LOCAL_SDK_VERSION := 21
+LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
 
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
Related to apk compatibility with 16 KB devices for dictionaries.

APK Unexpected-Keyboard-debug.apk is not compatible with 16 KB devices. Some libraries have LOAD segments not aligned at 16 KB boundaries: lib/arm64-v8a/libcdict_java.so Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes. For more information about compatibility with 16 KB devices, visit developer.android.com/16kb-page-size.