### PR TITLE
Add option to control behavior with physical keyboard

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -134,4 +134,12 @@
     <item>prev</item>
     <item>next</item>
   </string-array>
+  <string-array name="pref_physical_keyboard_behavior_entries">
+    <item>@string/pref_physical_keyboard_behavior_hide</item>
+    <item>@string/pref_physical_keyboard_behavior_show</item>
+  </string-array>
+  <string-array name="pref_physical_keyboard_behavior_values">
+    <item>hide</item>
+    <item>show</item>
+  </string-array>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -162,4 +162,7 @@
     <string name="dictionaries_download_failed">Download failed</string>
     <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string>
     <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string>
+    <string name="pref_physical_keyboard_behavior">When a physical keyboard is connected</string>
+    <string name="pref_physical_keyboard_behavior_hide">Hide everything</string>
+    <string name="pref_physical_keyboard_behavior_show">Show everything</string>
 </resources>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -24,6 +24,7 @@
     <CheckBoxPreference android:key="keyrepeat_enabled" android:title="@string/pref_keyrepeat_enabled" android:defaultValue="true"/>
     <juloo.keyboard2.prefs.IntSlideBarPreference android:key="longpress_interval" android:dependency="keyrepeat_enabled" android:title="@string/pref_long_interval_title" android:summary="%sms" android:defaultValue="25" min="5" max="100"/>
     <CheckBoxPreference android:key="lock_double_tap" android:title="@string/pref_lock_double_tap_title" android:summary="@string/pref_lock_double_tap_summary" android:defaultValue="false"/>
+    <ListPreference android:key="physical_keyboard_behavior" android:title="@string/pref_physical_keyboard_behavior" android:summary="%s" android:defaultValue="hide" android:entries="@array/pref_physical_keyboard_behavior_entries" android:entryValues="@array/pref_physical_keyboard_behavior_values"/>
   </PreferenceCategory>
   <PreferenceCategory android:title="@string/pref_category_behavior">
     <CheckBoxPreference android:key="autocapitalisation" android:title="@string/pref_autocapitalisation_title" android:summary="@string/pref_autocapitalisation_summary" android:defaultValue="true"/>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -75,6 +75,7 @@ public final class Config
   public boolean clipboard_history_enabled;
   public int clipboard_history_duration;
   public boolean space_bar_auto_complete;
+  public boolean physical_keyboard_hide;
 
   // Dynamically set
   /** Configuration options implied by the connected editor. */
@@ -195,7 +196,7 @@ public final class Config
     clipboard_history_enabled = _prefs.getBoolean("clipboard_history_enabled", false);
     clipboard_history_duration = Integer.parseInt(_prefs.getString("clipboard_history_duration", "5"));
     space_bar_auto_complete = _prefs.getBoolean("space_bar_auto_complete", false);
-
+    physical_keyboard_hide = _prefs.getString("physical_keyboard_behavior", "hide").equals("hide");
     float screen_width_dp = dm.widthPixels / dm.density;
     wide_screen = screen_width_dp >= WIDE_DEVICE_THRESHOLD;
   }

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -368,7 +368,8 @@ public class Keyboard2 extends InputMethodService
     if (super.onEvaluateInputViewShown())
       return true;
     if (getResources().getConfiguration().hardKeyboardHidden
-        == Configuration.HARDKEYBOARDHIDDEN_NO)
+        == Configuration.HARDKEYBOARDHIDDEN_NO
+        && _config.physical_keyboard_hide)
     {
       Logs.debug("Physical keyboard is present");
       return false;


### PR DESCRIPTION
The option can be set to "Show everything" to show the keyboard even when a physical keyboard is present.
This is a list preference to allow adding a "Show suggestions" option later.