### PR TITLE
Add landscape variant for the number and pin layouts

### DIFF
--- a/res/xml/numeric_landscape.xml
+++ b/res/xml/numeric_landscape.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<keyboard bottom_row="false">
+  <row>
+    <key width="0.75" role="action" key0="loc esc" key2="~" key4="!"/>
+    <key width="0.75" role="action" key0="(" key2="[" key4="{"/>
+    <key key0="7"/>
+    <key key0="8"/>
+    <key key0="9"/>
+    <key shift="4" key0="7" key1="&lt;" key2="&gt;"/>
+    <key key0="8" key2="∞"/>
+    <key key0="9" key2="π"/>
+    <key width="0.75" role="action" key0="*" key1="√" key2="×" key3="\#"/>
+    <key width="0.75" role="action" key0="/" key1="%" key3="÷"/>
+  </row>
+  <row>
+    <key width="0.75" role="action" key0="loc tab" key2="|" key4="\\"/>
+    <key width="0.75" role="action" key0=")" key2="]" key4="}"/>
+    <key key0="4"/>
+    <key key0="5"/>
+    <key key0="6"/>
+    <key shift="4" key0="4" key1="box" key3="arrows"/>
+    <key key0="5" key7="up" key6="right" key5="left" key8="down"/>
+    <key key0="6"/>
+    <key width="0.75" role="action" key0="+" key1="Σ" key2="$"/>
+    <key width="0.75" role="action" key0="-" key1="^"/>
+  </row>
+  <row>
+    <key width="0.75" role="action" key0="switch_greekmath"/>
+    <key width="0.75" role="action" key0="shift" key2="fn" key4="loc alt"/>
+    <key key0="1"/>
+    <key key0="2"/>
+    <key key0="3"/>
+    <key shift="4" key0="1" key1="superscript" key2="ordinal" key3="subscript"/>
+    <key key0="2"/>
+    <key key0="3"/>
+    <key width="1.5" role="action" key0="backspace" key2="delete"/>
+  </row>
+  <row height="0.95">
+    <key width="1.5" role="action" key0="switch_text" key2="ctrl"/>
+    <key width="2" key0="0"/>
+    <key role="action" key0="." key1=":" key2="," key3=";"/>
+    <key width="1.5" shift="4" role="action" key0="space" key1="&quot;" key2="'" key3="loc compose" key4="_"/>
+    <key width="1.5" key0="0"/>
+    <key width="1.5" role="action" key0="enter" key1="±" key2="action" key3="="/>
+  </row>
+</keyboard>

--- a/res/xml/pin_landscape.xml
+++ b/res/xml/pin_landscape.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<keyboard width="13.0" bottom_row="false">
+  <row>
+    <key shift="1" key0="1"/>
+    <key key0="2"/>
+    <key key0="3"/>
+    <key shift="5" key0="1"/>
+    <key key0="2" indication="ABC"/>
+    <key key0="3" indication="DEF"/>
+    <key role="action" key0="backspace" key2="delete"/>
+  </row>
+  <row>
+    <key shift="1" key0="4"/>
+    <key key0="5"/>
+    <key key0="6"/>
+    <key shift="5" key0="4" indication="GHI"/>
+    <key key0="5" indication="JKL"/>
+    <key key0="6" indication="MNO"/>
+    <key role="action" key0="(" key1="paste" key2="=" key3=":" key4="-"/>
+  </row>
+  <row>
+    <key shift="1" key0="7"/>
+    <key key0="8"/>
+    <key key0="9"/>
+    <key shift="5" key0="7" indication="PQRS"/>
+    <key key0="8" indication="TUV"/>
+    <key key0="9" indication="WXYZ"/>
+    <key role="action" key0=")" key2="," key3="/" key4="."/>
+  </row>
+  <row>
+    <key shift="1" width="1.5" key0="0"/>
+    <key width="1.5" role="action" key0="space"/>
+    <key shift="5" role="action" key0="*" key1="switch_text" key3="switch_numeric"/>
+    <key key0="0" key3="+" key4="space"/>
+    <key role="action" key0="\#" key7="up" key6="right" key5="left" key8="down"/>
+    <key role="action" key0="action" key2="enter"/>
+  </row>
+</keyboard>

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -109,6 +109,12 @@ public class Keyboard2 extends InputMethodService
         current_layout_unmodified());
   }
 
+  KeyboardData loadNumericLayout()
+  {
+    return loadNumpad(_config.orientation_landscape ?
+        R.xml.numeric_landscape : R.xml.numeric);
+  }
+
   KeyboardData loadPinentry(int layout_id)
   {
     return LayoutModifier.modify_pinentry(KeyboardData.load(getResources(), layout_id),
@@ -227,8 +233,11 @@ public class Keyboard2 extends InputMethodService
     {
       switch (_config.selected_number_layout)
       {
-        case PIN: return loadPinentry(R.xml.pin);
-        case NUMBER: return loadNumpad(R.xml.numeric);
+        case PIN:
+          return loadPinentry(_config.orientation_landscape ?
+              R.xml.pin_landscape : R.xml.pin);
+        case NUMBER:
+          return loadNumericLayout();
       }
     }
     return null;
@@ -407,7 +416,7 @@ public class Keyboard2 extends InputMethodService
           break;
 
         case SWITCH_NUMERIC:
-          setSpecialLayout(loadNumpad(R.xml.numeric));
+          setSpecialLayout(loadNumericLayout());
           break;
 
         case SWITCH_EMOJI:


### PR DESCRIPTION
Related: https://github.com/Julow/Unexpected-Keyboard/pull/1334

The number pane and the pin entry layouts are split in landscape orientation. Instead of inserting empty space in the middle of the layout, the numpad is duplicated. The other keys are not duplicated.