### PR TITLE
Increase lookback when looking for the last word

### DIFF
--- a/srcs/juloo.keyboard2/CurrentlyTypedWord.java
+++ b/srcs/juloo.keyboard2/CurrentlyTypedWord.java
@@ -113,7 +113,7 @@ public final class CurrentlyTypedWord
     if (_has_selection)
       set_current_word("");
     else
-      set_current_word(_ic.getTextBeforeCursor(10, 0));
+      set_current_word(_ic.getTextBeforeCursor(20, 0));
   }
 
   /** Refresh the current word by immediately querying the editor. */


### PR DESCRIPTION
For example, typing "dictionarirs" suggests "dictionaries" but moving the cursor away and back results in no suggestion. Because the lookback was 10 characters long, the keyboard was seeing "ctionarirs".

Reported in https://github.com/Julow/Unexpected-Keyboard/pull/1137#issuecomment-4212159713