### PR TITLE
Insert a space when undoing autocorrect

### DIFF
--- a/srcs/juloo.keyboard2/KeyEventHandler.java
+++ b/srcs/juloo.keyboard2/KeyEventHandler.java
@@ -540,7 +540,8 @@ public final class KeyEventHandler
   {
     if (last_replaced_word != null)
     {
-      replace_text_before_cursor(last_replacement_word_len, last_replaced_word);
+      replace_text_before_cursor(last_replacement_word_len,
+          last_replaced_word + " ");
       last_replaced_word = null;
     }
     else


### PR DESCRIPTION
This prevents the same suggestions to be presented again and autocorrect to be activated again when pressing space.

This extra space is wanted because pressing the spacebar triggered autocorrect in the first place.