### PR TITLE
Hide keyboard when physical keyboard is connected

### DIFF
--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -3,6 +3,7 @@ package juloo.keyboard2;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.inputmethodservice.InputMethodService;
 import android.os.Build.VERSION;
 import android.os.Handler;
@@ -361,9 +362,15 @@ public class Keyboard2 extends InputMethodService
   @Override
   public boolean onEvaluateInputViewShown()
   {
-    super.onEvaluateInputViewShown();
-    // Return true regardless of the super call result to fix the keyboard not
-    // being visible on Android 16
+    // Since Android 16, this method returns [false] for unknown reasons.
+    if (super.onEvaluateInputViewShown())
+      return true;
+    if (getResources().getConfiguration().hardKeyboardHidden
+        == Configuration.HARDKEYBOARDHIDDEN_NO)
+    {
+      Logs.debug("Physical keyboard is present");
+      return false;
+    }
     return true;
   }
 


### PR DESCRIPTION
Fix https://github.com/Julow/Unexpected-Keyboard/issues/1274 https://github.com/Julow/Unexpected-Keyboard/issues/1293
This is broken since #1190

Currently untested as I don't have a bluetooth keyboard. I'm acquiring one but I'd be happy if someone could test it.