### PR TITLE
CI: Run the tests

### DIFF
--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: true
+
     - name: Restore debug keystore from GitHub Secrets
       run: |
         # Check if exist and use the secret named DEBUG_KEYSTORE
@@ -28,12 +29,22 @@ jobs:
                 gpg -d --passphrase "debug0" --batch "debug.keystore.asc" > "debug.keystore"
             fi
         fi
+
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '17'
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
+
+    - name: Run tests
+      run: |
+        gradle test
+        # Warn about outdated generated files.
+        if ! git diff --name-only; then
+          echo "Warning: Generated files are not uptodate. Run 'gradle test'."
+        fi
+
     - name: Build debug APK
       run: ./gradlew assembleDebug
       env:
@@ -41,6 +52,7 @@ jobs:
         DEBUG_KEYSTORE_PASSWORD: debug0
         DEBUG_KEY_ALIAS: debug
         DEBUG_KEY_PASSWORD: debug0
+
     - name: Artifact naming
       run: |
         artifact="${{github.repository_owner}} ${{github.ref_name}}"


### PR DESCRIPTION
Run the tests before building the debug APK in CI. This checks that the unit tests pass and that the generated files are uptodate.

Doesn't fail if the generated files are outdated. Instead, the APK is built with them updated.