### PR TITLE
Reduce the size of suggestions to fit

### DIFF
--- a/res/layout/keyboard.xml
+++ b/res/layout/keyboard.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:hardwareAccelerated="false" android:orientation="vertical" android:background="?attr/colorKeyboard">
-  <juloo.keyboard2.suggestions.CandidatesView android:id="@+id/candidates_view" android:layout_width="match_parent" android:layout_height="48dp" android:orientation="horizontal" android:gravity="center">
-    <TextView android:id="@+id/candidates_left" style="@style/candidates_item" android:layout_width="match_parent" android:layout_height="match_parent" android:layout_weight="1"/>
-    <TextView android:id="@+id/candidates_middle" style="@style/candidates_item" android:layout_width="match_parent" android:layout_height="match_parent" android:layout_weight="1"/>
-    <TextView android:id="@+id/candidates_right" style="@style/candidates_item" android:layout_width="match_parent" android:layout_height="match_parent" android:layout_weight="1"/>
+  <juloo.keyboard2.suggestions.CandidatesView android:id="@+id/candidates_view" style="@style/candidates_view">
+    <TextView android:id="@+id/candidates_left" style="@style/candidates_item" android:layout_width="match_parent"/>
+    <TextView android:id="@+id/candidates_middle" style="@style/candidates_item" android:layout_width="match_parent"/>
+    <TextView android:id="@+id/candidates_right" style="@style/candidates_item" android:layout_width="match_parent"/>
   </juloo.keyboard2.suggestions.CandidatesView>
   <juloo.keyboard2.Keyboard2View android:id="@+id/keyboard_view" android:layout_width="match_parent" android:layout_height="wrap_content"/>
 </LinearLayout>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -1,9 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <!-- Candidates view -->
+  <style name="candidates_view">
+    <item name="android:layout_width">match_parent</item>
+    <item name="android:layout_height">48dp</item>
+    <item name="android:orientation">horizontal</item>
+    <item name="android:gravity">center</item>
+  </style>
   <style name="candidates_item">
+    <item name="android:layout_width">match_parent</item>
+    <item name="android:layout_height">match_parent</item>
+    <item name="android:layout_weight">1</item>
     <item name="android:gravity">center</item>
     <item name="android:textColor">?attr/colorLabel</item>
+    <item name="android:maxLines">1</item>
+    <item name="android:paddingHorizontal">@dimen/candidates_padding</item>
   </style>
   <style name="candidates_status">
     <item name="android:layout_width">match_parent</item>

--- a/res/values/values.xml
+++ b/res/values/values.xml
@@ -6,7 +6,7 @@
   <dimen name="emoji_text_size">28dp</dimen>
   <dimen name="clipboard_view_height">300dp</dimen>
   <dimen name="pref_button_size">28dp</dimen>
-  <dimen name="candidates_spacing">8dp</dimen>
+  <dimen name="candidates_padding">3dp</dimen>
   <!-- Will be overwritten automatically by Gradle for the debug build variant -->
   <bool name="debug_logs">false</bool>
   <!-- Color fallback for the Monet themes on Android API < 31. This makes the

--- a/srcs/juloo.keyboard2/suggestions/CandidatesView.java
+++ b/srcs/juloo.keyboard2/suggestions/CandidatesView.java
@@ -1,6 +1,7 @@
 package juloo.keyboard2.suggestions;
 
 import android.content.Context;
+import android.os.Build.VERSION;
 import android.text.InputType;
 import android.util.AttributeSet;
 import android.util.TypedValue;
@@ -76,10 +77,11 @@ public class CandidatesView extends LinearLayout
     _status_no_dict = inflate_and_show(_status_no_dict,
         (config.current_dictionary == null),
         R.layout.candidates_status_no_dict);
-    set_height(config);
+    set_sizes(config);
   }
 
-  void set_height(Config config)
+  /** Set the height of the suggestion row and the text size. */
+  void set_sizes(Config config)
   {
     // Make the candidates view about as high as a keyboard row.
     int height = (int)(config.keyboard_rows_height_pixels * (1 - config.key_vertical_margin));
@@ -88,11 +90,17 @@ public class CandidatesView extends LinearLayout
     for (int i = 0; i < NUM_CANDIDATES; i++)
     {
       TextView v = _item_views[i];
+      // Set view height
       ViewGroup.MarginLayoutParams p =
         (ViewGroup.MarginLayoutParams)v.getLayoutParams();
       p.height = height;
       v.setLayoutParams(p);
-      v.setTextSize(TypedValue.COMPLEX_UNIT_PX, text_size);
+      // Set text size and enable auto size if supported.
+      if (VERSION.SDK_INT < 26)
+        v.setTextSize(TypedValue.COMPLEX_UNIT_PX, text_size);
+      else
+        v.setAutoSizeTextTypeUniformWithConfiguration(
+            (int)(text_size / 2.), (int)text_size, 1, TypedValue.COMPLEX_UNIT_PX);
     }
   }
 


### PR DESCRIPTION
Reported in https://github.com/Julow/Unexpected-Keyboard/issues/68#issuecomment-4275751542

The font size of the suggested words is reduced if the word would otherwise split on two lines.