### PR TITLE
Disable spacebar autocomplete when suggestions are hidden

### DIFF
--- a/srcs/juloo.keyboard2/KeyEventHandler.java
+++ b/srcs/juloo.keyboard2/KeyEventHandler.java
@@ -50,6 +50,7 @@ public final class KeyEventHandler
     InputConnection ic = _recv.getCurrentInputConnection();
     _autocap.started(conf, ic);
     _typedword.started(conf, ic);
+    _suggestions.started();
     _move_cursor_force_fallback =
       conf.editor_config.should_move_cursor_force_fallback;
     _space_bar_auto_complete = conf.space_bar_auto_complete;

--- a/srcs/juloo.keyboard2/suggestions/Suggestions.java
+++ b/srcs/juloo.keyboard2/suggestions/Suggestions.java
@@ -12,6 +12,7 @@ public final class Suggestions
 {
   Callback _callback;
   Config _config;
+  boolean _enabled;
 
   /** The suggestion displayed at the center of the candidates view and entered
       by the space bar. */
@@ -23,8 +24,16 @@ public final class Suggestions
     _config = conf;
   }
 
+  public void started()
+  {
+    _enabled = _config.editor_config.should_show_candidates_view;
+    best_suggestion = null;
+  }
+
   public void currently_typed_word(String word)
   {
+    if (!_enabled)
+      return;
     Cdict dict = _config.current_dictionary;
     if (word.length() < 2 || dict == null)
     {


### PR DESCRIPTION
The spacebar autocomplete option was still working even when the suggestions strip was correctly hidden in applications like Termux.

Reported in https://github.com/Julow/Unexpected-Keyboard/pull/1137#issuecomment-4212159713