### PR TITLE
add hide_self key to hide keyboard

### DIFF
--- a/doc/Possible-key-values.md
+++ b/doc/Possible-key-values.md
@@ -190,6 +190,7 @@ Value                  | Meaning
 `voice_typing`         | Begin voice typing.
 `voice_typing_chooser` | Shows a menu where you can choose which voice typing provider to use, then begins voice typing when you make a selection.
 `shareText`            | Emit a share Intent for the selected text. **Oddity:** This is in CamelCase.
+`hide_self`            | Hide the keyboard.
 
 ## Unused
 These keys are known to do nothing.

--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -24,6 +24,7 @@ public final class KeyValue implements Comparable<KeyValue>
     CAPS_LOCK,
     SWITCH_VOICE_TYPING,
     SWITCH_VOICE_TYPING_CHOOSER,
+    HIDE_SELF,
   }
 
   // Must be evaluated in the reverse order of their values.
@@ -643,6 +644,7 @@ public final class KeyValue implements Comparable<KeyValue>
       case "capslock": return eventKey(0xE012, Event.CAPS_LOCK, 0);
       case "voice_typing": return eventKey(0xE015, Event.SWITCH_VOICE_TYPING, FLAG_SMALLER_FONT);
       case "voice_typing_chooser": return VOICE_TYPING_CHOOSER;
+      case "hide_self": return eventKey("⊻", Event.HIDE_SELF, FLAG_SMALLER_FONT);
 
       /* Key events */
       case "esc": return keyeventKey("Esc", KeyEvent.KEYCODE_ESCAPE, FLAG_SMALLER_FONT);

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import juloo.cdict.Cdict;
 import juloo.keyboard2.dict.Dictionaries;
@@ -475,6 +476,9 @@ public class Keyboard2 extends InputMethodService
         case SWITCH_VOICE_TYPING_CHOOSER:
           VoiceImeSwitcher.choose_voice_ime(Keyboard2.this, get_imm(),
               Config.globalPrefs());
+          break;
+        case HIDE_SELF:
+          get_imm().toggleSoftInput(0,0);
           break;
       }
     }

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -1,7 +1,5 @@
 package juloo.keyboard2;
 
-import static android.view.inputmethod.InputMethodManager.HIDE_NOT_ALWAYS;
-
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -26,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import juloo.cdict.Cdict;
 import juloo.keyboard2.dict.Dictionaries;

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -1,5 +1,7 @@
 package juloo.keyboard2;
 
+import static android.view.inputmethod.InputMethodManager.HIDE_NOT_ALWAYS;
+
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -478,7 +480,7 @@ public class Keyboard2 extends InputMethodService
               Config.globalPrefs());
           break;
         case HIDE_SELF:
-          get_imm().toggleSoftInput(0,0);
+          Keyboard2.this.requestHideSelf(0);
           break;
       }
     }


### PR DESCRIPTION
adds a `Event` key `hide_self` that will hide the keyboard when possible.

addresses issue #1325 