### PR TITLE
Fix crash when installing dictionaries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,9 @@ android {
   buildTypes {
     named("release") {
       isMinifyEnabled = true
+      proguardFiles(
+        getDefaultProguardFile("proguard-android-optimize.txt"),
+        "proguard-rules.pro")
       isShrinkResources = true
       isDebuggable = false
       resValue("string", "app_name", "@string/app_name_release")

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -1,0 +1,3 @@
+-keep public class juloo.cdict.* {
+  public protected private *;
+}


### PR DESCRIPTION
This happens in release mode due to minification.