### PR TITLE
Show the current locale when no dictionary is installed

### DIFF
--- a/res/layout/candidates_status_no_dict.xml
+++ b/res/layout/candidates_status_no_dict.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" style="@style/candidates_status">
-  <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="@string/candidates_status_no_dict"/>
-  <Button android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="@string/candidates_status_install" android:onClick="launch_dictionaries_activity"/>
+  <TextView android:id="@android:id/text1" style="@style/candidates_item" android:onClick="launch_dictionaries_activity"/>
 </LinearLayout>

--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-ars/strings.xml
+++ b/res/values-ars/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-arz/strings.xml
+++ b/res/values-arz/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-bn-rBD/strings.xml
+++ b/res/values-bn-rBD/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -203,7 +203,7 @@
     <string name="dictionaries_download_success">Diccionario instalado</string>
     <string name="dictionaries_download_failed">Falló la descarga</string>
     <string name="dictionaries_activity_not_enabled">Primero tienes que habilitar al teclado para descargar diccionarios.</string>
-    <string name="candidates_status_install">Instalar</string>
     <string name="pref_portrait_unfolded">En modo vertical desplegado</string>
     <string name="pref_landscape_unfolded">En modo horizontal desplegado</string>
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -203,7 +203,6 @@
     <string name="dictionaries_download_success">Diccionario instalado</string>
     <string name="dictionaries_download_failed">Falló la descarga</string>
     <string name="dictionaries_activity_not_enabled">Primero tienes que habilitar al teclado para descargar diccionarios.</string>
-    <string name="candidates_status_no_dict">No hay diccionarios instalados</string>
     <string name="candidates_status_install">Instalar</string>
     <string name="pref_portrait_unfolded">En modo vertical desplegado</string>
     <string name="pref_landscape_unfolded">En modo horizontal desplegado</string>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-fil/strings.xml
+++ b/res/values-fil/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -161,8 +161,6 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
 <string name="pref_portrait_unfolded">En mode portrait déplié</string>
     <string name="pref_landscape_unfolded">En mode paysage déplié</string>
     <string name="pref_show_number_row_no_number_row">Aucune rangée de chiffres</string>
@@ -185,4 +183,5 @@
     <string name="pref_theme_e_cobalt">Cobalt</string>
     <string name="pref_theme_e_pine">Pine</string>
     <string name="pref_theme_e_epaperblack">ePaper Noir</string>
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-lv/strings.xml
+++ b/res/values-lv/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-ml/strings.xml
+++ b/res/values-ml/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-ms/strings.xml
+++ b/res/values-ms/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-my/strings.xml
+++ b/res/values-my/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-ta/strings.xml
+++ b/res/values-ta/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-th/strings.xml
+++ b/res/values-th/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-tlh/strings.xml
+++ b/res/values-tlh/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-tok/strings.xml
+++ b/res/values-tok/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -161,6 +161,5 @@
     <!-- <string name="dictionaries_download_success">Dictionary installed</string> -->
     <!-- <string name="dictionaries_download_failed">Download failed</string> -->
     <!-- <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string> -->
-    <!-- <string name="candidates_status_no_dict">No dictionary installed</string> -->
-    <!-- <string name="candidates_status_install">Install</string> -->
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -205,5 +205,5 @@
     <string name="dictionaries_download_success">字典已安裝</string>
     <string name="dictionaries_download_failed">下載失敗</string>
     <string name="dictionaries_activity_not_enabled">需要啟用鍵盤才能下載字典。</string>
-    <string name="candidates_status_install">安裝</string>
+    <!-- <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string> -->
 </resources>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -205,6 +205,5 @@
     <string name="dictionaries_download_success">字典已安裝</string>
     <string name="dictionaries_download_failed">下載失敗</string>
     <string name="dictionaries_activity_not_enabled">需要啟用鍵盤才能下載字典。</string>
-    <string name="candidates_status_no_dict">無已安裝的字典</string>
     <string name="candidates_status_install">安裝</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -161,6 +161,5 @@
     <string name="dictionaries_download_success">Dictionary installed</string>
     <string name="dictionaries_download_failed">Download failed</string>
     <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string>
-    <string name="candidates_status_no_dict">No dictionary installed</string>
-    <string name="candidates_status_install">Install</string>
+    <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string>
 </resources>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -83,6 +83,7 @@ public final class Config
   public ExtraKeys extra_keys_subtype;
   public Map<KeyValue, KeyboardData.PreferredPos> extra_keys_param;
   public Map<KeyValue, KeyboardData.PreferredPos> extra_keys_custom;
+  public DeviceLocales device_locales = null;
   public Cdict current_dictionary = null; // Might be 'null'.
   public Cdict emoji_dictionary = null; // Might be 'null'.
   public IKeyEventHandler handler;

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -45,7 +45,6 @@ public class Keyboard2 extends InputMethodService
   /** Layout associated with the currently selected locale. Not 'null'. */
   private KeyboardData _localeTextLayout;
   /** Installed and current locales. */
-  private DeviceLocales _device_locales;
   private Dictionaries _dictionaries;
   private ViewGroup _emojiPane = null;
   private ViewGroup _clipboard_pane = null;
@@ -160,14 +159,14 @@ public class Keyboard2 extends InputMethodService
   {
     _config.shouldOfferVoiceTyping = true;
     KeyboardData default_layout = null;
-    _device_locales = DeviceLocales.load(this);
-    if (_device_locales.default_ != null)
+    _config.device_locales = DeviceLocales.load(this);
+    if (_config.device_locales.default_ != null)
     {
-      String layout_name = _device_locales.default_.default_layout;
+      String layout_name = _config.device_locales.default_.default_layout;
       if (layout_name != null)
         default_layout = LayoutsPreference.layout_of_string(getResources(), layout_name);
     }
-    _config.extra_keys_subtype = _device_locales.extra_keys();
+    _config.extra_keys_subtype = _config.device_locales.extra_keys();
     if (default_layout == null)
       default_layout = loadLayout(R.xml.latn_qwerty_us);
     _localeTextLayout = default_layout;
@@ -177,9 +176,9 @@ public class Keyboard2 extends InputMethodService
   {
     _config.current_dictionary = null;
     _config.emoji_dictionary = null;
-    if (_device_locales.default_ == null)
+    if (_config.device_locales.default_ == null)
       return;
-    String current = _device_locales.default_.dictionary;
+    String current = _config.device_locales.default_.dictionary;
     if (current == null)
       return;
     Cdict[] dicts = _dictionaries.load(current);

--- a/srcs/juloo.keyboard2/suggestions/CandidatesView.java
+++ b/srcs/juloo.keyboard2/suggestions/CandidatesView.java
@@ -12,6 +12,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import juloo.keyboard2.Config;
 import juloo.keyboard2.R;
 
@@ -29,9 +30,9 @@ public class CandidatesView extends LinearLayout
       set to [GONE] when there are less than [NUM_CANDIDATES] suggestions. */
   TextView[] _item_views = new TextView[NUM_CANDIDATES];
 
-  /** Optional view showing a message to the user. Visible when no candidates
-      are shown. Might be [null]. */
-  View _status_no_dict = null; // Dictionary not installed
+  /** Message when no dictionary is installed. Visible when no candidates are
+      shown. Might be [null]. */
+  View _status_no_dict = null;
 
   public CandidatesView(Context context, AttributeSet attrs)
   {
@@ -86,9 +87,10 @@ public class CandidatesView extends LinearLayout
     clear_candidates();
     // The status message indicates whether the dictionaries should be
     // installed.
-    _status_no_dict = inflate_and_show(_status_no_dict,
-        (config.current_dictionary == null),
-        R.layout.candidates_status_no_dict);
+    if (config.current_dictionary == null)
+      inflate_status_no_dict(config);
+    else if (_status_no_dict != null)
+      _status_no_dict.setVisibility(View.GONE);
     set_sizes(config);
   }
 
@@ -133,6 +135,24 @@ public class CandidatesView extends LinearLayout
       v.setVisibility(View.VISIBLE);
     }
     return v;
+  }
+
+  void inflate_status_no_dict(Config config)
+  {
+    if (_status_no_dict == null)
+    {
+      _status_no_dict = View.inflate(getContext(),
+          R.layout.candidates_status_no_dict, null);
+      addView(_status_no_dict);
+    }
+    Locale current_locale = (config.device_locales.default_ != null) ?
+      Locale.forLanguageTag(config.device_locales.default_.lang_tag) : null;
+    TextView tv = _status_no_dict.findViewById(android.R.id.text1);
+    if (tv != null && current_locale != null)
+      tv.setText(getResources().getString(
+            R.string.candidates_status_click_to_install,
+            current_locale.getDisplayName()));
+    _status_no_dict.setVisibility(View.VISIBLE);
   }
 
   private void setup_item_view(final int item_index, int item_id)


### PR DESCRIPTION
This helps understand why installing a dictionary doesn't remove the message asking to install a dictionary.

The "Install" button is removed and the message is more informative.