### PR TITLE
Handle Google Keep bug

### DIFF
--- a/srcs/juloo.keyboard2/Logs.java
+++ b/srcs/juloo.keyboard2/Logs.java
@@ -1,5 +1,6 @@
 package juloo.keyboard2;
 
+import android.text.InputType;
 import android.util.Log;
 import android.util.LogPrinter;
 import android.view.inputmethod.EditorInfo;
@@ -23,6 +24,9 @@ public final class Logs
     info.dump(_debug_logs, "");
     if (info.extras != null)
       _debug_logs.println("extras: "+info.extras.toString());
+    _debug_logs.println("class: "+(info.inputType & InputType.TYPE_MASK_CLASS));
+    _debug_logs.println("flags: "+(info.inputType & InputType.TYPE_MASK_FLAGS));
+    _debug_logs.println("variation: "+(info.inputType & InputType.TYPE_MASK_VARIATION));
   }
 
   public static void debug_config_migration(int from_version, int to_version)

--- a/srcs/juloo.keyboard2/suggestions/CandidatesView.java
+++ b/srcs/juloo.keyboard2/suggestions/CandidatesView.java
@@ -148,8 +148,15 @@ public class CandidatesView extends LinearLayout
           case InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD:
             return false;
           default:
-            if ((flags & InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS) != 0)
-              return false; // Editor requested that we don't show suggestions
+            /* Editor requested that we don't show suggestions. Enable
+               suggestions anyway when the flags [NO_SUGGESTIONS] and
+               [AUTO_CORRECT] are present at the same time. This happens with
+               Google Keep. */
+            if ((flags &
+                  (InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+                   | InputType.TYPE_TEXT_FLAG_AUTO_CORRECT))
+                == InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS)
+              return false;
             return true;
         }
       case InputType.TYPE_CLASS_NUMBER:


### PR DESCRIPTION
The Google Keep text area sends contradictory flags to keyboards, resulting in the suggestions to be disabled.
This seems to be a bug in Google Keep.

Reported in https://github.com/Julow/Unexpected-Keyboard/pull/1137#issuecomment-4212159713