### PR TITLE
Add IME clipboard fallbacks for terminal apps

### DIFF
--- a/srcs/juloo.keyboard2/ClipboardHistoryService.java
+++ b/srcs/juloo.keyboard2/ClipboardHistoryService.java
@@ -47,6 +47,30 @@ public final class ClipboardHistoryService
       _paste_callback.paste_from_clipboard_pane(clip);
   }
 
+  /** Read the first text item from the system clipboard. Might return [null]. */
+  public static String get_current_clip()
+  {
+    if (_service == null)
+      return null;
+    ClipData clip = null;
+    try { clip = _service._cm.getPrimaryClip(); } catch (Exception _e) {}
+    if (clip == null || clip.getItemCount() == 0)
+      return null;
+    CharSequence text = clip.getItemAt(0).getText();
+    return (text == null) ? null : text.toString();
+  }
+
+  /** Update the system clipboard and clipboard history. */
+  public static void set_current_clip(String clip)
+  {
+    if (_service == null)
+      return;
+    if (clip == null)
+      clip = "";
+    _service._cm.setPrimaryClip(ClipData.newPlainText("", clip));
+    _service.add_clip(clip);
+  }
+
   /** The maximum size limits the amount of user data stored in memory but also
       gives a sense to the user that the history is not persisted and can be
       forgotten as soon as the app stops. */

--- a/srcs/juloo.keyboard2/KeyEventHandler.java
+++ b/srcs/juloo.keyboard2/KeyEventHandler.java
@@ -274,12 +274,30 @@ public final class KeyEventHandler
   }
 
   /** See {!InputConnection.performContextMenuAction}. */
-  void send_context_menu_action(int id)
+  boolean send_context_menu_action(int id)
+  {
+    InputConnection conn = _recv.getCurrentInputConnection();
+    if (conn == null)
+      return false;
+    return conn.performContextMenuAction(id);
+  }
+
+  void fallback_paste_from_clipboard()
+  {
+    String clip = ClipboardHistoryService.get_current_clip();
+    if (clip != null && clip.length() > 0)
+      send_text(clip);
+  }
+
+  void fallback_copy_selection_to_clipboard()
   {
     InputConnection conn = _recv.getCurrentInputConnection();
     if (conn == null)
       return;
-    conn.performContextMenuAction(id);
+    CharSequence selected = conn.getSelectedText(0);
+    if (selected == null || selected.length() == 0)
+      return;
+    ClipboardHistoryService.set_current_clip(selected.toString());
   }
 
   @SuppressLint("InlinedApi")
@@ -287,12 +305,28 @@ public final class KeyEventHandler
   {
     switch (ev)
     {
-      case COPY: if(_typedword.is_selection_not_empty()) send_context_menu_action(android.R.id.copy); break;
-      case PASTE: send_context_menu_action(android.R.id.paste); break;
+      case COPY:
+        if (_typedword.is_selection_not_empty())
+        {
+          if (!send_context_menu_action(android.R.id.copy))
+            fallback_copy_selection_to_clipboard();
+        }
+        else
+        {
+          fallback_copy_selection_to_clipboard();
+        }
+        break;
+      case PASTE:
+        if (!send_context_menu_action(android.R.id.paste))
+          fallback_paste_from_clipboard();
+        break;
       case CUT: if(_typedword.is_selection_not_empty()) send_context_menu_action(android.R.id.cut); break;
       case SELECT_ALL: send_context_menu_action(android.R.id.selectAll); break;
       case SHARE: send_context_menu_action(android.R.id.shareText); break;
-      case PASTE_PLAIN: send_context_menu_action(android.R.id.pasteAsPlainText); break;
+      case PASTE_PLAIN:
+        if (!send_context_menu_action(android.R.id.pasteAsPlainText))
+          fallback_paste_from_clipboard();
+        break;
       case UNDO: send_context_menu_action(android.R.id.undo); break;
       case REDO: send_context_menu_action(android.R.id.redo); break;
       case REPLACE: send_context_menu_action(android.R.id.replaceText); break;


### PR DESCRIPTION
## Summary
- keep existing `performContextMenuAction()` path for `copy`, `paste`, and `pasteAsPlainText`
- add fallbacks when context actions are ignored by the target app:
  - `paste`/`pasteAsPlainText`: read system clipboard and `commitText` into the editor
  - `copy`: try `getSelectedText()` and write it to system clipboard
- expose small helpers in `ClipboardHistoryService` to read/write current clipboard text

## Motivation
Some terminal-like editors (notably Termux with `TYPE_NULL` input) may ignore IME context menu actions, which makes keyboard `copy/paste` keys no-op. This keeps behavior unchanged where supported and adds graceful fallback where not.

## Testing
- Not tested locally (Android SDK not configured in this environment, so no local Gradle build was possible).
- Please validate on-device, especially in Termux and a standard text editor app.