### PR TITLE
Prototype: embed direct Doubao voice input

### DIFF
--- a/.github/workflows/make-apk.yml
+++ b/.github/workflows/make-apk.yml
@@ -1,10 +1,8 @@
-name: Make Apk CI
+name: Build Doubao APK
 
 on:
   workflow_dispatch:
   push:
-    branches:
-      - master
   pull_request:
 
 jobs:
@@ -41,10 +39,11 @@ jobs:
 
     - name: Run tests
       run: |
-        gradle test
+        gradle checkKeyboardLayouts testDebugUnitTest
         # Warn about outdated generated files.
-        if ! git diff --name-only; then
+        if ! git diff --quiet; then
           echo "Warning: Generated files are not uptodate. Run 'gradle test'."
+          git diff --name-only
         fi
 
     - name: Build debug APK
@@ -57,11 +56,12 @@ jobs:
 
     - name: Artifact naming
       run: |
-        artifact="${{github.repository_owner}} ${{github.ref_name}}"
+        artifact="Unexpected-Keyboard-Doubao ${{github.ref_name}}"
         artifact="${artifact//\//-}" # replace slashes
         echo "artifact=${artifact}" >> $GITHUB_ENV
     - name: Upload debug APK
       uses: actions/upload-artifact@v4
       with:
-        name: "${{env.artifact}} debug_apk"
+        name: "${{env.artifact}} debug-apk"
         path: build/outputs/apk/debug/*.apk
+        if-no-files-found: error

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,6 +4,8 @@
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+  <uses-feature android:name="android.hardware.microphone" android:required="false"/>
 
   <application android:label="@string/app_name" android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:hardwareAccelerated="false">
     <service android:name="juloo.keyboard2.Keyboard2" android:label="@string/app_name" android:permission="android.permission.BIND_INPUT_METHOD" android:exported="true" android:directBootAware="true">
@@ -31,6 +33,11 @@
         <action android:name="android.intent.action.MAIN"/>
       </intent-filter>
     </activity>
+
+    <activity android:name="juloo.keyboard2.VoicePermissionActivity"
+      android:theme="@android:style/Theme.Translucent.NoTitleBar"
+      android:exported="false"
+      android:excludeFromRecents="true"/>
   </application>
 
   <!-- To query enabled input methods for voice IME detection -->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,9 @@ dependencies {
   // Following versions of androidx.window require sdk version 23
   implementation("androidx.window:window-java:1.4.0")
   implementation("androidx.core:core:1.16.0") // Version 1.17.0 available with sdk 36
+  implementation("com.google.code.gson:gson:2.14.0")
+  implementation("com.squareup.okhttp3:okhttp:5.4.0")
+  implementation("io.github.jaredmdobson:concentus:1.0.2")
   testImplementation("junit:junit:4.13.2")
 }
 
@@ -17,7 +20,7 @@ android {
   compileSdkVersion = "android-36"
 
   defaultConfig {
-    applicationId = "juloo.keyboard2"
+    applicationId = "com.molaison.unexpectedkeyboard.doubao"
     minSdk = 21
     targetSdk { version = release(36) }
     versionCode = 55
@@ -74,7 +77,7 @@ android {
         "proguard-rules.pro")
       isShrinkResources = true
       isDebuggable = false
-      resValue("string", "app_name", "@string/app_name_release")
+      resValue("string", "app_name", "@string/app_name_doubao")
       signingConfig = signingConfigs["release"]
     }
 
@@ -82,8 +85,7 @@ android {
       isMinifyEnabled = false
       isShrinkResources = false
       isDebuggable = true
-      applicationIdSuffix = ".debug"
-      resValue("string", "app_name", "@string/app_name_debug")
+      resValue("string", "app_name", "@string/app_name_doubao")
       resValue("bool", "debug_logs", "true")
       signingConfig = signingConfigs["debug"]
     }

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -119,4 +119,10 @@
     <string name="clipboard_pin_heading">已固定</string>
     <string name="clipboard_remove_confirm">确定移除此剪贴内容？</string>
     <string name="clipboard_remove_confirmed">确定</string>
+    <string name="toast_voice_connecting">正在连接豆包语音输入…</string>
+    <string name="toast_voice_listening">正在聆听…再次点击语音键即可停止</string>
+    <string name="toast_voice_finishing">正在完成语音输入…</string>
+    <string name="toast_voice_permission_granted">已授予麦克风权限</string>
+    <string name="toast_voice_permission_denied">语音输入需要麦克风权限</string>
+    <string name="toast_voice_input_failed">语音输入失败：%1$s</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name_release">Unexpected Keyboard</string>
     <string name="app_name_debug">Unexpected Keyboard (Debug)</string>
+    <string name="app_name_doubao">Unexpected Keyboard (Doubao)</string>
     <string name="short_description">Lightweight and privacy-conscious virtual keyboard for Android.</string>
     <string name="store_description">The main feature is that you can type more characters by swiping the keys towards the corners.\n\nThis application was originally designed for programmers using Termux.\nNow perfect for everyday use.\n\nThis application contains no ads and is Open Source.</string>
     <string name="pref_portrait">In portrait mode</string>
@@ -150,6 +151,12 @@
     <string name="clipboard_remove_confirm">Remove this clipboard item?</string>
     <string name="clipboard_remove_confirmed">Yes</string>
     <string name="toast_no_voice_input">No voice typing app installed</string>
+    <string name="toast_voice_connecting" tools:ignore="MissingTranslation">Connecting to Doubao voice input…</string>
+    <string name="toast_voice_listening" tools:ignore="MissingTranslation">Listening… Tap the voice key again to stop</string>
+    <string name="toast_voice_finishing" tools:ignore="MissingTranslation">Finishing voice input…</string>
+    <string name="toast_voice_permission_granted" tools:ignore="MissingTranslation">Microphone permission granted</string>
+    <string name="toast_voice_permission_denied" tools:ignore="MissingTranslation">Microphone permission is required for voice input</string>
+    <string name="toast_voice_input_failed" tools:ignore="MissingTranslation">Voice input failed: %1$s</string>
     <string name="pref_category_clipboard">Clipboard</string>
     <string name="pref_clipboard_history_duration">Clipboard memory duration</string>
     <string name="pref_clipboard_history_duration_1">At most 1 minute</string>

--- a/res/xml/bottom_row.xml
+++ b/res/xml/bottom_row.xml
@@ -2,7 +2,8 @@
 <row height="0.95">
   <key width="1.7" role="action" key0="ctrl" key1="loc switch_greekmath" key2="loc meta" key3="loc switch_clipboard" key4="switch_numeric"/>
   <key width="1.1" role="action" key0="fn" key1="loc alt" key2="loc change_method" key3="switch_emoji" key4="config"/>
-  <key width="4.4" role="space_bar" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right"/>
+  <key width="3.5" role="space_bar" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right"/>
+  <key width="0.9" role="action" key0="voice_typing"/>
   <key width="1.1" role="action" key0="loc compose" key7="up" key6="right" key5="left" key8="down" key1="loc home" key2="loc page_up" key3="loc end" key4="loc page_down"/>
-  <key width="1.7" role="action" key0="enter" key1="loc voice_typing" key2="action"/>
+  <key width="1.7" role="action" key0="enter" key2="action"/>
 </row>

--- a/srcs/juloo.keyboard2/KeyEventHandler.java
+++ b/srcs/juloo.keyboard2/KeyEventHandler.java
@@ -74,6 +74,12 @@ public final class KeyEventHandler
   {
     if (key == null)
       return;
+    if (key.getKind() == KeyValue.Kind.Event
+        && key.getEvent() == KeyValue.Event.SWITCH_VOICE_TYPING_CHOOSER)
+    {
+      _recv.handle_event_key(KeyValue.Event.SWITCH_VOICE_TYPING_CHOOSER);
+      return;
+    }
     // Stop auto capitalisation when pressing some keys
     switch (key.getKind())
     {
@@ -112,7 +118,12 @@ public final class KeyEventHandler
     {
       case Char: send_text(String.valueOf(key.getChar())); break;
       case String: send_text(key.getString()); break;
-      case Event: _recv.handle_event_key(key.getEvent()); break;
+      case Event:
+        if (key.getEvent() == KeyValue.Event.SWITCH_VOICE_TYPING_CHOOSER)
+          _recv.handle_event_key(KeyValue.Event.STOP_VOICE_TYPING_HOLD);
+        else
+          _recv.handle_event_key(key.getEvent());
+        break;
       case Keyevent: send_key_down_up(key.getKeyevent()); break;
       case Modifier: break;
       case Editing: handle_editing_key(key.getEditing()); break;

--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -24,6 +24,7 @@ public final class KeyValue implements Comparable<KeyValue>
     CAPS_LOCK,
     SWITCH_VOICE_TYPING,
     SWITCH_VOICE_TYPING_CHOOSER,
+    STOP_VOICE_TYPING_HOLD,
     HIDE_SELF,
   }
 

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -1,8 +1,10 @@
 package juloo.keyboard2;
 
+import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.inputmethodservice.InputMethodService;
@@ -19,6 +21,8 @@ import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodSubtype;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
+import android.widget.Toast;
+import androidx.core.content.ContextCompat;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,6 +32,7 @@ import java.util.Set;
 import juloo.cdict.Cdict;
 import juloo.keyboard2.dict.Dictionaries;
 import juloo.keyboard2.dict.DictionariesActivity;
+import juloo.keyboard2.doubao.DoubaoVoiceInput;
 import juloo.keyboard2.prefs.LayoutsPreference;
 import juloo.keyboard2.suggestions.CandidatesView;
 import juloo.keyboard2.suggestions.Suggestions;
@@ -50,6 +55,9 @@ public class Keyboard2 extends InputMethodService
   private ViewGroup _emojiPane = null;
   private ViewGroup _clipboard_pane = null;
   private Handler _handler;
+  private DoubaoVoiceInput _doubaoVoiceInput;
+  private boolean _startVoiceAfterPermission;
+  private boolean _voicePushToTalkActive;
 
   private Config _config;
 
@@ -134,6 +142,7 @@ public class Keyboard2 extends InputMethodService
         _foldStateTracker.isUnfolded(), _dictionaries);
     _config = Config.globalConfig();
     Receiver recvr = this.new Receiver();
+    _doubaoVoiceInput = new DoubaoVoiceInput(this, recvr);
     _suggestions = new Suggestions(recvr, _config);
     _keyeventhandler = new KeyEventHandler(recvr, _suggestions);
     KeyValue.Stateful._handler = recvr;
@@ -148,9 +157,10 @@ public class Keyboard2 extends InputMethodService
 
   @Override
   public void onDestroy() {
-    super.onDestroy();
-
+    _voicePushToTalkActive = false;
+    _doubaoVoiceInput.shutdown();
     _foldStateTracker.close();
+    super.onDestroy();
   }
 
   private void create_keyboard_view()
@@ -251,6 +261,8 @@ public class Keyboard2 extends InputMethodService
   @Override
   public void onStartInputView(EditorInfo info, boolean restarting)
   {
+    _voicePushToTalkActive = false;
+    _doubaoVoiceInput.cancel();
     _config.editor_config.refresh(info, getResources());
     refresh_config();
     _currentSpecialLayout = refresh_special_layout();
@@ -258,6 +270,12 @@ public class Keyboard2 extends InputMethodService
     _keyeventhandler.started(_config);
     setInputView(_keyboard_container_view);
     Logs.debug_startup_input_view(info, _config);
+    if (_startVoiceAfterPermission)
+    {
+      _startVoiceAfterPermission = false;
+      if (has_record_audio_permission())
+        _handler.post(() -> start_doubao_voice_input());
+    }
   }
 
   @Override
@@ -357,8 +375,88 @@ public class Keyboard2 extends InputMethodService
   @Override
   public void onFinishInputView(boolean finishingInput)
   {
+    _voicePushToTalkActive = false;
+    _doubaoVoiceInput.cancel();
     super.onFinishInputView(finishingInput);
     _keyboard_layout_view.reset();
+  }
+
+  private boolean has_record_audio_permission()
+  {
+    return ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO)
+      == PackageManager.PERMISSION_GRANTED;
+  }
+
+  private void toggle_doubao_voice_input()
+  {
+    _voicePushToTalkActive = false;
+    if (_doubaoVoiceInput.isActive())
+    {
+      run_doubao_voice_action(() -> _doubaoVoiceInput.toggle());
+      return;
+    }
+    if (!has_record_audio_permission())
+    {
+      _startVoiceAfterPermission = true;
+      Intent intent = new Intent(this, VoicePermissionActivity.class);
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      startActivity(intent);
+      return;
+    }
+    _startVoiceAfterPermission = false;
+    run_doubao_voice_action(() -> _doubaoVoiceInput.start());
+  }
+
+  private void start_doubao_voice_input()
+  {
+    _voicePushToTalkActive = false;
+    run_doubao_voice_action(() -> _doubaoVoiceInput.start());
+  }
+
+  private void start_doubao_voice_hold()
+  {
+    if (_doubaoVoiceInput.isActive())
+    {
+      Log.i("Unexpected/DoubaoASR", "voice_hold_ignored_already_active");
+      return;
+    }
+    if (!has_record_audio_permission())
+    {
+      _startVoiceAfterPermission = false;
+      Intent intent = new Intent(this, VoicePermissionActivity.class);
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      startActivity(intent);
+      return;
+    }
+    run_doubao_voice_action(() -> {
+      _doubaoVoiceInput.start();
+      _voicePushToTalkActive = true;
+    });
+  }
+
+  private void stop_doubao_voice_hold()
+  {
+    if (!_voicePushToTalkActive)
+      return;
+    _voicePushToTalkActive = false;
+    run_doubao_voice_action(() -> _doubaoVoiceInput.stop());
+  }
+
+  private void run_doubao_voice_action(Runnable action)
+  {
+    try
+    {
+      action.run();
+    }
+    catch (RuntimeException error)
+    {
+      Log.e("Unexpected/DoubaoASR", "Voice input action failed", error);
+      Toast.makeText(this,
+          getString(R.string.toast_voice_input_failed,
+            error.getMessage() == null
+              ? error.getClass().getSimpleName() : error.getMessage()),
+          Toast.LENGTH_LONG).show();
+    }
   }
 
   @Override
@@ -406,6 +504,7 @@ public class Keyboard2 extends InputMethodService
 
   /** Not static */
   public class Receiver implements KeyEventHandler.IReceiver,
+         DoubaoVoiceInput.Host,
          KeyValue.Stateful.Symbol_provider
   {
     public void handle_event_key(KeyValue.Event ev)
@@ -483,14 +582,18 @@ public class Keyboard2 extends InputMethodService
           break;
 
         case SWITCH_VOICE_TYPING:
-          if (!VoiceImeSwitcher.switch_to_voice_ime(Keyboard2.this, get_imm(),
-                Config.globalPrefs()))
-            _config.shouldOfferVoiceTyping = false;
+          Log.i("Unexpected/DoubaoASR", "voice_key_event=toggle");
+          toggle_doubao_voice_input();
           break;
 
         case SWITCH_VOICE_TYPING_CHOOSER:
-          VoiceImeSwitcher.choose_voice_ime(Keyboard2.this, get_imm(),
-              Config.globalPrefs());
+          Log.i("Unexpected/DoubaoASR", "voice_key_event=hold_start");
+          start_doubao_voice_hold();
+          break;
+
+        case STOP_VOICE_TYPING_HOLD:
+          Log.i("Unexpected/DoubaoASR", "voice_key_event=hold_stop");
+          stop_doubao_voice_hold();
           break;
         case HIDE_SELF:
           Keyboard2.this.requestHideSelf(0);
@@ -516,6 +619,34 @@ public class Keyboard2 extends InputMethodService
     public InputConnection getCurrentInputConnection()
     {
       return Keyboard2.this.getCurrentInputConnection();
+    }
+
+    public void onVoiceStateChanged(DoubaoVoiceInput.State state)
+    {
+      int message;
+      switch (state)
+      {
+        case CONNECTING:
+          message = R.string.toast_voice_connecting;
+          break;
+        case LISTENING:
+          message = R.string.toast_voice_listening;
+          break;
+        case FINISHING:
+          message = R.string.toast_voice_finishing;
+          break;
+        case IDLE:
+        default:
+          return;
+      }
+      Toast.makeText(Keyboard2.this, message, Toast.LENGTH_SHORT).show();
+    }
+
+    public void onVoiceFailure(String message)
+    {
+      Toast.makeText(Keyboard2.this,
+          getString(R.string.toast_voice_input_failed, message),
+          Toast.LENGTH_LONG).show();
     }
 
     public Handler getHandler()

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -58,6 +58,7 @@ public class Keyboard2 extends InputMethodService
   private DoubaoVoiceInput _doubaoVoiceInput;
   private boolean _startVoiceAfterPermission;
   private boolean _voicePushToTalkActive;
+  private Toast _voiceStateToast;
 
   private Config _config;
 
@@ -623,6 +624,14 @@ public class Keyboard2 extends InputMethodService
 
     public void onVoiceStateChanged(DoubaoVoiceInput.State state)
     {
+      _keyboard_layout_view.set_voice_input_active(
+          state == DoubaoVoiceInput.State.CONNECTING
+          || state == DoubaoVoiceInput.State.LISTENING);
+      if (_voiceStateToast != null)
+      {
+        _voiceStateToast.cancel();
+        _voiceStateToast = null;
+      }
       int message;
       switch (state)
       {
@@ -633,13 +642,13 @@ public class Keyboard2 extends InputMethodService
           message = R.string.toast_voice_listening;
           break;
         case FINISHING:
-          message = R.string.toast_voice_finishing;
-          break;
         case IDLE:
         default:
           return;
       }
-      Toast.makeText(Keyboard2.this, message, Toast.LENGTH_SHORT).show();
+      _voiceStateToast =
+        Toast.makeText(Keyboard2.this, message, Toast.LENGTH_SHORT);
+      _voiceStateToast.show();
     }
 
     public void onVoiceFailure(String message)

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -32,6 +32,10 @@ public class Keyboard2View extends View
   /** Used to add fake pointers. */
   private KeyboardData.Key _compose_key;
 
+  /** Dedicated voice-typing action key. */
+  private KeyboardData.Key _voice_key;
+  private boolean _voice_input_active;
+
   private Pointers _pointers;
 
   private Pointers.Modifiers _mods;
@@ -109,6 +113,8 @@ public class Keyboard2View extends View
     _keyboard = kw;
     _shift_key = _keyboard.findKeyWithValue(KeyValue.SHIFT);
     _compose_key = _keyboard.findKeyWithValue(KeyValue.COMPOSE);
+    _voice_key =
+      _keyboard.findKeyWithValue(KeyValue.getKeyByName("voice_typing"));
     KeyModifier.set_modmap(_keyboard.modmap);
     reset();
   }
@@ -139,6 +145,12 @@ public class Keyboard2View extends View
   public void set_compose_pending(boolean pending)
   {
     set_fake_ptr_latched(_compose_key, KeyValue.COMPOSE, pending, false);
+  }
+
+  public void set_voice_input_active(boolean active)
+  {
+    _voice_input_active = active;
+    invalidate();
   }
 
   /** Called from [Keybard2.onUpdateSelection].  */
@@ -350,7 +362,8 @@ public class Keyboard2View extends View
       {
         x += k.shift * _keyWidth;
         float keyW = _keyWidth * k.width - _tc.horizontal_margin;
-        boolean isKeyDown = _pointers.isKeyDown(k);
+        boolean isKeyDown =
+          _pointers.isKeyDown(k) || (_voice_input_active && k == _voice_key);
         Theme.Computed.Key tc_key;
         if (isKeyDown)
           tc_key = _tc.key_activated;
@@ -417,6 +430,10 @@ public class Keyboard2View extends View
 
   private int labelColor(KeyValue k, boolean isKeyDown, boolean sublabel)
   {
+    if (_voice_input_active
+        && k.getKind() == KeyValue.Kind.Event
+        && k.getEvent() == KeyValue.Event.SWITCH_VOICE_TYPING)
+      return _theme.lockedColor;
     if (isKeyDown)
     {
       int flags = _pointers.getKeyFlags(k);

--- a/srcs/juloo.keyboard2/Pointers.java
+++ b/srcs/juloo.keyboard2/Pointers.java
@@ -185,8 +185,18 @@ public final class Pointers implements Handler.Callback
 
   public void onTouchCancel()
   {
+    for (Pointer ptr : _ptrs)
+      if (isVoiceTypingHold(ptr.value))
+        _handler.onPointerUp(ptr.value, ptr.modifiers);
     clear();
     _handler.onPointerFlagsChanged(true);
+  }
+
+  private static boolean isVoiceTypingHold(KeyValue value)
+  {
+    return value != null
+      && value.getKind() == KeyValue.Kind.Event
+      && value.getEvent() == KeyValue.Event.SWITCH_VOICE_TYPING_CHOOSER;
   }
 
   /* Whether an other pointer is down on a non-special key. */

--- a/srcs/juloo.keyboard2/VoicePermissionActivity.java
+++ b/srcs/juloo.keyboard2/VoicePermissionActivity.java
@@ -1,0 +1,55 @@
+package juloo.keyboard2;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.widget.Toast;
+import androidx.core.content.ContextCompat;
+
+/** Minimal Activity used by the IME service to request microphone permission. */
+public final class VoicePermissionActivity extends Activity
+{
+  private static final int REQUEST_RECORD_AUDIO = 1;
+
+  @Override
+  protected void onCreate(Bundle state)
+  {
+    super.onCreate(state);
+    if (Build.VERSION.SDK_INT < 23)
+    {
+      Toast.makeText(this, R.string.toast_voice_permission_granted,
+          Toast.LENGTH_SHORT).show();
+      finish();
+      return;
+    }
+    if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO)
+        == PackageManager.PERMISSION_GRANTED)
+    {
+      Toast.makeText(this, R.string.toast_voice_permission_granted,
+          Toast.LENGTH_SHORT).show();
+      finish();
+      return;
+    }
+    requestPermissions(new String[]{Manifest.permission.RECORD_AUDIO},
+        REQUEST_RECORD_AUDIO);
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, String[] permissions,
+      int[] grantResults)
+  {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    if (requestCode != REQUEST_RECORD_AUDIO)
+      return;
+
+    boolean granted = grantResults.length > 0
+        && grantResults[0] == PackageManager.PERMISSION_GRANTED;
+    Toast.makeText(this, granted
+        ? R.string.toast_voice_permission_granted
+        : R.string.toast_voice_permission_denied,
+        Toast.LENGTH_SHORT).show();
+    finish();
+  }
+}

--- a/srcs/juloo.keyboard2/doubao/DoubaoAsrClient.java
+++ b/srcs/juloo.keyboard2/doubao/DoubaoAsrClient.java
@@ -1,0 +1,683 @@
+package juloo.keyboard2.doubao;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.util.Log;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okio.ByteString;
+
+/** Device registration, authentication, and WebSocket transport for Doubao ASR. */
+public final class DoubaoAsrClient
+{
+  private static final String TAG = "Unexpected/DoubaoASR";
+  private static final String REGISTER_URL =
+      "https://log.snssdk.com/service/2/device_register/";
+  private static final String SETTINGS_URL =
+      "https://is.snssdk.com/service/settings/v3/";
+  // OkHttp models a secure WebSocket handshake as an HTTPS request and
+  // performs the protocol upgrade in newWebSocket().
+  private static final String WEBSOCKET_URL =
+      "https://frontier-audio-ime-ws.doubao.com/ocean/api/v1/ws";
+
+  private static final int AID = 401734;
+  private static final String APP_NAME = "oime";
+  private static final int VERSION_CODE = 100316010;
+  private static final String VERSION_NAME = "1.3.16";
+  private static final String CHANNEL = "official";
+  private static final String PACKAGE = "com.bytedance.android.doubaoime";
+  private static final long HANDSHAKE_TIMEOUT_MS = 10000;
+
+  private static final MediaType JSON =
+      MediaType.get("application/json; charset=utf-8");
+
+  public interface Listener
+  {
+    void onResponse(DoubaoProtocol.Response response);
+    void onFailure(IOException failure);
+  }
+
+  private final Context context;
+  private final OkHttpClient httpClient;
+  private final CredentialStore credentialStore;
+
+  public DoubaoAsrClient(Context context)
+  {
+    this.context = context.getApplicationContext();
+    httpClient = new OkHttpClient.Builder()
+      .connectTimeout(10, TimeUnit.SECONDS)
+      .readTimeout(30, TimeUnit.SECONDS)
+      .writeTimeout(10, TimeUnit.SECONDS)
+      .build();
+    credentialStore = new CredentialStore(this.context, httpClient);
+  }
+
+  public Session open(Listener listener) throws IOException
+  {
+    if (listener == null)
+      throw new IllegalArgumentException("listener must not be null");
+    Credentials credentials = credentialStore.ensureCredentials();
+    Log.i(TAG, "credentials_ready");
+    Session session = new Session(httpClient, credentials, listener);
+    session.connectAndStartTask();
+    return session;
+  }
+
+  public void shutdown()
+  {
+    httpClient.dispatcher().executorService().shutdown();
+    httpClient.connectionPool().evictAll();
+  }
+
+  public static final class Session
+  {
+    private final OkHttpClient httpClient;
+    private final Credentials credentials;
+    private final Listener listener;
+    private final String requestId = UUID.randomUUID().toString();
+    private final CountDownLatch openLatch = new CountDownLatch(1);
+    private final CountDownLatch terminalLatch = new CountDownLatch(1);
+    private final BlockingQueue<DoubaoProtocol.Response> controlResponses =
+        new LinkedBlockingQueue<DoubaoProtocol.Response>();
+    private final AtomicReference<IOException> failure =
+        new AtomicReference<IOException>();
+    private final AtomicBoolean closeRequested = new AtomicBoolean(false);
+
+    private volatile WebSocket webSocket;
+    private volatile boolean finishSent;
+
+    Session(OkHttpClient httpClient, Credentials credentials, Listener listener)
+    {
+      this.httpClient = httpClient;
+      this.credentials = credentials;
+      this.listener = listener;
+    }
+
+    void connectAndStartTask() throws IOException
+    {
+      HttpUrl url = buildWebSocketUrl(credentials.deviceId);
+      Request request = new Request.Builder()
+        .url(url)
+        .header("User-Agent", userAgent())
+        .header("proto-version", "v2")
+        .header("x-custom-keepalive", "true")
+        .build();
+
+      webSocket = httpClient.newWebSocket(request, new SocketListener());
+      await(openLatch, HANDSHAKE_TIMEOUT_MS, "WebSocket open");
+      throwIfFailed();
+      send(DoubaoProtocol.buildStartTask(requestId, credentials.token));
+      awaitControl(DoubaoProtocol.ResponseType.TASK_STARTED,
+          HANDSHAKE_TIMEOUT_MS);
+      Log.i(TAG, "task_started");
+    }
+
+    static HttpUrl buildWebSocketUrl(String deviceId)
+    {
+      return HttpUrl.get(WEBSOCKET_URL).newBuilder()
+        .addQueryParameter("aid", Integer.toString(AID))
+        .addQueryParameter("device_id", deviceId)
+        .build();
+    }
+
+    public void startSession() throws IOException
+    {
+      send(DoubaoProtocol.buildStartSession(requestId, credentials.token,
+          credentials.deviceId));
+      awaitControl(DoubaoProtocol.ResponseType.SESSION_STARTED,
+          HANDSHAKE_TIMEOUT_MS);
+      Log.i(TAG, "session_started");
+    }
+
+    public void sendAudio(byte[] opusFrame, int frameState, long timestampMs)
+        throws IOException
+    {
+      send(DoubaoProtocol.buildAudioRequest(requestId, opusFrame, frameState,
+          timestampMs));
+    }
+
+    public void finish() throws IOException
+    {
+      if (finishSent)
+        throw new IllegalStateException("FinishSession was already sent");
+      finishSent = true;
+      send(DoubaoProtocol.buildFinishSession(requestId, credentials.token));
+      Log.i(TAG, "finish_session_sent");
+    }
+
+    public boolean awaitFinalOrFinished(long timeoutMs) throws IOException
+    {
+      await(terminalLatch, timeoutMs, "final ASR result", false);
+      throwIfFailed();
+      return terminalLatch.getCount() == 0;
+    }
+
+    public void close() throws IOException
+    {
+      closeRequested.set(true);
+      WebSocket socket = webSocket;
+      if (socket != null && !socket.close(1000, "ASR session complete"))
+        throw new IOException("WebSocket refused the close request");
+    }
+
+    public void cancel()
+    {
+      closeRequested.set(true);
+      WebSocket socket = webSocket;
+      if (socket != null)
+        socket.cancel();
+      openLatch.countDown();
+      terminalLatch.countDown();
+    }
+
+    private void send(byte[] message) throws IOException
+    {
+      throwIfFailed();
+      WebSocket socket = webSocket;
+      if (socket == null)
+        throw new IOException("ASR WebSocket is not open");
+      if (!socket.send(ByteString.of(message)))
+        throw new IOException("ASR WebSocket rejected an outgoing message");
+    }
+
+    private void awaitControl(DoubaoProtocol.ResponseType expected,
+        long timeoutMs) throws IOException
+    {
+      long deadline = System.nanoTime()
+          + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+      while (true)
+      {
+        throwIfFailed();
+        long remaining = deadline - System.nanoTime();
+        if (remaining <= 0)
+          throw new IOException("Timed out waiting for " + expected);
+
+        final DoubaoProtocol.Response response;
+        try
+        {
+          response = controlResponses.poll(remaining, TimeUnit.NANOSECONDS);
+        }
+        catch (InterruptedException e)
+        {
+          Thread.currentThread().interrupt();
+          throw new IOException("Interrupted while waiting for " + expected, e);
+        }
+        if (response == null)
+          throw new IOException("Timed out waiting for " + expected);
+        if (response.type == expected)
+          return;
+        if (response.type == DoubaoProtocol.ResponseType.ERROR)
+          throw new IOException("Doubao ASR rejected the request: "
+              + response.errorMessage);
+        throw new IOException("Expected " + expected + " but received "
+            + response.type);
+      }
+    }
+
+    private void throwIfFailed() throws IOException
+    {
+      IOException current = failure.get();
+      if (current != null)
+        throw current;
+    }
+
+    private void fail(IOException exception)
+    {
+      if (!failure.compareAndSet(null, exception))
+        return;
+      controlResponses.offer(DoubaoProtocol.Response.error(-1,
+          exception.getMessage()));
+      openLatch.countDown();
+      terminalLatch.countDown();
+      listener.onFailure(exception);
+    }
+
+    private final class SocketListener extends WebSocketListener
+    {
+      @Override
+      public void onOpen(WebSocket socket, Response response)
+      {
+        openLatch.countDown();
+      }
+
+      @Override
+      public void onMessage(WebSocket socket, ByteString bytes)
+      {
+        final DoubaoProtocol.Response response;
+        try
+        {
+          response = DoubaoProtocol.parseResponse(bytes.toByteArray());
+        }
+        catch (DoubaoProtocol.ProtocolException e)
+        {
+          fail(e);
+          socket.cancel();
+          return;
+        }
+
+        listener.onResponse(response);
+        switch (response.type)
+        {
+          case TASK_STARTED:
+          case SESSION_STARTED:
+          case SESSION_FINISHED:
+          case ERROR:
+            controlResponses.offer(response);
+            break;
+          default:
+            break;
+        }
+
+        if (response.type == DoubaoProtocol.ResponseType.SESSION_FINISHED
+            || response.type == DoubaoProtocol.ResponseType.ERROR
+            || (finishSent
+                && response.type == DoubaoProtocol.ResponseType.FINAL_RESULT))
+          terminalLatch.countDown();
+      }
+
+      @Override
+      public void onClosing(WebSocket socket, int code, String reason)
+      {
+        if (!closeRequested.get()
+            && terminalLatch.getCount() != 0)
+          fail(new IOException("ASR WebSocket is closing: " + code + " "
+              + reason));
+      }
+
+      @Override
+      public void onClosed(WebSocket socket, int code, String reason)
+      {
+        if (!closeRequested.get()
+            && terminalLatch.getCount() != 0)
+          fail(new IOException("ASR WebSocket closed: " + code + " "
+              + reason));
+      }
+
+      @Override
+      public void onFailure(WebSocket socket, Throwable error,
+          Response response)
+      {
+        String message = "ASR WebSocket failed";
+        if (response != null)
+          message += " with HTTP " + response.code();
+        fail(new IOException(message, error));
+      }
+    }
+  }
+
+  private static void await(CountDownLatch latch, long timeoutMs,
+      String operation) throws IOException
+  {
+    await(latch, timeoutMs, operation, true);
+  }
+
+  private static void await(CountDownLatch latch, long timeoutMs,
+      String operation, boolean timeoutIsFailure) throws IOException
+  {
+    final boolean completed;
+    try
+    {
+      completed = latch.await(timeoutMs, TimeUnit.MILLISECONDS);
+    }
+    catch (InterruptedException e)
+    {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while waiting for " + operation, e);
+    }
+    if (!completed && timeoutIsFailure)
+      throw new IOException("Timed out waiting for " + operation);
+  }
+
+  private static final class Credentials
+  {
+    String deviceId;
+    String installId;
+    String cdid;
+    String openudid;
+    String clientudid;
+    String token;
+  }
+
+  private static final class CredentialStore
+  {
+    private static final String PREFS_NAME = "doubao_asr_credentials";
+
+    private final Context context;
+    private final OkHttpClient httpClient;
+    private final SharedPreferences preferences;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    CredentialStore(Context context, OkHttpClient httpClient)
+    {
+      this.context = context;
+      this.httpClient = httpClient;
+      preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+
+    synchronized Credentials ensureCredentials() throws IOException
+    {
+      Credentials credentials = load();
+      if (credentials.cdid.isEmpty())
+        credentials.cdid = UUID.randomUUID().toString();
+      if (credentials.openudid.isEmpty())
+        credentials.openudid = generateOpenudid();
+      if (credentials.clientudid.isEmpty())
+        credentials.clientudid = UUID.randomUUID().toString();
+
+      if (credentials.deviceId.isEmpty())
+      {
+        registerDevice(credentials);
+        save(credentials);
+      }
+      if (credentials.token.isEmpty())
+      {
+        requestToken(credentials);
+        save(credentials);
+      }
+      return credentials;
+    }
+
+    private Credentials load()
+    {
+      Credentials credentials = new Credentials();
+      credentials.deviceId = preferences.getString("device_id", "");
+      credentials.installId = preferences.getString("install_id", "");
+      credentials.cdid = preferences.getString("cdid", "");
+      credentials.openudid = preferences.getString("openudid", "");
+      credentials.clientudid = preferences.getString("clientudid", "");
+      credentials.token = preferences.getString("token", "");
+      return credentials;
+    }
+
+    private void save(Credentials credentials) throws IOException
+    {
+      boolean committed = preferences.edit()
+        .putString("device_id", credentials.deviceId)
+        .putString("install_id", credentials.installId)
+        .putString("cdid", credentials.cdid)
+        .putString("openudid", credentials.openudid)
+        .putString("clientudid", credentials.clientudid)
+        .putString("token", credentials.token)
+        .commit();
+      if (!committed)
+        throw new IOException("Failed to persist Doubao ASR credentials");
+    }
+
+    private void registerDevice(Credentials credentials) throws IOException
+    {
+      long now = System.currentTimeMillis();
+      DeviceIdentity identity = new DeviceIdentity(context);
+      JsonObject header = identity.registrationHeader(credentials);
+
+      JsonObject body = new JsonObject();
+      body.addProperty("magic_tag", "ss_app_log");
+      body.add("header", header);
+      body.addProperty("_gen_time", now);
+
+      HttpUrl url = commonUrl(REGISTER_URL, credentials, now)
+        .addQueryParameter("manifest_version_code",
+            Integer.toString(VERSION_CODE))
+        .addQueryParameter("update_version_code",
+            Integer.toString(VERSION_CODE))
+        .addQueryParameter("resolution", identity.resolution)
+        .addQueryParameter("dpi", identity.dpi)
+        .addQueryParameter("device_type", identity.deviceType)
+        .addQueryParameter("device_brand", identity.deviceBrand)
+        .addQueryParameter("language", "zh")
+        .addQueryParameter("os_api", identity.osApi)
+        .addQueryParameter("os_version", identity.osVersion)
+        .addQueryParameter("ac", "wifi")
+        .build();
+
+      Request request = new Request.Builder()
+        .url(url)
+        .header("User-Agent", userAgent())
+        .post(RequestBody.create(body.toString(), JSON))
+        .build();
+      JsonObject result = executeJson(request, "device registration");
+      credentials.deviceId = requiredId(result, "device_id");
+      credentials.installId = requiredId(result, "install_id");
+      if (credentials.deviceId.equals("0"))
+        throw new IOException("Device registration returned device_id 0");
+      Log.i(TAG, "device_registered");
+    }
+
+    private void requestToken(Credentials credentials) throws IOException
+    {
+      long now = System.currentTimeMillis();
+      HttpUrl url = commonUrl(SETTINGS_URL, credentials, now)
+        .addQueryParameter("device_id", credentials.deviceId)
+        .build();
+      String body = "body=null";
+      Request request = new Request.Builder()
+        .url(url)
+        .header("User-Agent", userAgent())
+        .header("x-ss-stub", md5Uppercase(body))
+        .post(RequestBody.create(body, null))
+        .build();
+
+      JsonObject root = executeJson(request, "ASR settings");
+      credentials.token = requiredString(
+          requiredJsonObject(
+              requiredJsonObject(
+                  requiredJsonObject(root, "data"), "settings"),
+              "asr_config"),
+          "app_key");
+      if (credentials.token.isEmpty())
+        throw new IOException("ASR settings returned an empty app_key");
+      Log.i(TAG, "token_received");
+    }
+
+    private HttpUrl.Builder commonUrl(String baseUrl, Credentials credentials,
+        long now)
+    {
+      return HttpUrl.get(baseUrl).newBuilder()
+        .addQueryParameter("device_platform", "android")
+        .addQueryParameter("os", "android")
+        .addQueryParameter("ssmix", "a")
+        .addQueryParameter("_rticket", Long.toString(now))
+        .addQueryParameter("cdid", credentials.cdid)
+        .addQueryParameter("channel", CHANNEL)
+        .addQueryParameter("aid", Integer.toString(AID))
+        .addQueryParameter("app_name", APP_NAME)
+        .addQueryParameter("version_code", Integer.toString(VERSION_CODE))
+        .addQueryParameter("version_name", VERSION_NAME);
+    }
+
+    private JsonObject executeJson(Request request, String operation)
+        throws IOException
+    {
+      try (Response response = httpClient.newCall(request).execute())
+      {
+        String body = response.body() == null ? "" : response.body().string();
+        if (!response.isSuccessful())
+          throw new IOException("Doubao " + operation + " failed with HTTP "
+              + response.code() + ": " + body);
+        try
+        {
+          JsonElement parsed = JsonParser.parseString(body);
+          if (!parsed.isJsonObject())
+            throw new IOException("Doubao " + operation
+                + " returned non-object JSON");
+          return parsed.getAsJsonObject();
+        }
+        catch (JsonParseException e)
+        {
+          throw new IOException("Doubao " + operation
+              + " returned invalid JSON", e);
+        }
+      }
+    }
+
+    private JsonObject requiredJsonObject(JsonObject object, String key)
+        throws IOException
+    {
+      JsonElement value = object.get(key);
+      if (value == null)
+        throw new IOException("Doubao response is missing '" + key + "'");
+      if (!value.isJsonObject())
+        throw new IOException("Doubao response field '" + key
+            + "' is not an object");
+      return value.getAsJsonObject();
+    }
+
+    private String requiredString(JsonObject object, String key)
+        throws IOException
+    {
+      JsonElement value = object.get(key);
+      if (value == null || !value.isJsonPrimitive()
+          || !value.getAsJsonPrimitive().isString())
+        throw new IOException("Doubao response field '" + key
+            + "' is not a string");
+      return value.getAsString();
+    }
+
+    private String requiredId(JsonObject object, String key) throws IOException
+    {
+      JsonElement value = object.get(key);
+      if (value == null || !value.isJsonPrimitive())
+        throw new IOException("Doubao response is missing '" + key + "'");
+      String id = value.getAsString();
+      if (id.isEmpty())
+        throw new IOException("Doubao response field '" + key + "' is empty");
+      return id;
+    }
+
+    private String generateOpenudid()
+    {
+      byte[] bytes = new byte[8];
+      secureRandom.nextBytes(bytes);
+      StringBuilder result = new StringBuilder(16);
+      for (byte value : bytes)
+        result.append(String.format(Locale.US, "%02x", value & 0xff));
+      return result.toString();
+    }
+  }
+
+  private static final class DeviceIdentity
+  {
+    final String osApi;
+    final String osVersion;
+    final String deviceType;
+    final String deviceBrand;
+    final String deviceModel;
+    final String resolution;
+    final String dpi;
+    final String rom;
+    final String cpuAbi;
+
+    DeviceIdentity(Context context)
+    {
+      DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+      osApi = Integer.toString(Build.VERSION.SDK_INT);
+      osVersion = Build.VERSION.RELEASE;
+      deviceType = Build.MODEL;
+      deviceBrand = Build.BRAND;
+      deviceModel = Build.MODEL;
+      resolution = metrics.widthPixels + "*" + metrics.heightPixels;
+      dpi = Integer.toString(metrics.densityDpi);
+      rom = Build.ID;
+      cpuAbi = Build.SUPPORTED_ABIS.length == 0
+          ? "unknown" : Build.SUPPORTED_ABIS[0];
+    }
+
+    JsonObject registrationHeader(Credentials credentials)
+    {
+      long now = System.currentTimeMillis();
+      TimeZone zone = TimeZone.getDefault();
+      int offsetSeconds = zone.getOffset(now) / 1000;
+
+      JsonObject header = new JsonObject();
+      header.addProperty("device_id", 0);
+      header.addProperty("install_id", 0);
+      header.addProperty("aid", AID);
+      header.addProperty("app_name", APP_NAME);
+      header.addProperty("version_code", VERSION_CODE);
+      header.addProperty("version_name", VERSION_NAME);
+      header.addProperty("manifest_version_code", VERSION_CODE);
+      header.addProperty("update_version_code", VERSION_CODE);
+      header.addProperty("channel", CHANNEL);
+      header.addProperty("package", PACKAGE);
+      header.addProperty("device_platform", "android");
+      header.addProperty("os", "android");
+      header.addProperty("os_api", osApi);
+      header.addProperty("os_version", osVersion);
+      header.addProperty("device_type", deviceType);
+      header.addProperty("device_brand", deviceBrand);
+      header.addProperty("device_model", deviceModel);
+      header.addProperty("resolution", resolution);
+      header.addProperty("dpi", dpi);
+      header.addProperty("language", "zh");
+      header.addProperty("timezone", offsetSeconds / 3600);
+      header.addProperty("access", "wifi");
+      header.addProperty("rom", rom);
+      header.addProperty("rom_version", rom);
+      header.addProperty("openudid", credentials.openudid);
+      header.addProperty("clientudid", credentials.clientudid);
+      header.addProperty("cdid", credentials.cdid);
+      header.addProperty("region", "CN");
+      header.addProperty("tz_name", zone.getID());
+      header.addProperty("tz_offset", offsetSeconds);
+      header.addProperty("sim_region", "cn");
+      header.addProperty("carrier_region", "cn");
+      header.addProperty("cpu_abi", cpuAbi);
+      header.addProperty("build_serial", "unknown");
+      header.addProperty("not_request_sender", 0);
+      header.addProperty("sig_hash", "");
+      header.addProperty("google_aid", "");
+      header.addProperty("mc", "");
+      header.addProperty("serial_number", "");
+      return header;
+    }
+  }
+
+  private static String userAgent()
+  {
+    return String.format(Locale.US,
+        "%s/%d (Linux; U; Android %s; zh_CN; %s; Build/%s)",
+        PACKAGE, VERSION_CODE, Build.VERSION.RELEASE, Build.MODEL, Build.ID);
+  }
+
+  private static String md5Uppercase(String value) throws IOException
+  {
+    final byte[] digest;
+    try
+    {
+      digest = MessageDigest.getInstance("MD5")
+          .digest(value.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+    catch (NoSuchAlgorithmException e)
+    {
+      throw new IOException("MD5 is unavailable", e);
+    }
+    StringBuilder result = new StringBuilder(digest.length * 2);
+    for (byte b : digest)
+      result.append(String.format(Locale.US, "%02X", b & 0xff));
+    return result.toString();
+  }
+}

--- a/srcs/juloo.keyboard2/doubao/DoubaoProtocol.java
+++ b/srcs/juloo.keyboard2/doubao/DoubaoProtocol.java
@@ -1,0 +1,563 @@
+package juloo.keyboard2.doubao;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Wire-level implementation of the Doubao IME ASR protobuf protocol. */
+public final class DoubaoProtocol
+{
+  public static final int FRAME_UNSPECIFIED = 0;
+  public static final int FRAME_FIRST = 1;
+  public static final int FRAME_MIDDLE = 3;
+  public static final int FRAME_LAST = 9;
+
+  private static final String SERVICE_NAME = "ASR";
+  private static final String APP_NAME = "oime";
+
+  public enum ResponseType
+  {
+    TASK_STARTED,
+    SESSION_STARTED,
+    SESSION_FINISHED,
+    VAD_START,
+    INTERIM_RESULT,
+    FINAL_RESULT,
+    HEARTBEAT,
+    ERROR,
+    UNKNOWN
+  }
+
+  public static final class Response
+  {
+    public final ResponseType type;
+    public final String text;
+    public final boolean isFinal;
+    public final boolean vadStart;
+    public final boolean vadFinished;
+    public final int packetNumber;
+    public final int statusCode;
+    public final String errorMessage;
+    public final String rawJson;
+
+    private Response(ResponseType type, String text, boolean isFinal,
+        boolean vadStart, boolean vadFinished, int packetNumber,
+        int statusCode, String errorMessage, String rawJson)
+    {
+      this.type = type;
+      this.text = text;
+      this.isFinal = isFinal;
+      this.vadStart = vadStart;
+      this.vadFinished = vadFinished;
+      this.packetNumber = packetNumber;
+      this.statusCode = statusCode;
+      this.errorMessage = errorMessage;
+      this.rawJson = rawJson;
+    }
+
+    static Response simple(ResponseType type)
+    {
+      return new Response(type, "", false, false, false, -1, 0, "", null);
+    }
+
+    static Response error(int statusCode, String message)
+    {
+      return new Response(ResponseType.ERROR, "", false, false, false, -1,
+          statusCode, message, null);
+    }
+  }
+
+  public static final class ProtocolException extends IOException
+  {
+    ProtocolException(String message)
+    {
+      super(message);
+    }
+
+    ProtocolException(String message, Throwable cause)
+    {
+      super(message, cause);
+    }
+  }
+
+  private DoubaoProtocol() {}
+
+  public static byte[] buildStartTask(String requestId, String token)
+  {
+    requireNonEmpty(requestId, "requestId");
+    requireNonEmpty(token, "token");
+    return request(requestId, token, "StartTask", "", null, FRAME_UNSPECIFIED);
+  }
+
+  public static byte[] buildStartSession(String requestId, String token,
+      String deviceId)
+  {
+    requireNonEmpty(requestId, "requestId");
+    requireNonEmpty(token, "token");
+    requireNonEmpty(deviceId, "deviceId");
+    return request(requestId, token, "StartSession",
+        buildSessionPayload(deviceId), null, FRAME_UNSPECIFIED);
+  }
+
+  public static byte[] buildFinishSession(String requestId, String token)
+  {
+    requireNonEmpty(requestId, "requestId");
+    requireNonEmpty(token, "token");
+    return request(requestId, token, "FinishSession", "", null,
+        FRAME_UNSPECIFIED);
+  }
+
+  public static byte[] buildAudioRequest(String requestId, byte[] opusFrame,
+      int frameState, long timestampMs)
+  {
+    requireNonEmpty(requestId, "requestId");
+    if (opusFrame == null || opusFrame.length == 0)
+      throw new IllegalArgumentException("opusFrame must not be empty");
+    if (frameState != FRAME_FIRST && frameState != FRAME_MIDDLE
+        && frameState != FRAME_LAST)
+      throw new IllegalArgumentException("Invalid frameState: " + frameState);
+
+    JsonObject payload = new JsonObject();
+    payload.add("extra", new JsonObject());
+    payload.addProperty("timestamp_ms", timestampMs);
+    return request(requestId, "", "TaskRequest", payload.toString(),
+        opusFrame, frameState);
+  }
+
+  public static String buildSessionPayload(String deviceId)
+  {
+    requireNonEmpty(deviceId, "deviceId");
+
+    JsonObject audioInfo = new JsonObject();
+    audioInfo.addProperty("channel", 1);
+    audioInfo.addProperty("format", "speech_opus");
+    audioInfo.addProperty("sample_rate", 16000);
+
+    JsonObject extra = new JsonObject();
+    extra.addProperty("app_name", APP_NAME);
+    extra.addProperty("cell_compress_rate", 8);
+    extra.addProperty("did", deviceId);
+    extra.addProperty("enable_asr_threepass", false);
+    extra.addProperty("enable_asr_twopass", false);
+    extra.addProperty("input_mode", "tool");
+    extra.addProperty("interim_results", true);
+
+    JsonObject config = new JsonObject();
+    config.add("audio_info", audioInfo);
+    config.addProperty("enable_punctuation", true);
+    config.addProperty("enable_speech_rejection", false);
+    config.addProperty("enable_vad", true);
+    config.addProperty("low_latency", false);
+    config.add("extra", extra);
+    return config.toString();
+  }
+
+  public static Response parseResponse(byte[] data) throws ProtocolException
+  {
+    if (data == null || data.length == 0)
+      throw new ProtocolException("Empty ASR protobuf response");
+
+    ProtoReader reader = new ProtoReader(data);
+    String messageType = "";
+    int statusCode = 0;
+    String statusMessage = "";
+    String resultJson = "";
+
+    while (reader.hasRemaining())
+    {
+      int tag = reader.readTag();
+      int field = tag >>> 3;
+      int wireType = tag & 7;
+      switch (field)
+      {
+        case 4:
+          messageType = reader.readString(wireType, field);
+          break;
+        case 5:
+          statusCode = reader.readInt32(wireType, field);
+          break;
+        case 6:
+          statusMessage = reader.readString(wireType, field);
+          break;
+        case 7:
+          resultJson = reader.readString(wireType, field);
+          break;
+        default:
+          reader.skip(wireType);
+          break;
+      }
+    }
+
+    switch (messageType)
+    {
+      case "TaskStarted":
+        return Response.simple(ResponseType.TASK_STARTED);
+      case "SessionStarted":
+        return Response.simple(ResponseType.SESSION_STARTED);
+      case "SessionFinished":
+        return Response.simple(ResponseType.SESSION_FINISHED);
+      case "TaskFailed":
+      case "SessionFailed":
+        return Response.error(statusCode, nonEmptyStatus(statusCode, statusMessage));
+      default:
+        break;
+    }
+
+    if (resultJson.isEmpty())
+      return Response.simple(ResponseType.UNKNOWN);
+
+    final JsonObject root;
+    try
+    {
+      JsonElement parsed = JsonParser.parseString(resultJson);
+      if (!parsed.isJsonObject())
+        throw new ProtocolException("ASR result_json is not an object");
+      root = parsed.getAsJsonObject();
+    }
+    catch (JsonParseException e)
+    {
+      throw new ProtocolException("Invalid ASR result_json", e);
+    }
+
+    JsonObject extra = optionalObject(root, "extra");
+    JsonElement resultsElement = root.get("results");
+    if (resultsElement == null || resultsElement.isJsonNull())
+    {
+      int packetNumber = optionalInt(extra, "packet_number", -1);
+      return new Response(ResponseType.HEARTBEAT, "", false, false, false,
+          packetNumber, 0, "", resultJson);
+    }
+
+    if (optionalBoolean(extra, "vad_start", false))
+      return new Response(ResponseType.VAD_START, "", false, true, false,
+          -1, 0, "", resultJson);
+
+    List<JsonObject> results = resultObjects(resultsElement);
+    String text = "";
+    boolean explicitFinal = false;
+    boolean vadFinished = false;
+    boolean nonstreamResult = false;
+
+    for (JsonObject result : results)
+    {
+      String candidate = extractResultText(result);
+      if (!candidate.isEmpty())
+        text = candidate;
+
+      Boolean interim = firstBoolean(result, "is_interim", "interim");
+      if (Boolean.FALSE.equals(interim))
+        explicitFinal = true;
+      if (optionalBoolean(result, "is_final", false))
+        explicitFinal = true;
+      if (firstBooleanValue(result, false, "is_vad_finished", "vad_finished"))
+        vadFinished = true;
+
+      JsonObject resultExtra = optionalObject(result, "extra");
+      if (optionalBoolean(resultExtra, "nonstream_result", false))
+        nonstreamResult = true;
+    }
+
+    boolean isFinal = nonstreamResult || (explicitFinal && vadFinished);
+    return new Response(
+        isFinal ? ResponseType.FINAL_RESULT : ResponseType.INTERIM_RESULT,
+        text, isFinal, false, vadFinished, -1, 0, "", resultJson);
+  }
+
+  private static byte[] request(String requestId, String token,
+      String methodName, String payload, byte[] audioData, int frameState)
+  {
+    ProtoWriter writer = new ProtoWriter();
+    writer.string(2, token);
+    writer.string(3, SERVICE_NAME);
+    writer.string(5, methodName);
+    writer.string(6, payload);
+    writer.bytes(7, audioData);
+    writer.string(8, requestId);
+    writer.int32(9, frameState);
+    return writer.toByteArray();
+  }
+
+  private static String nonEmptyStatus(int statusCode, String statusMessage)
+  {
+    if (!statusMessage.isEmpty())
+      return statusMessage;
+    return "ASR returned status " + statusCode;
+  }
+
+  private static List<JsonObject> resultObjects(JsonElement results)
+      throws ProtocolException
+  {
+    List<JsonObject> objects = new ArrayList<JsonObject>();
+    if (results.isJsonObject())
+    {
+      objects.add(results.getAsJsonObject());
+      return objects;
+    }
+    if (!results.isJsonArray())
+      throw new ProtocolException("ASR results must be an object or array");
+
+    JsonArray array = results.getAsJsonArray();
+    for (JsonElement item : array)
+    {
+      if (!item.isJsonObject())
+        throw new ProtocolException("ASR results array contains a non-object");
+      objects.add(item.getAsJsonObject());
+    }
+    return objects;
+  }
+
+  private static String extractResultText(JsonObject result)
+  {
+    String direct = firstString(result, "text", "utterance", "transcript");
+    if (!direct.isEmpty())
+      return direct;
+
+    for (String key : new String[]{"alternatives", "words", "utterances"})
+    {
+      JsonElement nested = result.get(key);
+      if (nested == null || !nested.isJsonArray())
+        continue;
+      for (JsonElement item : nested.getAsJsonArray())
+      {
+        if (!item.isJsonObject())
+          continue;
+        String text = extractResultText(item.getAsJsonObject());
+        if (!text.isEmpty())
+          return text;
+      }
+    }
+    return "";
+  }
+
+  private static String firstString(JsonObject object, String... keys)
+  {
+    for (String key : keys)
+    {
+      JsonElement value = object.get(key);
+      if (value != null && value.isJsonPrimitive())
+      {
+        JsonPrimitive primitive = value.getAsJsonPrimitive();
+        if (primitive.isString() && !primitive.getAsString().isEmpty())
+          return primitive.getAsString();
+      }
+    }
+    return "";
+  }
+
+  private static Boolean firstBoolean(JsonObject object, String... keys)
+  {
+    for (String key : keys)
+    {
+      JsonElement value = object.get(key);
+      if (value != null && value.isJsonPrimitive()
+          && value.getAsJsonPrimitive().isBoolean())
+        return value.getAsBoolean();
+    }
+    return null;
+  }
+
+  private static boolean firstBooleanValue(JsonObject object,
+      boolean defaultValue, String... keys)
+  {
+    Boolean value = firstBoolean(object, keys);
+    return value == null ? defaultValue : value.booleanValue();
+  }
+
+  private static boolean optionalBoolean(JsonObject object, String key,
+      boolean defaultValue)
+  {
+    if (object == null)
+      return defaultValue;
+    return firstBooleanValue(object, defaultValue, key);
+  }
+
+  private static int optionalInt(JsonObject object, String key, int defaultValue)
+  {
+    if (object == null)
+      return defaultValue;
+    JsonElement value = object.get(key);
+    if (value == null || !value.isJsonPrimitive()
+        || !value.getAsJsonPrimitive().isNumber())
+      return defaultValue;
+    return value.getAsInt();
+  }
+
+  private static JsonObject optionalObject(JsonObject parent, String key)
+      throws ProtocolException
+  {
+    if (parent == null)
+      return null;
+    JsonElement value = parent.get(key);
+    if (value == null || value.isJsonNull())
+      return null;
+    if (!value.isJsonObject())
+      throw new ProtocolException("ASR JSON field '" + key + "' is not an object");
+    return value.getAsJsonObject();
+  }
+
+  private static void requireNonEmpty(String value, String name)
+  {
+    if (value == null || value.isEmpty())
+      throw new IllegalArgumentException(name + " must not be empty");
+  }
+
+  private static final class ProtoWriter
+  {
+    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    void string(int field, String value)
+    {
+      if (value == null || value.isEmpty())
+        return;
+      bytes(field, value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    void bytes(int field, byte[] value)
+    {
+      if (value == null || value.length == 0)
+        return;
+      varint((field << 3) | 2);
+      varint(value.length);
+      out.write(value, 0, value.length);
+    }
+
+    void int32(int field, int value)
+    {
+      if (value == 0)
+        return;
+      varint((field << 3) | 0);
+      varint(value);
+    }
+
+    void varint(long value)
+    {
+      while ((value & ~0x7fL) != 0)
+      {
+        out.write(((int)value & 0x7f) | 0x80);
+        value >>>= 7;
+      }
+      out.write((int)value);
+    }
+
+    byte[] toByteArray()
+    {
+      return out.toByteArray();
+    }
+  }
+
+  private static final class ProtoReader
+  {
+    private final byte[] data;
+    private int position;
+
+    ProtoReader(byte[] data)
+    {
+      this.data = data;
+    }
+
+    boolean hasRemaining()
+    {
+      return position < data.length;
+    }
+
+    int readTag() throws ProtocolException
+    {
+      long tag = readVarint();
+      if (tag == 0 || tag > Integer.MAX_VALUE)
+        throw new ProtocolException("Invalid protobuf tag: " + tag);
+      return (int)tag;
+    }
+
+    String readString(int wireType, int field) throws ProtocolException
+    {
+      byte[] value = readBytes(wireType, field);
+      return new String(value, StandardCharsets.UTF_8);
+    }
+
+    byte[] readBytes(int wireType, int field) throws ProtocolException
+    {
+      requireWireType(wireType, 2, field);
+      long lengthValue = readVarint();
+      if (lengthValue > Integer.MAX_VALUE)
+        throw new ProtocolException("Protobuf field is too large");
+      int length = (int)lengthValue;
+      if (length < 0 || position + length > data.length)
+        throw new ProtocolException("Truncated protobuf length-delimited field");
+      byte[] value = new byte[length];
+      System.arraycopy(data, position, value, 0, length);
+      position += length;
+      return value;
+    }
+
+    int readInt32(int wireType, int field) throws ProtocolException
+    {
+      requireWireType(wireType, 0, field);
+      return (int)readVarint();
+    }
+
+    long readVarint() throws ProtocolException
+    {
+      long value = 0;
+      for (int shift = 0; shift < 64; shift += 7)
+      {
+        if (position >= data.length)
+          throw new ProtocolException("Truncated protobuf varint",
+              new EOFException());
+        int b = data[position++] & 0xff;
+        value |= (long)(b & 0x7f) << shift;
+        if ((b & 0x80) == 0)
+          return value;
+      }
+      throw new ProtocolException("Malformed protobuf varint");
+    }
+
+    void skip(int wireType) throws ProtocolException
+    {
+      switch (wireType)
+      {
+        case 0:
+          readVarint();
+          return;
+        case 1:
+          skipBytes(8);
+          return;
+        case 2:
+          long length = readVarint();
+          if (length > Integer.MAX_VALUE)
+            throw new ProtocolException("Protobuf field is too large");
+          skipBytes((int)length);
+          return;
+        case 5:
+          skipBytes(4);
+          return;
+        default:
+          throw new ProtocolException("Unsupported protobuf wire type: "
+              + wireType);
+      }
+    }
+
+    void skipBytes(int length) throws ProtocolException
+    {
+      if (length < 0 || position + length > data.length)
+        throw new ProtocolException("Truncated protobuf field");
+      position += length;
+    }
+
+    void requireWireType(int actual, int expected, int field)
+        throws ProtocolException
+    {
+      if (actual != expected)
+        throw new ProtocolException("Unexpected wire type " + actual
+            + " for protobuf field " + field);
+    }
+  }
+}

--- a/srcs/juloo.keyboard2/doubao/DoubaoVoiceInput.java
+++ b/srcs/juloo.keyboard2/doubao/DoubaoVoiceInput.java
@@ -315,7 +315,7 @@ public final class DoubaoVoiceInput
         session.startSession();
         throwIfCancelledOrFailed();
         mainHandler.post(() -> {
-          if (isCurrent(this) && !cancelled)
+          if (isCurrent(this) && !cancelled && !stopRequested)
             host.onVoiceStateChanged(State.LISTENING);
         });
 

--- a/srcs/juloo.keyboard2/doubao/DoubaoVoiceInput.java
+++ b/srcs/juloo.keyboard2/doubao/DoubaoVoiceInput.java
@@ -1,0 +1,542 @@
+package juloo.keyboard2.doubao;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.media.AudioFormat;
+import android.media.AudioRecord;
+import android.media.MediaRecorder;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Process;
+import android.util.Log;
+import android.view.inputmethod.InputConnection;
+import androidx.core.content.ContextCompat;
+import io.github.jaredmdobson.concentus.OpusApplication;
+import io.github.jaredmdobson.concentus.OpusEncoder;
+import io.github.jaredmdobson.concentus.OpusException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Coordinates microphone capture, streaming ASR, and InputConnection updates. */
+public final class DoubaoVoiceInput
+{
+  private static final String TAG = "Unexpected/DoubaoASR";
+  private static final int SAMPLE_RATE = 16000;
+  private static final int SAMPLES_PER_FRAME = 320;
+  private static final int PCM_BYTES_PER_FRAME = SAMPLES_PER_FRAME * 2;
+  private static final int FRAME_DURATION_MS = 20;
+  private static final long FINAL_DRAIN_TIMEOUT_MS = 1500;
+  private static final long INTERIM_UPDATE_INTERVAL_NS = 150000000L;
+
+  public enum State
+  {
+    IDLE,
+    CONNECTING,
+    LISTENING,
+    FINISHING
+  }
+
+  public interface Host
+  {
+    InputConnection getCurrentInputConnection();
+    void onVoiceStateChanged(State state);
+    void onVoiceFailure(String message);
+  }
+
+  private final Context context;
+  private final Host host;
+  private final Handler mainHandler;
+  private final DoubaoAsrClient asrClient;
+  private final ExecutorService executor;
+  private final Object lock = new Object();
+
+  private SessionRun activeRun;
+  private boolean destroyed;
+
+  public DoubaoVoiceInput(Context context, Host host)
+  {
+    this.context = context.getApplicationContext();
+    this.host = host;
+    mainHandler = new Handler(Looper.getMainLooper());
+    asrClient = new DoubaoAsrClient(this.context);
+    executor = Executors.newSingleThreadExecutor(new ThreadFactory()
+    {
+      @Override
+      public Thread newThread(Runnable runnable)
+      {
+        Thread thread = new Thread(runnable, "doubao-asr");
+        thread.setDaemon(true);
+        return thread;
+      }
+    });
+  }
+
+  public boolean isActive()
+  {
+    synchronized (lock)
+    {
+      return activeRun != null;
+    }
+  }
+
+  public void toggle()
+  {
+    requireMainThread();
+    synchronized (lock)
+    {
+      if (activeRun == null)
+      {
+        startLocked();
+        return;
+      }
+      requestStopLocked();
+    }
+  }
+
+  public void stop()
+  {
+    requireMainThread();
+    synchronized (lock)
+    {
+      if (activeRun != null)
+        requestStopLocked();
+    }
+  }
+
+  public void start()
+  {
+    requireMainThread();
+    synchronized (lock)
+    {
+      if (activeRun != null)
+        throw new IllegalStateException("Doubao voice input is already active");
+      startLocked();
+    }
+  }
+
+  public void cancel()
+  {
+    requireMainThread();
+    final SessionRun run;
+    synchronized (lock)
+    {
+      run = activeRun;
+      if (run == null)
+        return;
+      activeRun = null;
+      run.cancelled = true;
+      run.stopRequested = true;
+    }
+    DoubaoAsrClient.Session session = run.session;
+    if (session != null)
+      session.cancel();
+    if (run.hasComposingText)
+      finishComposingText(run);
+    host.onVoiceStateChanged(State.IDLE);
+  }
+
+  public void shutdown()
+  {
+    requireMainThread();
+    synchronized (lock)
+    {
+      if (destroyed)
+        return;
+      destroyed = true;
+    }
+    cancel();
+    executor.shutdownNow();
+    asrClient.shutdown();
+  }
+
+  private void startLocked()
+  {
+    if (destroyed)
+      throw new IllegalStateException("Doubao voice input was destroyed");
+    if (ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO)
+        != PackageManager.PERMISSION_GRANTED)
+      throw new SecurityException("Microphone permission is not granted");
+
+    InputConnection connection = host.getCurrentInputConnection();
+    if (connection == null)
+      throw new IllegalStateException("No active InputConnection for voice input");
+
+    SessionRun run = new SessionRun(connection);
+    activeRun = run;
+    Log.i(TAG, "voice_start_requested");
+    host.onVoiceStateChanged(State.CONNECTING);
+    executor.execute(run);
+  }
+
+  private void requestStopLocked()
+  {
+    if (activeRun.stopRequested)
+      return;
+    activeRun.stopRequested = true;
+    host.onVoiceStateChanged(State.FINISHING);
+  }
+
+  private void handleTranscript(SessionRun run,
+      DoubaoProtocol.Response response)
+  {
+    mainHandler.post(() -> {
+      if (!isCurrent(run) || run.cancelled || response.text.isEmpty())
+        return;
+      if (host.getCurrentInputConnection() != run.connection)
+      {
+        failInputConnection(run, "The target editor changed during voice input");
+        return;
+      }
+
+      final boolean accepted;
+      if (response.type == DoubaoProtocol.ResponseType.FINAL_RESULT)
+      {
+        accepted = run.connection.commitText(response.text, 1);
+        run.hasComposingText = false;
+        run.latestInterim = "";
+      }
+      else
+      {
+        accepted = run.connection.setComposingText(response.text, 1);
+        run.hasComposingText = true;
+        run.latestInterim = response.text;
+      }
+      if (!accepted)
+        failInputConnection(run, "The target editor rejected voice text");
+      else
+        Log.i(TAG, "transcript_applied final=" + response.isFinal
+            + " chars=" + response.text.length());
+    });
+  }
+
+  private void failInputConnection(SessionRun run, String message)
+  {
+    synchronized (lock)
+    {
+      if (activeRun != run)
+        return;
+      activeRun = null;
+      run.cancelled = true;
+      run.stopRequested = true;
+    }
+    DoubaoAsrClient.Session session = run.session;
+    if (session != null)
+      session.cancel();
+    host.onVoiceFailure(message);
+    host.onVoiceStateChanged(State.IDLE);
+  }
+
+  private void finishComposingText(SessionRun run)
+  {
+    if (!run.connection.finishComposingText())
+      host.onVoiceFailure("The target editor rejected the final voice text");
+    run.hasComposingText = false;
+    run.latestInterim = "";
+  }
+
+  private void complete(SessionRun run, Throwable problem)
+  {
+    mainHandler.post(() -> {
+      synchronized (lock)
+      {
+        if (activeRun != run)
+          return;
+        activeRun = null;
+      }
+      if (run.hasComposingText)
+        finishComposingText(run);
+      if (problem != null)
+      {
+        Log.e(TAG, "Voice input failed", problem);
+        host.onVoiceFailure(failureMessage(problem));
+      }
+      else
+        Log.i(TAG, "voice_session_complete");
+      host.onVoiceStateChanged(State.IDLE);
+    });
+  }
+
+  private boolean isCurrent(SessionRun run)
+  {
+    synchronized (lock)
+    {
+      return activeRun == run;
+    }
+  }
+
+  private void requireMainThread()
+  {
+    if (Looper.myLooper() != Looper.getMainLooper())
+      throw new IllegalStateException("Voice input lifecycle must run on main thread");
+  }
+
+  private static String failureMessage(Throwable problem)
+  {
+    String message = problem.getMessage();
+    if (message == null || message.isEmpty())
+      return problem.getClass().getSimpleName();
+    return message;
+  }
+
+  final class SessionRun implements Runnable, DoubaoAsrClient.Listener
+  {
+    final InputConnection connection;
+    final AtomicReference<IOException> asyncFailure =
+        new AtomicReference<IOException>();
+
+    volatile DoubaoAsrClient.Session session;
+    volatile AudioRecord recorder;
+    volatile boolean stopRequested;
+    volatile boolean cancelled;
+
+    boolean hasComposingText;
+    String latestInterim = "";
+    long lastInterimUpdateNs;
+
+    SessionRun(InputConnection connection)
+    {
+      this.connection = connection;
+    }
+
+    @Override
+    public void run()
+    {
+      Process.setThreadPriority(Process.THREAD_PRIORITY_AUDIO);
+      Throwable problem = null;
+      try
+      {
+        session = asrClient.open(this);
+        throwIfCancelledOrFailed();
+        session.startSession();
+        throwIfCancelledOrFailed();
+        mainHandler.post(() -> {
+          if (isCurrent(this) && !cancelled)
+            host.onVoiceStateChanged(State.LISTENING);
+        });
+
+        streamAudio();
+        throwIfCancelledOrFailed();
+        session.finish();
+        boolean receivedFinal = session.awaitFinalOrFinished(
+            FINAL_DRAIN_TIMEOUT_MS);
+        if (!receivedFinal)
+          Log.w(TAG, "Final ASR drain timed out; keeping the latest transcript");
+      }
+      catch (Throwable error)
+      {
+        problem = error;
+      }
+      finally
+      {
+        problem = releaseRecorder(problem);
+        DoubaoAsrClient.Session currentSession = session;
+        if (currentSession != null)
+        {
+          if (cancelled || problem != null)
+            currentSession.cancel();
+          else
+          {
+            try
+            {
+              currentSession.close();
+            }
+            catch (Throwable closeError)
+            {
+              if (problem == null)
+                problem = closeError;
+              else
+                problem.addSuppressed(closeError);
+            }
+          }
+        }
+        if (!cancelled)
+          complete(this, problem);
+      }
+    }
+
+    private void streamAudio() throws Exception
+    {
+      if (ContextCompat.checkSelfPermission(context,
+          Manifest.permission.RECORD_AUDIO)
+          != PackageManager.PERMISSION_GRANTED)
+        throw new SecurityException("Microphone permission was revoked");
+
+      int minimumBuffer = AudioRecord.getMinBufferSize(SAMPLE_RATE,
+          AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT);
+      if (minimumBuffer <= 0)
+        throw new IOException("Invalid AudioRecord buffer size: "
+            + minimumBuffer);
+
+      AudioRecord audioRecord = new AudioRecord(MediaRecorder.AudioSource.MIC,
+          SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO,
+          AudioFormat.ENCODING_PCM_16BIT,
+          Math.max(minimumBuffer, PCM_BYTES_PER_FRAME * 4));
+      recorder = audioRecord;
+      if (audioRecord.getState() != AudioRecord.STATE_INITIALIZED)
+        throw new IOException("AudioRecord initialization failed");
+
+      OpusFrameEncoder encoder = new OpusFrameEncoder();
+      short[] pcmFrame = new short[SAMPLES_PER_FRAME];
+      long startedAtMs = System.currentTimeMillis();
+      long frameIndex = 0;
+
+      audioRecord.startRecording();
+      if (audioRecord.getRecordingState()
+          != AudioRecord.RECORDSTATE_RECORDING)
+        throw new IOException("AudioRecord did not enter recording state");
+
+      while (!stopRequested && !cancelled)
+      {
+        int samplesRead = readFrame(audioRecord, pcmFrame);
+        if (samplesRead != SAMPLES_PER_FRAME)
+          break;
+        throwIfCancelledOrFailed();
+        byte[] opus = encoder.encode(pcmFrame);
+        int frameState = frameIndex == 0
+            ? DoubaoProtocol.FRAME_FIRST : DoubaoProtocol.FRAME_MIDDLE;
+        session.sendAudio(opus, frameState,
+            startedAtMs + frameIndex * FRAME_DURATION_MS);
+        frameIndex++;
+        if (frameIndex == 1 || frameIndex % 50 == 0)
+          Log.i(TAG, "audio_frames_sent=" + frameIndex);
+      }
+
+      if (!cancelled)
+      {
+        audioRecord.stop();
+        Arrays.fill(pcmFrame, (short)0);
+        byte[] finalOpus = encoder.encode(pcmFrame);
+        session.sendAudio(finalOpus, DoubaoProtocol.FRAME_LAST,
+            startedAtMs + frameIndex * FRAME_DURATION_MS);
+        Log.i(TAG, "audio_last_sent frames=" + frameIndex);
+      }
+    }
+
+    private int readFrame(AudioRecord audioRecord, short[] pcmFrame)
+        throws IOException
+    {
+      int offset = 0;
+      while (offset < pcmFrame.length && !stopRequested && !cancelled)
+      {
+        int read = audioRecord.read(pcmFrame, offset,
+            pcmFrame.length - offset);
+        if (read < 0)
+          throw new IOException("AudioRecord read failed: " + read);
+        if (read == 0)
+          throw new IOException("AudioRecord returned zero samples");
+        offset += read;
+      }
+      return offset;
+    }
+
+    private void throwIfCancelledOrFailed() throws IOException
+    {
+      if (cancelled)
+        throw new IOException("Voice input was cancelled");
+      IOException failure = asyncFailure.get();
+      if (failure != null)
+        throw failure;
+    }
+
+    private Throwable releaseRecorder(Throwable problem)
+    {
+      AudioRecord audioRecord = recorder;
+      recorder = null;
+      if (audioRecord == null)
+        return problem;
+
+      try
+      {
+        if (audioRecord.getRecordingState()
+            == AudioRecord.RECORDSTATE_RECORDING)
+          audioRecord.stop();
+      }
+      catch (Throwable stopError)
+      {
+        if (problem == null)
+          problem = stopError;
+        else
+          problem.addSuppressed(stopError);
+      }
+      try
+      {
+        audioRecord.release();
+      }
+      catch (Throwable releaseError)
+      {
+        if (problem == null)
+          problem = releaseError;
+        else
+          problem.addSuppressed(releaseError);
+      }
+      return problem;
+    }
+
+    @Override
+    public void onResponse(DoubaoProtocol.Response response)
+    {
+      switch (response.type)
+      {
+        case INTERIM_RESULT:
+          long now = System.nanoTime();
+          if (now - lastInterimUpdateNs >= INTERIM_UPDATE_INTERVAL_NS)
+          {
+            lastInterimUpdateNs = now;
+            handleTranscript(this, response);
+          }
+          if (response.vadFinished)
+            stopRequested = true;
+          break;
+        case FINAL_RESULT:
+          handleTranscript(this, response);
+          if (response.vadFinished)
+            stopRequested = true;
+          break;
+        case SESSION_FINISHED:
+          stopRequested = true;
+          break;
+        case ERROR:
+          asyncFailure.compareAndSet(null, new IOException(
+              "Doubao ASR error: " + response.errorMessage));
+          stopRequested = true;
+          break;
+        default:
+          break;
+      }
+    }
+
+    @Override
+    public void onFailure(IOException failure)
+    {
+      asyncFailure.compareAndSet(null, failure);
+      stopRequested = true;
+    }
+  }
+
+  static final class OpusFrameEncoder
+  {
+    private final OpusEncoder encoder;
+    private final byte[] output = new byte[4000];
+
+    OpusFrameEncoder() throws OpusException
+    {
+      encoder = new OpusEncoder(SAMPLE_RATE, 1,
+          OpusApplication.OPUS_APPLICATION_AUDIO);
+    }
+
+    byte[] encode(short[] pcm) throws OpusException
+    {
+      if (pcm.length != SAMPLES_PER_FRAME)
+        throw new IllegalArgumentException("Expected " + SAMPLES_PER_FRAME
+            + " PCM samples, got " + pcm.length);
+      int encodedLength = encoder.encode(pcm, 0, SAMPLES_PER_FRAME,
+          output, 0, output.length);
+      return Arrays.copyOf(output, encodedLength);
+    }
+  }
+}

--- a/srcs/layouts/latn_neo2.xml
+++ b/srcs/layouts/latn_neo2.xml
@@ -43,9 +43,10 @@
   <row height="0.95">
     <key width="1.7" role="action" key0="ctrl" key1="loc switch_greekmath" key2="loc meta" key4="switch_numeric"/>
     <key width="1.1" role="action" key0="fn" key1="loc alt" key2="loc change_method" key3="switch_emoji" key4="config"/>
-    <key width="4.4" role="space_bar" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right"/>
+    <key width="3.5" role="space_bar" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right"/>
+    <key width="0.9" role="action" key0="voice_typing"/>
     <key width="1.1" role="action" key0="loc compose" key7="up" key6="right" key5="left" key8="down" key1="loc home" key2="loc page_up" key3="loc end" key4="loc page_down"/>
     <key key0="j" key4=";"/>
-    <key width="1.7" role="action" key0="enter" key1="loc voice_typing" key2="action"/>
+    <key width="1.7" role="action" key0="enter" key2="action"/>
   </row>
 </keyboard>

--- a/test/juloo.keyboard2.doubao/DoubaoProtocolTest.java
+++ b/test/juloo.keyboard2.doubao/DoubaoProtocolTest.java
@@ -1,0 +1,282 @@
+package juloo.keyboard2.doubao;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import okhttp3.HttpUrl;
+import org.junit.Test;
+
+public class DoubaoProtocolTest
+{
+  @Test
+  public void startTaskMatchesProtobufSchema()
+  {
+    byte[] request = DoubaoProtocol.buildStartTask("r", "t");
+    assertArrayEquals(new byte[]{
+        0x12, 0x01, 't',
+        0x1a, 0x03, 'A', 'S', 'R',
+        0x2a, 0x09, 'S', 't', 'a', 'r', 't', 'T', 'a', 's', 'k',
+        0x42, 0x01, 'r'
+    }, request);
+  }
+
+  @Test
+  public void sessionPayloadKeepsReferenceSettings()
+  {
+    JsonObject payload = JsonParser.parseString(
+        DoubaoProtocol.buildSessionPayload("123")).getAsJsonObject();
+    JsonObject audio = payload.getAsJsonObject("audio_info");
+    JsonObject extra = payload.getAsJsonObject("extra");
+
+    assertEquals(1, audio.get("channel").getAsInt());
+    assertEquals("speech_opus", audio.get("format").getAsString());
+    assertEquals(16000, audio.get("sample_rate").getAsInt());
+    assertTrue(payload.get("enable_punctuation").getAsBoolean());
+    assertTrue(payload.get("enable_vad").getAsBoolean());
+    assertFalse(payload.get("low_latency").getAsBoolean());
+    assertEquals("oime", extra.get("app_name").getAsString());
+    assertEquals(8, extra.get("cell_compress_rate").getAsInt());
+    assertEquals("123", extra.get("did").getAsString());
+    assertEquals("tool", extra.get("input_mode").getAsString());
+    assertTrue(extra.get("interim_results").getAsBoolean());
+  }
+
+  @Test
+  public void audioRequestCarriesFrameAndTimestamp()
+  {
+    byte[] request = DoubaoProtocol.buildAudioRequest("request",
+        new byte[]{1, 2, 3}, DoubaoProtocol.FRAME_LAST, 42);
+    Map<Integer, byte[]> fields = decodeLengthDelimitedFields(request);
+
+    assertEquals("ASR", utf8(fields.get(3)));
+    assertEquals("TaskRequest", utf8(fields.get(5)));
+    assertArrayEquals(new byte[]{1, 2, 3}, fields.get(7));
+    assertEquals("request", utf8(fields.get(8)));
+    assertTrue(utf8(fields.get(6)).contains("\"timestamp_ms\":42"));
+    assertEquals(DoubaoProtocol.FRAME_LAST, decodeVarintField(request, 9));
+  }
+
+  @Test
+  public void parsesLifecycleResponse() throws Exception
+  {
+    DoubaoProtocol.Response response = DoubaoProtocol.parseResponse(
+        response("TaskStarted", 0, "", ""));
+    assertEquals(DoubaoProtocol.ResponseType.TASK_STARTED, response.type);
+  }
+
+  @Test
+  public void parsesArrayInterimResult() throws Exception
+  {
+    String json = "{\"results\":[{\"text\":\"你好\","
+        + "\"is_interim\":true}],\"extra\":{\"packet_number\":7}}";
+    DoubaoProtocol.Response response = DoubaoProtocol.parseResponse(
+        response("", 0, "", json));
+
+    assertEquals(DoubaoProtocol.ResponseType.INTERIM_RESULT, response.type);
+    assertEquals("你好", response.text);
+    assertFalse(response.isFinal);
+  }
+
+  @Test
+  public void parsesObjectFinalWithNestedAlternative() throws Exception
+  {
+    String json = "{\"results\":{\"alternatives\":[{\"transcript\":\"你好。\"}],"
+        + "\"is_final\":true,\"is_vad_finished\":true}}";
+    DoubaoProtocol.Response response = DoubaoProtocol.parseResponse(
+        response("", 0, "", json));
+
+    assertEquals(DoubaoProtocol.ResponseType.FINAL_RESULT, response.type);
+    assertEquals("你好。", response.text);
+    assertTrue(response.isFinal);
+    assertTrue(response.vadFinished);
+  }
+
+  @Test
+  public void failureMessageTypeIsVisibleError() throws Exception
+  {
+    DoubaoProtocol.Response response = DoubaoProtocol.parseResponse(
+        response("SessionFailed", 401, "bad token", ""));
+    assertEquals(DoubaoProtocol.ResponseType.ERROR, response.type);
+    assertEquals(401, response.statusCode);
+    assertEquals("bad token", response.errorMessage);
+  }
+
+  @Test
+  public void okStatusCodeDoesNotOverrideRecognitionPayload() throws Exception
+  {
+    String json = "{\"results\":[{\"text\":\"端到端测试\","
+        + "\"is_interim\":true}]}";
+    DoubaoProtocol.Response response = DoubaoProtocol.parseResponse(
+        response("", 200, "OK", json));
+
+    assertEquals(DoubaoProtocol.ResponseType.INTERIM_RESULT, response.type);
+    assertEquals("端到端测试", response.text);
+  }
+
+  @Test
+  public void okStatusWithoutPayloadIsNotAnError() throws Exception
+  {
+    DoubaoProtocol.Response response = DoubaoProtocol.parseResponse(
+        response("", 200, "OK", ""));
+
+    assertEquals(DoubaoProtocol.ResponseType.UNKNOWN, response.type);
+  }
+
+  @Test(expected = DoubaoProtocol.ProtocolException.class)
+  public void malformedJsonFails() throws Exception
+  {
+    DoubaoProtocol.parseResponse(response("", 0, "", "{broken"));
+  }
+
+  @Test(expected = DoubaoProtocol.ProtocolException.class)
+  public void malformedProtobufFails() throws Exception
+  {
+    DoubaoProtocol.parseResponse(new byte[]{0x3a, 0x05, '{'});
+  }
+
+  @Test
+  public void encodesTwentyMillisecondOpusFrame() throws Exception
+  {
+    DoubaoVoiceInput.OpusFrameEncoder encoder =
+        new DoubaoVoiceInput.OpusFrameEncoder();
+    byte[] opus = encoder.encode(new short[320]);
+    assertTrue(opus.length > 0);
+    assertTrue(opus.length < 4000);
+  }
+
+  @Test
+  public void webSocketHandshakeUsesHttpsUrlForOkHttp()
+  {
+    HttpUrl url = DoubaoAsrClient.Session.buildWebSocketUrl("device id");
+
+    assertEquals("https", url.scheme());
+    assertEquals("frontier-audio-ime-ws.doubao.com", url.host());
+    assertEquals("401734", url.queryParameter("aid"));
+    assertEquals("device id", url.queryParameter("device_id"));
+  }
+
+  private static byte[] response(String messageType, int statusCode,
+      String statusMessage, String resultJson)
+  {
+    TestProtoWriter writer = new TestProtoWriter();
+    writer.string(4, messageType);
+    writer.int32(5, statusCode);
+    writer.string(6, statusMessage);
+    writer.string(7, resultJson);
+    return writer.toByteArray();
+  }
+
+  private static Map<Integer, byte[]> decodeLengthDelimitedFields(byte[] data)
+  {
+    Map<Integer, byte[]> fields = new HashMap<Integer, byte[]>();
+    int[] position = new int[]{0};
+    while (position[0] < data.length)
+    {
+      long tag = readVarint(data, position);
+      int field = (int)(tag >>> 3);
+      int wire = (int)(tag & 7);
+      if (wire == 2)
+      {
+        int length = (int)readVarint(data, position);
+        fields.put(field, Arrays.copyOfRange(data, position[0],
+            position[0] + length));
+        position[0] += length;
+      }
+      else if (wire == 0)
+        readVarint(data, position);
+      else
+        throw new AssertionError("Unexpected wire type " + wire);
+    }
+    return fields;
+  }
+
+  private static int decodeVarintField(byte[] data, int wantedField)
+  {
+    int[] position = new int[]{0};
+    while (position[0] < data.length)
+    {
+      long tag = readVarint(data, position);
+      int field = (int)(tag >>> 3);
+      int wire = (int)(tag & 7);
+      if (wire == 0)
+      {
+        int value = (int)readVarint(data, position);
+        if (field == wantedField)
+          return value;
+      }
+      else if (wire == 2)
+      {
+        int length = (int)readVarint(data, position);
+        position[0] += length;
+      }
+      else
+        throw new AssertionError("Unexpected wire type " + wire);
+    }
+    throw new AssertionError("Missing field " + wantedField);
+  }
+
+  private static long readVarint(byte[] data, int[] position)
+  {
+    long value = 0;
+    for (int shift = 0; shift < 64; shift += 7)
+    {
+      int b = data[position[0]++] & 0xff;
+      value |= (long)(b & 0x7f) << shift;
+      if ((b & 0x80) == 0)
+        return value;
+    }
+    throw new AssertionError("Malformed varint");
+  }
+
+  private static String utf8(byte[] value)
+  {
+    return new String(value, StandardCharsets.UTF_8);
+  }
+
+  private static final class TestProtoWriter
+  {
+    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    void string(int field, String value)
+    {
+      if (value.isEmpty())
+        return;
+      byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+      varint((field << 3) | 2);
+      varint(bytes.length);
+      out.write(bytes, 0, bytes.length);
+    }
+
+    void int32(int field, int value)
+    {
+      if (value == 0)
+        return;
+      varint(field << 3);
+      varint(value);
+    }
+
+    void varint(long value)
+    {
+      while ((value & ~0x7fL) != 0)
+      {
+        out.write(((int)value & 0x7f) | 0x80);
+        value >>>= 7;
+      }
+      out.write((int)value);
+    }
+
+    byte[] toByteArray()
+    {
+      return out.toByteArray();
+    }
+  }
+}

--- a/test/juloo.keyboard2/KeyModifierTest.java
+++ b/test/juloo.keyboard2/KeyModifierTest.java
@@ -17,4 +17,11 @@ public class KeyModifierTest
     assertEquals(eval("compose", "-", "space"), str("~"));
     assertEquals(eval("compose", "space", "-"), str("~"));
   }
+
+  @Test
+  public void longPressVoiceUsesHoldEvent()
+  {
+    assertEquals(KeyValue.VOICE_TYPING_CHOOSER,
+        KeyModifier.modify_long_press(KeyValue.getKeyByName("voice_typing")));
+  }
 }


### PR DESCRIPTION
## What changed

- Embed the Doubao IME registration, settings-token, WebSocket, protobuf, and
  streaming ASR flow directly in Unexpected Keyboard.
- Capture 16 kHz mono audio and encode exact 20 ms Opus frames with Concentus,
  retaining the existing API 21 minimum.
- Apply interim results through `setComposingText` and commit final text through
  `commitText`.
- Keep normal voice activation as a start/stop toggle.
- Treat long press as push-to-talk: start at the hold threshold and stop on
  release or touch cancellation.
- Add explicit microphone permission UI, lifecycle cancellation, visible
  failures, and protocol regression tests.
- Use the separate application ID `com.molaison.unexpectedkeyboard.doubao` so
  this prototype can coexist with the upstream installation.

## Why

Unexpected Keyboard's existing voice action switches to an enabled IME subtype
whose mode is `voice`. Doubao and several Chinese IMEs expose only a normal
`keyboard` subtype, with speech implemented inside their own keyboard UI.
Therefore they cannot be discovered by the existing switcher and the chooser
reports "No voice typing app installed".

This prototype calls the speech service directly and writes recognition results
through the current `InputConnection`, without switching IMEs.

## Validation

- `./gradlew testDebugUnitTest assembleDebug`
- 29 unit tests passed, 0 failed.
- `git diff --check`
- Physical vivo V2426A / Android 16 validation:
  - real credential, WebSocket, microphone, Opus, and final text path completed;
  - committed Mandarin text: `端到端语音输入测试。`;
  - normal activation toggled start/stop;
  - long press stopped on release and `ACTION_CANCEL`;
  - the selected IME remained unchanged;
  - the system voice-IME chooser did not appear.

## Draft notes

This is intentionally a draft because it currently uses Doubao-specific
endpoints/client identity and changes the application ID for side-by-side
testing. Upstream may prefer a configurable provider boundary and retention of
the original application identity before considering a merge.
