### PR TITLE
Split layout on tablets and foldables

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -143,10 +143,12 @@
     <item>show</item>
   </string-array>
   <string-array name="pref_split_layout_entries">
+    <item>@string/pref_split_layout_wide</item>
     <item>@string/pref_split_layout_landscape</item>
     <item>@string/pref_split_layout_never</item>
   </string-array>
   <string-array name="pref_split_layout_values">
+    <item>wide</item>
     <item>landscape</item>
     <item>never</item>
   </string-array>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -168,4 +168,5 @@
     <string name="pref_split_layout">Split layout</string>
     <string name="pref_split_layout_never">Never</string>
     <string name="pref_split_layout_landscape">In landscape orientation</string>
+    <string name="pref_split_layout_wide">On wide screens</string>
 </resources>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -11,7 +11,7 @@
     <ListPreference android:key="number_row" android:title="@string/pref_number_row_title" android:summary="%s" android:defaultValue="no_number_row" android:entries="@array/pref_show_number_row_entries" android:entryValues="@array/pref_show_number_row_values"/>
     <ListPreference android:key="show_numpad" android:title="@string/pref_show_numpad_title" android:summary="%s" android:defaultValue="1" android:entries="@array/pref_show_numpad_entries" android:entryValues="@array/pref_show_numpad_values"/>
     <ListPreference android:key="numpad_layout" android:title="@string/pref_numpad_layout" android:summary="%s" android:defaultValue="high_first" android:entries="@array/pref_numpad_layout_entries" android:entryValues="@array/pref_numpad_layout_values"/>
-    <ListPreference android:key="split_layout" android:title="@string/pref_split_layout" android:summary="%s" android:defaultValue="landscape" android:entries="@array/pref_split_layout_entries" android:entryValues="@array/pref_split_layout_values"/>
+    <ListPreference android:key="split_layout" android:title="@string/pref_split_layout" android:summary="%s" android:defaultValue="wide" android:entries="@array/pref_split_layout_entries" android:entryValues="@array/pref_split_layout_values"/>
   </PreferenceCategory>
   <PreferenceCategory android:title="@string/pref_category_suggestions">
     <CheckBoxPreference android:key="suggestions" android:title="@string/pref_suggestions_title" android:summary="@string/pref_suggestions_summary" android:defaultValue="true"/>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -134,12 +134,10 @@ public final class Config
         show_numpad = true;
       keyboardHeightPercent = _prefs.getInt(foldable_unfolded ? "keyboard_height_landscape_unfolded" : "keyboard_height_landscape", 50);
       characterSizeScale = 1.25f;
-      split_layout = _prefs.getString("split_layout", "landscape").equals("landscape");
     }
     else
     {
       keyboardHeightPercent = _prefs.getInt(foldable_unfolded ? "keyboard_height_unfolded" : "keyboard_height", 35);
-      split_layout = false;
     }
     layouts = LayoutsPreference.load_from_preferences(res, _prefs);
     inverse_numpad = _prefs.getString("numpad_layout", "default").equals("low_first");
@@ -203,6 +201,7 @@ public final class Config
     physical_keyboard_hide = _prefs.getString("physical_keyboard_behavior", "hide").equals("hide");
     float screen_width_dp = dm.widthPixels / dm.density;
     wide_screen = screen_width_dp >= WIDE_DEVICE_THRESHOLD;
+    split_layout = get_split_layout();
   }
 
   public int get_current_layout()
@@ -294,6 +293,16 @@ public final class Config
       case "next": return KeyValue.CHANGE_METHOD_NEXT;
       default:
       case "picker": return KeyValue.CHANGE_METHOD;
+    }
+  }
+
+  final boolean get_split_layout()
+  {
+    switch (_prefs.getString("split_layout", "wide"))
+    {
+      case "wide": return wide_screen;
+      case "landscape": return orientation_landscape;
+      default: return false;
     }
   }
 


### PR DESCRIPTION
Issue: https://github.com/Julow/Unexpected-Keyboard/issues/224

Split the layout on wide screens by default, not just in landscape orientation.