### PR TITLE
CI: Disable workflow runs on push

### DIFF
--- a/.github/workflows/check-layouts.yml
+++ b/.github/workflows/check-layouts.yml
@@ -3,6 +3,8 @@ name: Check layouts
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -3,6 +3,8 @@ name: Make Apk CI
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
Workflows run twice, which is wasteful.