### PR TITLE
Fix exclusion rects overlapping with the navigation bar

### DIFF
--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -294,7 +294,9 @@ public class Keyboard2View extends View
   {
     if (!changed)
       return;
-    if (VERSION.SDK_INT >= 29)
+    // Since SDK 30, this is done automatically:
+    // https://android.googlesource.com/platform/frameworks/base/+/android11-release/core/java/android/inputmethodservice/InputMethodService.java#852
+    if (VERSION.SDK_INT == 29)
     {
       // Disable the back-gesture on the keyboard area
       _cached_exclusion_rect.set(


### PR DESCRIPTION
Fix https://github.com/Julow/Unexpected-Keyboard/issues/1286#issuecomment-4621007721

Since SDK 29, calling setSystemGestureExclusionRects is mandatory to continue supporting the keyboard's gestures but since SDK 30, this is done automatically.