### PR TITLE
Dictionary activity: Status message when the keyboard is not enabled

### DIFF
--- a/res/layout/dictionary_status_not_enabled.xml
+++ b/res/layout/dictionary_status_not_enabled.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android" style="@style/paragraph" android:paddingHorizontal="24dp" android:gravity="center" android:text="@string/dictionaries_activity_not_enabled"/>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -160,6 +160,7 @@
     <string name="dictionaries_from_internet">Download a dictionary from the Internet</string>
     <string name="dictionaries_download_success">Dictionary installed</string>
     <string name="dictionaries_download_failed">Download failed</string>
+    <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string>
     <string name="candidates_status_no_dict">No dictionary installed</string>
     <string name="candidates_status_install">Install</string>
 </resources>

--- a/srcs/juloo.keyboard2/dict/DictionaryListView.java
+++ b/srcs/juloo.keyboard2/dict/DictionaryListView.java
@@ -54,6 +54,9 @@ public class DictionaryListView extends LinearLayout
       }
     }
     refresh();
+    // The keyboard is not enabled and the list is empty, show a message.
+    if (locales.installed.size() == 0)
+      addView(View.inflate(ctx, R.layout.dictionary_status_not_enabled, null));
   }
 
   /** Update the "installed" status of item views. Meaning whether the


### PR DESCRIPTION
This shows a reason why the list is empty and removes confusion.

Reported in https://github.com/Julow/Unexpected-Keyboard/pull/1137#issuecomment-4212159713