### PR TITLE
Suggestion bar to the middle of split layouts

### DIFF
--- a/res/xml/split_middle_column.xml
+++ b/res/xml/split_middle_column.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file define a row but it's layed out as a column instead in
+     [LayoutLandscapeModifier]. -->
+<row>
+  <key role="suggestion" width="1" c="complete_emoji"/>
+  <key role="suggestion" width="3" c="complete_first"/>
+  <key role="suggestion" width="3" c="complete_second"/>
+  <key role="suggestion" width="3" c="complete_third"/>
+</row>

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -202,7 +202,8 @@ public class Keyboard2 extends InputMethodService
   {
     boolean should_show =
       _config.suggestions_enabled
-      && _config.editor_config.should_show_candidates_view;
+      && _config.editor_config.should_show_candidates_view
+      && !_config.split_layout;
     if (should_show)
       _candidates_view.refresh_config(_config);
     _candidates_view.setVisibility(should_show ? View.VISIBLE : View.GONE);

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -359,6 +359,7 @@ public class Keyboard2View extends View
           {
             case Action: tc_key = _tc.key_action; break;
             case Space_bar: tc_key = _tc.key_space_bar; break;
+            case Suggestion: tc_key = _tc.key_suggestion; break;
             default:
             case Normal: tc_key = _tc.key; break;
           }

--- a/srcs/juloo.keyboard2/KeyboardData.java
+++ b/srcs/juloo.keyboard2/KeyboardData.java
@@ -568,7 +568,8 @@ public final class KeyboardData
     {
       Normal,
       Action, // Generally Shift, Delete and keys on the bottom row
-      Space_bar;
+      Space_bar,
+      Suggestion;
 
       public static Role parse(String str)
       {
@@ -576,6 +577,7 @@ public final class KeyboardData
         {
           case "action": return Action;
           case "space_bar": return Space_bar;
+          case "suggestion": return Suggestion;
           default: case "normal": return Normal;
         }
       }

--- a/srcs/juloo.keyboard2/LayoutLandscapeModifier.java
+++ b/srcs/juloo.keyboard2/LayoutLandscapeModifier.java
@@ -11,17 +11,19 @@ public final class LayoutLandscapeModifier
   public static KeyboardData transform_to_landscape(KeyboardData kw)
   {
     ArrayList<KeyboardData.Row> new_rows = new ArrayList<KeyboardData.Row>();
+    // Bottom row as index 0. Used by [add_middle_column] below.
+    int row_index = kw.rows.size() - 1;
     for (KeyboardData.Row r : kw.rows)
-      new_rows.add(split_row(r));
+      new_rows.add(split_row(r, row_index--));
     return kw.with_rows(new_rows);
   }
 
   public static KeyboardData.Row transform_number_row(KeyboardData.Row r)
   {
-    return split_row(r);
+    return split_row(r, -1);
   }
 
-  static KeyboardData.Row split_row(KeyboardData.Row r)
+  static KeyboardData.Row split_row(KeyboardData.Row r, int row_index)
   {
     if (r.keys.size() < 2)
       return r;
@@ -39,24 +41,27 @@ public final class LayoutLandscapeModifier
       if (off > mid_start || i == end)
       {
         if (off > mid_end)
-          return duplicate_at_index(r, i, off);
-        return split_at_index(r, i + 1);
+          return duplicate_at_index(r, i, off, row_index);
+        return split_at_index(r, i + 1, row_index);
       }
     }
   }
 
   /** Insert [ADDED_WIDTH] empty space before the key at index [i]. */
-  static KeyboardData.Row split_at_index(KeyboardData.Row r, int i)
+  static KeyboardData.Row split_at_index(KeyboardData.Row r, int i,
+      int row_index)
   {
     List<KeyboardData.Key> new_keys = new ArrayList<KeyboardData.Key>(r.keys);
     KeyboardData.Key k = new_keys.get(i);
     new_keys.set(i, k.withShift(k.shift + ADDED_WIDTH));
+    add_middle_key(new_keys, i, row_index);
     return r.with_keys(new_keys);
   }
 
   /** Duplicate the key at index [i] and insert [ADDED_WIDTH] empty space in
       between. */
-  static KeyboardData.Row duplicate_at_index(KeyboardData.Row r, int i, float off)
+  static KeyboardData.Row duplicate_at_index(KeyboardData.Row r, int i,
+      float off, int row_index)
   {
     List<KeyboardData.Key> new_keys = new ArrayList<KeyboardData.Key>(r.keys);
     KeyboardData.Key k = new_keys.get(i);
@@ -67,7 +72,22 @@ public final class LayoutLandscapeModifier
     float mid_d = Math.min(off - (r.keysWidth + k.width) / 2, k_width - 1);
     new_keys.add(i + 1, k.withWidthAndShift(k_width + mid_d, ADDED_WIDTH - 1));
     new_keys.set(i, k.withWidth(k_width - mid_d));
+    add_middle_key(new_keys, i + 1, row_index);
     return r.with_keys(new_keys);
+  }
+
+  /** Add the middle column defined in [split_middle_column.xml]. */
+  static void add_middle_key(List<KeyboardData.Key> new_keys, int i,
+      int row_index)
+  {
+    List<KeyboardData.Key> mid_keys = LayoutModifier.split_middle_column.keys;
+    if (row_index >= mid_keys.size())
+      return;
+    KeyboardData.Key mid_key = mid_keys.get(row_index);
+    KeyboardData.Key right_key = new_keys.get(i);
+    float shift = (right_key.shift - mid_key.width) / 2.f;
+    new_keys.set(i, right_key.withShift(shift));
+    new_keys.add(i, mid_key.withShift(shift));
   }
 
 }

--- a/srcs/juloo.keyboard2/LayoutModifier.java
+++ b/srcs/juloo.keyboard2/LayoutModifier.java
@@ -14,6 +14,8 @@ public final class LayoutModifier
   static KeyboardData.Row number_row_no_symbols;
   static KeyboardData.Row number_row_symbols;
   static KeyboardData num_pad;
+  // Not used in this file but defined here for convenience.
+  public static KeyboardData.Row split_middle_column;
 
   /** Update the layout according to the configuration.
    *  - Remove the switching key if it isn't needed
@@ -209,6 +211,7 @@ public final class LayoutModifier
       number_row_symbols = KeyboardData.load_row(res, R.xml.number_row);
       bottom_row = KeyboardData.load_row(res, R.xml.bottom_row);
       num_pad = KeyboardData.load_num_pad(res);
+      split_middle_column = KeyboardData.load_row(res, R.xml.split_middle_column);
     }
     catch (Exception e)
     {

--- a/srcs/juloo.keyboard2/Theme.java
+++ b/srcs/juloo.keyboard2/Theme.java
@@ -111,6 +111,7 @@ public class Theme
     public final Key key_activated;
     public final Key key_action;
     public final Key key_space_bar;
+    public final Key key_suggestion;
 
     public Computed(Theme theme, Config config, float keyWidth, KeyboardData layout)
     {
@@ -128,6 +129,7 @@ public class Theme
       key_action = new Key(theme, config, keyWidth, false, KeyboardData.Key.Role.Action);
       key_space_bar = new Key(theme, config, keyWidth, false, KeyboardData.Key.Role.Space_bar);
       key_activated = new Key(theme, config, keyWidth, true, KeyboardData.Key.Role.Normal);
+      key_suggestion = new Key(theme, config, keyWidth, false, KeyboardData.Key.Role.Suggestion);
       indication_paint = init_label_paint(config, null);
       indication_paint.setColor(theme.subLabelColor);
     }
@@ -169,6 +171,10 @@ public class Theme
             case Space_bar:
               bg_color = theme.colorKeySpaceBar;
               border_width = theme.keyBorderWidthSpaceBar;
+              break;
+            case Suggestion:
+              bg_color = 0;
+              border_width = 0;
               break;
             default:
               bg_color = theme.colorKey;


### PR DESCRIPTION
When the layout is split, insert a middle column showing the complete_first, complete_second, etc.. keys.
These keys are rendered without borders and background with a new role.

The suggestion bar is hidden for split layouts. The intention is to gain much needed vertical space.