### PR TITLE
Refresh suggestions immediately after language switch

### DIFF
--- a/srcs/juloo.keyboard2/KeyEventHandler.java
+++ b/srcs/juloo.keyboard2/KeyEventHandler.java
@@ -145,6 +145,12 @@ public final class KeyEventHandler
     _suggestions.currently_typed_word(word);
   }
 
+  public void ime_subtype_changed()
+  {
+    // Refresh the suggestions immediately after dictionary changed.
+    _suggestions.currently_typed_word(_typedword.get());
+  }
+
   /** Update [_mods] to be consistent with the [mods], sending key events if
       needed. */
   void update_meta_state(Pointers.Modifiers mods)

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -320,6 +320,7 @@ public class Keyboard2 extends InputMethodService
     refresh_current_dictionary();
     refresh_candidates_view();
     _keyboard_layout_view.setKeyboard(current_layout());
+    _keyeventhandler.ime_subtype_changed();
   }
 
   @Override

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -317,6 +317,7 @@ public class Keyboard2 extends InputMethodService
   public void onCurrentInputMethodSubtypeChanged(InputMethodSubtype subtype)
   {
     refreshSubtypeImm();
+    refresh_current_dictionary();
     refresh_candidates_view();
     _keyboard_layout_view.setKeyboard(current_layout());
   }


### PR DESCRIPTION
The suggestions was otherwise updated by closing and opening the keyboard again.

Reported in https://github.com/Julow/Unexpected-Keyboard/pull/1137#issuecomment-4212159713