### PR TITLE
fix: Suggestions do not appear after a space

### DIFF
--- a/srcs/juloo.keyboard2/CurrentlyTypedWord.java
+++ b/srcs/juloo.keyboard2/CurrentlyTypedWord.java
@@ -129,7 +129,7 @@ public final class CurrentlyTypedWord
       _cursor++;
       // [i >= end] might happen when the cursor is in the middle of a
       // surrogate pair
-      if (!Character.isLetter(c) && i < end)
+      if (!Character.isLetter(c) && i <= end)
         insert_start = i;
     }
     if (insert_start > 0)


### PR DESCRIPTION
Fixes #1269 : because we increment the loop counter before the boundary check, it needs to be inclusive.
Example: entering a single space will not start a new word because `i < end` will not hold true.
Works fine with emojis as well (#1259)
Verified on Android 16