### PR TITLE
Add Dracula theme

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -46,6 +46,7 @@
     <item>@string/pref_theme_e_cobalt</item>
     <item>@string/pref_theme_e_pine</item>
     <item>@string/pref_theme_e_epaperblack</item>
+    <item>@string/pref_theme_e_dracula</item>
   </string-array>
   <string-array name="pref_theme_values">
     <item>system</item>
@@ -65,6 +66,7 @@
     <item>cobalt</item>
     <item>pine</item>
     <item>epaperblack</item>
+    <item>dracula</item>
   </string-array>
   <string-array name="pref_swipe_dist_entries">
     <item>@string/pref_swipe_dist_e_very_short</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -83,6 +83,7 @@
     <string name="pref_theme_e_cobalt">Cobalt</string>
     <string name="pref_theme_e_pine">Pine</string>
     <string name="pref_theme_e_epaperblack">ePaper Black</string>
+    <string name="pref_theme_e_dracula">Dracula</string>
     <string name="pref_swipe_dist_e_very_short">Very short</string>
     <string name="pref_swipe_dist_e_short">Short</string>
     <string name="pref_swipe_dist_e_default">Normal</string>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -332,4 +332,21 @@
     <item name="clipboard_divider_color">?colorLabel</item>
     <item name="clipboard_divider_height">2dp</item>
  </style>
+ <style name="Dracula" parent="BaseTheme">
+    <item name="android:isLightTheme">false</item>
+    <item name="colorKeyboard">#282A36</item>
+    <item name="colorKey">#343746</item>
+    <item name="colorKeyActivated">#44475A</item>
+    <item name="colorKeyAction">#7446A8</item>
+    <item name="colorKeySpaceBar">#343746</item>
+    <item name="colorLabel">#F8F8F2</item>
+    <item name="colorLabelActivated">#FF79C6</item>
+    <item name="colorLabelLocked">#50FA7B</item>
+    <item name="colorSubLabel">#6272A4</item>
+    <item name="keyBorderRadius">8dp</item>
+    <item name="keyBorderWidth">0dp</item>
+    <item name="keyBorderWidthActivated">0dp</item>
+    <item name="emoji_button_bg">#343746</item>
+    <item name="emoji_color">#F8F8F2</item>
+  </style>
 </resources>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -278,6 +278,7 @@ public final class Config
       case "cobalt": return R.style.Cobalt;
       case "pine": return R.style.Pine;
       case "epaperblack": return R.style.ePaperBlack;
+      case "dracula": return R.style.Dracula;
       default:
       case "system":
         if ((night_mode & Configuration.UI_MODE_NIGHT_NO) != 0)


### PR DESCRIPTION
Adds a Dracula-inspired dark theme based on the official Dracula palette.

- Adds the theme resources and preference entry
- Does not modify keyboard behavior or rendering
(Tested on a Pixel 8 Pro API 37 emulator)

<img width="351" height="213" alt="image" src="https://github.com/user-attachments/assets/188c0c34-8fd3-4d98-bffe-42d2c9dd8efc" />
