### PR TITLE
More informative "download failed" message

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -154,7 +154,6 @@
     <string name="pref_dialog_edit_text">eigene Definition</string>
     <string name="dictionaries_from_internet">Lade ein Wörterbuch aus dem Internet</string>
     <string name="dictionaries_download_success">Wörterbuch installiert</string>
-    <string name="dictionaries_download_failed">Herunterladen fehlgeschlagen</string>
     <string name="dictionaries_activity_not_enabled">Du musst die Tastatur aktivieren um Wörterbücher herunterzuladen.</string>
     <string name="pref_portrait_unfolded">im Hochformat aufgeklappt</string>
     <string name="pref_landscape_unfolded">Im Querformat aufgeklappt</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -159,6 +159,5 @@
     <string name="pref_dialog_edit_text">Definición personalizada</string>
     <string name="dictionaries_from_internet">Descargar un diccionario de internet</string>
     <string name="dictionaries_download_success">Diccionario instalado</string>
-    <string name="dictionaries_download_failed">Falló la descarga</string>
     <string name="dictionaries_activity_not_enabled">Primero tienes que habilitar al teclado para descargar diccionarios.</string>
 </resources>

--- a/res/values-et/strings.xml
+++ b/res/values-et/strings.xml
@@ -144,7 +144,6 @@
     <string name="key_descr_end">Lõpp</string>
     <string name="key_descr_ª">Järgarvu tunnus</string>
     <string name="dictionaries_download_success">Sõnastik on paigaldatud</string>
-    <string name="dictionaries_download_failed">Allalaadimine ei õnnestunud</string>
     <string name="dictionaries_activity_not_enabled">Sõnastike allalaadimiseks pead esmalt klahvistiku kasutusele võtma.</string>
     <string name="key_descr_clipboard">Lõikelaua haldur</string>
     <string name="key_descr_combining">Täpitähemärkide kombineerimine</string>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -132,6 +132,5 @@
     <string name="pref_clipboard_history_duration_stop">تا زمان بسته شدن برنامه</string>
     <string name="dictionaries_from_internet">دانلود دیکشنری از اینترنت</string>
     <string name="dictionaries_download_success">دیکشنری نصب شد</string>
-    <string name="dictionaries_download_failed">دانلود با خطا مواجه شد</string>
     <string name="dictionaries_activity_not_enabled">شما ابتدا باید صفحه کلید را برای دانلود دیکشنری ها فعال کنید.</string>
 </resources>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -159,7 +159,6 @@
     <string name="pref_dialog_edit_text">Personnalisée</string>
     <string name="dictionaries_from_internet">Télécharger un dictionnaire depuis Internet</string>
     <string name="dictionaries_download_success">Dictionnaire installé</string>
-    <string name="dictionaries_download_failed">Le téléchargement a échoué</string>
     <string name="dictionaries_activity_not_enabled">Vous devez d\'abord activer le clavier.</string>
     <string name="candidates_status_click_to_install">Cliquez pour installer un dictionnaire pour le %s</string>
 </resources>

--- a/res/values-lv/strings.xml
+++ b/res/values-lv/strings.xml
@@ -131,7 +131,6 @@
     <string name="pref_theme_e_epaperblack">ePapīrs melns</string>
     <string name="launcher_button_dictionaries">Uzstādīt vārdnīcas</string>
     <string name="dictionaries_download_success">Vārdnīca uzstādīta</string>
-    <string name="dictionaries_download_failed">Neizdevās lejupielādēt</string>
     <string name="key_descr_delete_word">Dzēst vārdu</string>
     <string name="pref_clipboard_history_duration">Starpliktuves glabāšanas ilgums</string>
     <string name="pref_change_method_key_replacement_e_prev">Pārslēgties uz pēdējo izmantoto</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -158,7 +158,6 @@
     <string name="pref_clipboard_history_duration_stop">Do zatrzymania aplikacji</string>
     <string name="dictionaries_from_internet">Pobierz słownik z internetu</string>
     <string name="dictionaries_download_success">Słownik zainstalowany</string>
-    <string name="dictionaries_download_failed">Pobieranie nieudane</string>
     <string name="dictionaries_activity_not_enabled">Aby pobrać słowniki, najpierw włącz klawiaturę.</string>
     <string name="pref_dialog_edit_text">Własna definicja</string>
 </resources>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -158,7 +158,6 @@
     <string name="pref_clipboard_history_duration_stop">До остановки приложения</string>
     <string name="dictionaries_from_internet">Загрузить словарь из Интернета</string>
     <string name="dictionaries_download_success">Словарь установлен</string>
-    <string name="dictionaries_download_failed">Ошибка при загрузке</string>
     <string name="dictionaries_activity_not_enabled">Необходимо включить клавиатуру до загрузки словарей.</string>
     <string name="pref_dialog_edit_text">Собственное определение</string>
     <string name="candidates_status_click_to_install">Нажмите, чтобы установить словарь для %s</string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -159,6 +159,5 @@
     <string name="pref_dialog_edit_text">自定義</string>
     <string name="dictionaries_from_internet">從網路下載字典</string>
     <string name="dictionaries_download_success">字典已安裝</string>
-    <string name="dictionaries_download_failed">下載失敗</string>
     <string name="dictionaries_activity_not_enabled">需要啟用鍵盤才能下載字典。</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -159,7 +159,7 @@
     <string name="pref_dialog_edit_text">Custom definition</string>
     <string name="dictionaries_from_internet">Download a dictionary from the Internet</string>
     <string name="dictionaries_download_success">Dictionary installed</string>
-    <string name="dictionaries_download_failed">Download failed</string>
+    <string name="dictionaries_download_failed">Download failed: Please allow internet access</string>
     <string name="dictionaries_activity_not_enabled">You must first enable the keyboard to download dictionaries.</string>
     <string name="candidates_status_click_to_install">Click to install a dictionary for %s</string>
     <string name="pref_physical_keyboard_behavior">When a physical keyboard is connected</string>


### PR DESCRIPTION
Fix: https://github.com/Julow/Unexpected-Keyboard/issues/1347

Ask users to allow internet access, which will make sense to users of grapheneOS and other systems that restrict internet access to apps.