### PR TITLE
CI: Set gradle version

### DIFF
--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -36,6 +36,8 @@ jobs:
         java-version: '17'
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
+      with:
+        gradle-version: 8.14.4
 
     - name: Run tests
       run: |


### PR DESCRIPTION
Since gradle release, the CI fails due to the android plugin.