### PR TITLE
Avoid Github redirection when downloading dictionaries

### DIFF
--- a/srcs/juloo.keyboard2/dict/DictionaryListView.java
+++ b/srcs/juloo.keyboard2/dict/DictionaryListView.java
@@ -150,7 +150,7 @@ public class DictionaryListView extends LinearLayout
   }
 
   static final String DICT_REPO_URL =
-    "https://github.com/Julow/Unexpected-Keyboard-dictionaries/raw/refs/heads/main";
+    "https://raw.githubusercontent.com/Julow/Unexpected-Keyboard-dictionaries/refs/heads/main";
 
   static URL url_of_dictionary(String dict_name)
       throws MalformedURLException


### PR DESCRIPTION
Related to https://github.com/Julow/Unexpected-Keyboard/issues/1288

This removes a domain from connection logs and avoids an unnecessary redirection.