### PR TITLE
Add support for keyboard background gradients

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -46,6 +46,7 @@
     <item>@string/pref_theme_e_cobalt</item>
     <item>@string/pref_theme_e_pine</item>
     <item>@string/pref_theme_e_epaperblack</item>
+    <item>@string/pref_theme_e_gradientpurplepink</item>
   </string-array>
   <string-array name="pref_theme_values">
     <item>system</item>
@@ -65,6 +66,7 @@
     <item>cobalt</item>
     <item>pine</item>
     <item>epaperblack</item>
+    <item>gradientpurplepink</item>
   </string-array>
   <string-array name="pref_swipe_dist_entries">
     <item>@string/pref_swipe_dist_e_very_short</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -83,6 +83,7 @@
     <string name="pref_theme_e_cobalt">Cobalt</string>
     <string name="pref_theme_e_pine">Pine</string>
     <string name="pref_theme_e_epaperblack">ePaper Black</string>
+    <string name="pref_theme_e_gradientpurplepink">Purple Pink Gradient</string>
     <string name="pref_swipe_dist_e_very_short">Very short</string>
     <string name="pref_swipe_dist_e_short">Short</string>
     <string name="pref_swipe_dist_e_default">Normal</string>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -3,6 +3,9 @@
   <declare-styleable name="keyboard">
     <!-- The background of the keyboard -->
     <attr name="colorKeyboard" format="color"/>
+    <!-- Optional vertical gradient drawn behind the keys -->
+    <attr name="keyboardGradientStart" format="color"/>
+    <attr name="keyboardGradientEnd" format="color"/>
     <!-- Background of the keys -->
     <attr name="colorKey" format="color"/>
     <!-- Background of the keys when pressed -->

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -335,4 +335,29 @@
     <item name="clipboard_divider_color">?colorLabel</item>
     <item name="clipboard_divider_height">2dp</item>
  </style>
+ <style name="GradientPurplePink" parent="BaseTheme">
+    <item name="android:isLightTheme">false</item>
+    <item name="colorKeyboard">#251A3A</item>
+    <!-- Vertical Gradient -->
+    <item name="keyboardGradientStart">#8A2BE2</item>
+    <item name="keyboardGradientEnd">#AF6679</item>
+    <!-- Translucid keys : format #AARRGGBB -->
+    <item name="colorKey">#B3262033</item>
+    <item name="colorKeyActivated">#DD67527E</item>
+    <item name="colorKeyAction">#D13B2D50</item>
+    <item name="colorKeySpaceBar">#C72D253D</item>
+    <!-- Letters -->
+    <item name="colorLabel">#FFFFFFFF</item>
+    <item name="colorLabelPressed">#FFFFFFFF</item>
+    <item name="colorLabelActivated">#462563</item>
+    <item name="colorLabelLocked">#B9F6FF</item>
+    <item name="colorSubLabel">#B088D3</item>
+    <!-- Keys forms -->
+    <item name="keyBorderRadius">8dp</item>
+    <item name="keyBorderWidth">0dp</item>
+    <item name="keyBorderWidthActivated">0dp</item>
+    <!-- Emojis -->
+    <item name="emoji_button_bg">#3B2D50</item>
+    <item name="emoji_color">#FFFFFF</item>
+ </style>
 </resources>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -278,6 +278,7 @@ public final class Config
       case "cobalt": return R.style.Cobalt;
       case "pine": return R.style.Pine;
       case "epaperblack": return R.style.ePaperBlack;
+      case "gradientpurplepink": return R.style.GradientPurplePink;
       default:
       case "system":
         if ((night_mode & Configuration.UI_MODE_NIGHT_NO) != 0)

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -19,6 +19,8 @@ import android.view.WindowManager;
 import android.view.WindowMetrics;
 import java.util.Arrays;
 import java.util.List;
+import android.graphics.LinearGradient;
+import android.graphics.Shader;
 
 public class Keyboard2View extends View
   implements View.OnTouchListener, Pointers.IPointerEventHandler
@@ -52,6 +54,8 @@ public class Keyboard2View extends View
 
   private Theme _theme;
   private Theme.Computed _tc;
+
+  private final Paint _keyboardBackgroundPaint = new Paint();
 
   private static RectF _tmpRect = new RectF();
 
@@ -338,8 +342,41 @@ public class Keyboard2View extends View
   };
 
   @Override
+  protected void onSizeChanged(int w, int h, int oldw, int oldh)
+  {
+    super.onSizeChanged(w, h, oldw, oldh);
+
+    if (_theme.hasKeyboardGradient && h > 0)
+    {
+      LinearGradient gradient = new LinearGradient(
+              0,
+              0,
+              0,
+              h,
+              _theme.keyboardGradientStart,
+              _theme.keyboardGradientEnd,
+              Shader.TileMode.CLAMP);
+
+      _keyboardBackgroundPaint.setShader(gradient);
+    }
+    else
+    {
+      _keyboardBackgroundPaint.setShader(null);
+    }
+  }
+
+  @Override
   protected void onDraw(Canvas canvas)
   {
+    if (_theme.hasKeyboardGradient)
+    {
+      canvas.drawRect(
+              0,
+              0,
+              getWidth(),
+              getHeight(),
+              _keyboardBackgroundPaint);
+    }
     float y = _tc.margin_top;
     for (KeyboardData.Row row : _keyboard.rows)
     {

--- a/srcs/juloo.keyboard2/Theme.java
+++ b/srcs/juloo.keyboard2/Theme.java
@@ -15,6 +15,11 @@ public class Theme
   public final int colorKeyAction;
   public final int colorKeySpaceBar;
 
+  // Optional keyboard background gradient
+  public final boolean hasKeyboardGradient;
+  public final int keyboardGradientStart;
+  public final int keyboardGradientEnd;
+
   // Label colors
   public final int lockedColor;
   public final int activatedColor;
@@ -42,6 +47,9 @@ public class Theme
   {
     getKeyFont(context); // _key_font will be accessed
     TypedArray s = context.getTheme().obtainStyledAttributes(attrs, R.styleable.keyboard, 0, 0);
+    hasKeyboardGradient = s.hasValue(R.styleable.keyboard_keyboardGradientStart) && s.hasValue(R.styleable.keyboard_keyboardGradientEnd);
+    keyboardGradientStart = s.getColor(R.styleable.keyboard_keyboardGradientStart, 0);
+    keyboardGradientEnd = s.getColor(R.styleable.keyboard_keyboardGradientEnd, 0);
     colorKey = s.getColor(R.styleable.keyboard_colorKey, 0);
     colorKeyActivated = s.getColor(R.styleable.keyboard_colorKeyActivated, 0);
     colorKeyAction = s.getColor(R.styleable.keyboard_colorKeyAction, colorKey);


### PR DESCRIPTION
Adds optional support for two-color vertical gradients on the keyboard background.

- Adds optional theme attributes for the gradient colors
- Adds a custom Purple Pink Gradient theme as example
- (Keeps the existing solid-color rendering for themes without gradients)
- (Does not modify keyboard input behavior)

(Tested on a Pixel 8 Pro API 37 emulator)

<img width="373" height="280" alt="image" src="https://github.com/user-attachments/assets/0a998c0d-2803-46f0-a6f2-006a0ffb8683" />
