### PR TITLE
Add a background color under suggestions

### DIFF
--- a/res/drawable/suggestions_item_background.xml
+++ b/res/drawable/suggestions_item_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+  <solid android:color="?attr/colorKeyboard"/>
+  <corners android:radius="?attr/keyBorderRadius"/>
+</shape>

--- a/res/drawable/suggestions_item_background.xml
+++ b/res/drawable/suggestions_item_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-  <solid android:color="?attr/colorKeyboard"/>
-  <corners android:radius="?attr/keyBorderRadius"/>
+  <solid android:color="?attr/suggestions_background"/>
+  <corners android:radius="?attr/suggestions_border_radius"/>
 </shape>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -3,25 +3,30 @@
   <!-- Candidates view -->
   <style name="candidates_view">
     <item name="android:layout_width">match_parent</item>
-    <item name="android:layout_height">48dp</item>
+    <item name="android:layout_height">wrap_content</item>
     <item name="android:orientation">horizontal</item>
     <item name="android:gravity">center</item>
+    <item name="android:paddingEnd">@dimen/candidates_gap</item>
   </style>
   <style name="candidates_item">
-    <item name="android:layout_width">match_parent</item>
+    <item name="android:layout_width">0dp</item>
     <item name="android:layout_height">match_parent</item>
     <item name="android:layout_weight">1</item>
-    <item name="android:paddingHorizontal">@dimen/candidates_padding</item>
+    <item name="android:layout_marginStart">@dimen/candidates_gap</item>
+    <item name="android:layout_marginTop">@dimen/candidates_margin_vertical</item>
+    <item name="android:layout_marginBottom">@dimen/candidates_margin_vertical</item>
+    <item name="android:padding">@dimen/candidates_suggestions_padding</item>
     <item name="android:gravity">center</item>
+    <item name="android:background">@drawable/suggestions_item_background</item>
     <item name="android:textColor">?attr/colorLabel</item>
     <item name="android:maxLines">1</item>
   </style>
   <style name="candidates_emoji">
-    <item name="android:layout_width">wrap_content</item>
-    <item name="android:layout_height">match_parent</item>
-    <item name="android:layout_marginLeft">12dp</item>
+    <item name="android:layout_width">@dimen/candidates_emoji_width</item>
+    <item name="android:layout_height">@dimen/candidates_emoji_width</item>
     <item name="android:layout_weight">0</item>
-    <item name="android:paddingHorizontal">@dimen/candidates_padding</item>
+    <item name="android:layout_marginStart">@dimen/candidates_gap</item>
+    <item name="android:padding">@dimen/candidates_suggestions_padding</item>
     <item name="android:gravity">center</item>
   </style>
   <style name="candidates_status">

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -35,6 +35,9 @@
     <!-- System integration -->
     <attr name="navigationBarColor" format="color"/>
     <attr name="windowLightNavigationBar" format="boolean"/>
+    <!-- Suggestions -->
+    <attr name="suggestions_background" format="color"/>
+    <attr name="suggestions_border_radius" format="dimension"/>
   </declare-styleable>
   <style name="BaseTheme">
     <item name="android:forceDarkAllowed">false</item>
@@ -49,6 +52,8 @@
     <item name="emoji_key_text" type="color">?attr/colorLabel</item>
     <item name="clipboard_divider_color" type="color">?attr/colorKey</item>
     <item name="clipboard_divider_height">1px</item>
+    <item name="suggestions_background">?attr/colorKeyboard</item>
+    <item name="suggestions_border_radius">?attr/keyBorderRadius</item>
   </style>
   <style name="Dark" parent="BaseTheme">
     <item name="android:isLightTheme">false</item>

--- a/res/values/values.xml
+++ b/res/values/values.xml
@@ -6,7 +6,11 @@
   <dimen name="emoji_text_size">28dp</dimen>
   <dimen name="clipboard_view_height">300dp</dimen>
   <dimen name="pref_button_size">28dp</dimen>
-  <dimen name="candidates_padding">3dp</dimen>
+  <dimen name="candidates_gap">8dp</dimen>
+  <dimen name="candidates_suggestions_padding">4dp</dimen>
+  <dimen name="candidates_margin_vertical">8dp</dimen>
+  <dimen name="candidates_emoji_width">40dp</dimen>
+  <dimen name="candidates_emoji_height">40dp</dimen>
   <!-- Will be overwritten automatically by Gradle for the debug build variant -->
   <bool name="debug_logs">false</bool>
   <!-- Color fallback for the Monet themes on Android API < 31. This makes the

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.graphics.drawable.Drawable;
 import android.inputmethodservice.InputMethodService;
 import android.os.Build.VERSION;
 import android.os.Handler;
@@ -214,7 +215,9 @@ public class Keyboard2 extends InputMethodService
       setInputView(_keyboard_container_view);
     }
     // Set keyboard background opacity
-    _keyboard_container_view.getBackground().setAlpha(_config.keyboardOpacity);
+    Drawable bg = _keyboard_container_view.getBackground().mutate();
+    bg.setAlpha(_config.keyboardOpacity);
+    _keyboard_container_view.setBackground(bg);
     _keyboard_layout_view.reset();
     refresh_candidates_view();
   }

--- a/srcs/juloo.keyboard2/suggestions/CandidatesView.java
+++ b/srcs/juloo.keyboard2/suggestions/CandidatesView.java
@@ -96,17 +96,16 @@ public class CandidatesView extends LinearLayout
   void set_sizes(Config config)
   {
     // Make the candidates view about as high as a keyboard row.
-    int height = (int)(config.keyboard_rows_height_pixels * (1 - config.key_vertical_margin));
+    float row_height = config.keyboard_rows_height_pixels * (1 - config.key_vertical_margin);
+    ViewGroup.MarginLayoutParams p =
+      (ViewGroup.MarginLayoutParams)getLayoutParams();
+    p.height = (int)row_height;
+    setLayoutParams(p);
     // Match the size of labels on the keyboard.
-    float text_size = height * config.characterSize * config.labelTextSize;
+    float text_size = row_height * config.characterSize * config.labelTextSize;
     for (int i = 0; i < NUM_CANDIDATES; i++)
     {
       TextView v = _item_views[i];
-      // Set view height
-      ViewGroup.MarginLayoutParams p =
-        (ViewGroup.MarginLayoutParams)v.getLayoutParams();
-      p.height = height;
-      v.setLayoutParams(p);
       // Set text size and enable auto size if supported.
       if (VERSION.SDK_INT < 26)
         v.setTextSize(TypedValue.COMPLEX_UNIT_PX, text_size);


### PR DESCRIPTION
Suggestions might be unreadable when the keyboard opacity is very low (eg. black on black).

The new background is normally invisible, unless the opacity option is not set to 100%. The corner are rounded like the keys on the keyboard.