### PR TITLE
Fix the keyboard drawing behind the navigation bar

### DIFF
--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -264,13 +264,11 @@ public class Keyboard2View extends View
   @Override
   public void onMeasure(int wSpec, int hSpec)
   {
-    int width;
     DisplayMetrics dm = getContext().getResources().getDisplayMetrics();
-    width = dm.widthPixels;
+    int width = dm.widthPixels;
     _marginLeft = Math.max(_config.horizontal_margin, _insets_left);
     _marginRight = Math.max(_config.horizontal_margin, _insets_right);
     _marginBottom = _config.margin_bottom + _insets_bottom;
-    width += _insets_left + _insets_right;
     _keyWidth = (width - _marginLeft - _marginRight) / _keyboard.keysWidth;
     _tc = new Theme.Computed(_theme, _config, _keyWidth, _keyboard);
     // Compute the size of labels based on the width or the height of keys. The


### PR DESCRIPTION
Fix https://github.com/Julow/Unexpected-Keyboard/issues/1260

The width of the navigation was not accounted correctly.

This reverts https://github.com/Julow/Unexpected-Keyboard/pull/1127