### PR TITLE
Fix building on NixOS

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -36,26 +36,16 @@ let
 
   ANDROID_SDK_ROOT = "${android.androidsdk}/libexec/android-sdk";
 
-  gradle = pkgs.gradle.override { java = jdk; };
-  # Without this option, aapt2 fails to run with a permissions error.
-  gradle_wrapped = pkgs.runCommandLocal "gradle-wrapped" {
-    nativeBuildInputs = with pkgs; [ makeBinaryWrapper ];
-  } ''
-    mkdir -p $out/bin
-    ln -s ${gradle}/bin/gradle $out/bin/gradle
-    wrapProgram $out/bin/gradle \
-    --add-flags "-Dorg.gradle.project.android.aapt2FromMavenOverride=${ANDROID_SDK_ROOT}/build-tools/${build_tools_version}/aapt2"
-  '';
-
 in pkgs.mkShell {
   buildInputs = [
     pkgs.findutils
     pkgs.fontforge
     jdk
     android.androidsdk
-    gradle_wrapped
+    (pkgs.gradle.override { java = jdk; })
     emulators
   ];
   JAVA_HOME = jdk.home;
   inherit ANDROID_SDK_ROOT;
+  GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${ANDROID_SDK_ROOT}/build-tools/${build_tools_version}/aapt2";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,7 @@ let
 
   android = pkgs.androidenv.composeAndroidPackages {
     buildToolsVersions = [ build_tools_version ];
-    platformVersions = [ "35" ];
+    platformVersions = [ "36" ];
     abiVersions = [ "armeabi-v7a" ];
     includeNDK = true;
     ndkVersion = "27.0.12077973";


### PR DESCRIPTION
This bumps the platform in `shell.nix` to match the target platform. It also exports an environment variable that makes gradle use `aapt2` from Nix. Without this, it tries to run the downloaded one, which fails on NixOS. These changes allowed me to run `./gradlew assembleDebug` after entering `nix-shell`.