### PR TITLE
Add keyboard background gradients and a purple pink theme

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -46,6 +46,7 @@
     <item>@string/pref_theme_e_cobalt</item>
     <item>@string/pref_theme_e_pine</item>
     <item>@string/pref_theme_e_epaperblack</item>
+    <item>@string/pref_theme_e_gradientpurplepink</item>
   </string-array>
   <string-array name="pref_theme_values">
     <item>system</item>
@@ -65,6 +66,7 @@
     <item>cobalt</item>
     <item>pine</item>
     <item>epaperblack</item>
+    <item>gradientpurplepink</item>
   </string-array>
   <string-array name="pref_swipe_dist_entries">
     <item>@string/pref_swipe_dist_e_very_short</item>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -47,6 +47,7 @@
     <item>@string/pref_theme_e_pine</item>
     <item>@string/pref_theme_e_epaperblack</item>
     <item>@string/pref_theme_e_dracula</item>
+    <item>@string/pref_theme_e_gradientpurplepink</item>
   </string-array>
   <string-array name="pref_theme_values">
     <item>system</item>
@@ -67,6 +68,7 @@
     <item>pine</item>
     <item>epaperblack</item>
     <item>dracula</item>
+    <item>gradientpurplepink</item>
   </string-array>
   <string-array name="pref_swipe_dist_entries">
     <item>@string/pref_swipe_dist_e_very_short</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -84,6 +84,7 @@
     <string name="pref_theme_e_pine">Pine</string>
     <string name="pref_theme_e_epaperblack">ePaper Black</string>
     <string name="pref_theme_e_dracula">Dracula</string>
+    <string name="pref_theme_e_gradientpurplepink">Purple Pink Gradient</string>
     <string name="pref_swipe_dist_e_very_short">Very short</string>
     <string name="pref_swipe_dist_e_short">Short</string>
     <string name="pref_swipe_dist_e_default">Normal</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -83,6 +83,7 @@
     <string name="pref_theme_e_cobalt">Cobalt</string>
     <string name="pref_theme_e_pine">Pine</string>
     <string name="pref_theme_e_epaperblack">ePaper Black</string>
+    <string name="pref_theme_e_gradientpurplepink">Purple Pink Gradient</string>
     <string name="pref_swipe_dist_e_very_short">Very short</string>
     <string name="pref_swipe_dist_e_short">Short</string>
     <string name="pref_swipe_dist_e_default">Normal</string>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -3,6 +3,9 @@
   <declare-styleable name="keyboard">
     <!-- The background of the keyboard -->
     <attr name="colorKeyboard" format="color"/>
+    <!-- Optional vertical gradient drawn behind the keys -->
+    <attr name="keyboardGradientStart" format="color"/>
+    <attr name="keyboardGradientEnd" format="color"/>
     <!-- Background of the keys -->
     <attr name="colorKey" format="color"/>
     <!-- Background of the keys when pressed -->

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -352,4 +352,24 @@
     <item name="emoji_button_bg">#343746</item>
     <item name="emoji_color">#F8F8F2</item>
   </style>
+  <style name="GradientPurplePink" parent="BaseTheme">
+    <item name="android:isLightTheme">false</item>
+    <item name="colorKeyboard">#251A3A</item>
+    <item name="keyboardGradientStart">#8A2BE2</item>
+    <item name="keyboardGradientEnd">#AF6679</item>
+    <item name="colorKey">#B3262033</item>
+    <item name="colorKeyActivated">#DD67527E</item>
+    <item name="colorKeyAction">#D13B2D50</item>
+    <item name="colorKeySpaceBar">#C72D253D</item>
+    <item name="colorLabel">#FFFFFFFF</item>
+    <item name="colorLabelPressed">#FFFFFFFF</item>
+    <item name="colorLabelActivated">#462563</item>
+    <item name="colorLabelLocked">#B9F6FF</item>
+    <item name="colorSubLabel">#B088D3</item>
+    <item name="keyBorderRadius">8dp</item>
+    <item name="keyBorderWidth">0dp</item>
+    <item name="keyBorderWidthActivated">0dp</item>
+    <item name="emoji_button_bg">#3B2D50</item>
+    <item name="emoji_color">#FFFFFF</item>
+  </style>
 </resources>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -335,4 +335,29 @@
     <item name="clipboard_divider_color">?colorLabel</item>
     <item name="clipboard_divider_height">2dp</item>
  </style>
+ <style name="GradientPurplePink" parent="BaseTheme">
+    <item name="android:isLightTheme">false</item>
+    <item name="colorKeyboard">#251A3A</item>
+    <!-- Vertical Gradient -->
+    <item name="keyboardGradientStart">#8A2BE2</item>
+    <item name="keyboardGradientEnd">#AF6679</item>
+    <!-- Translucid keys : format #AARRGGBB -->
+    <item name="colorKey">#B3262033</item>
+    <item name="colorKeyActivated">#DD67527E</item>
+    <item name="colorKeyAction">#D13B2D50</item>
+    <item name="colorKeySpaceBar">#C72D253D</item>
+    <!-- Letters -->
+    <item name="colorLabel">#FFFFFFFF</item>
+    <item name="colorLabelPressed">#FFFFFFFF</item>
+    <item name="colorLabelActivated">#462563</item>
+    <item name="colorLabelLocked">#B9F6FF</item>
+    <item name="colorSubLabel">#B088D3</item>
+    <!-- Keys forms -->
+    <item name="keyBorderRadius">8dp</item>
+    <item name="keyBorderWidth">0dp</item>
+    <item name="keyBorderWidthActivated">0dp</item>
+    <!-- Emojis -->
+    <item name="emoji_button_bg">#3B2D50</item>
+    <item name="emoji_color">#FFFFFF</item>
+ </style>
 </resources>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -278,6 +278,7 @@ public final class Config
       case "cobalt": return R.style.Cobalt;
       case "pine": return R.style.Pine;
       case "epaperblack": return R.style.ePaperBlack;
+      case "gradientpurplepink": return R.style.GradientPurplePink;
       default:
       case "system":
         if ((night_mode & Configuration.UI_MODE_NIGHT_NO) != 0)

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -280,6 +280,7 @@ public final class Config
       case "pine": return R.style.Pine;
       case "epaperblack": return R.style.ePaperBlack;
       case "dracula": return R.style.Dracula;
+      case "gradientpurplepink": return R.style.GradientPurplePink;
       default:
       case "system":
         if ((night_mode & Configuration.UI_MODE_NIGHT_NO) != 0)

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -19,6 +19,8 @@ import android.view.WindowManager;
 import android.view.WindowMetrics;
 import java.util.Arrays;
 import java.util.List;
+import android.graphics.LinearGradient;
+import android.graphics.Shader;
 
 public class Keyboard2View extends View
   implements View.OnTouchListener, Pointers.IPointerEventHandler
@@ -52,6 +54,8 @@ public class Keyboard2View extends View
 
   private Theme _theme;
   private Theme.Computed _tc;
+
+  private final Paint _keyboardBackgroundPaint = new Paint();
 
   private static RectF _tmpRect = new RectF();
 
@@ -338,8 +342,41 @@ public class Keyboard2View extends View
   };
 
   @Override
+  protected void onSizeChanged(int w, int h, int oldw, int oldh)
+  {
+    super.onSizeChanged(w, h, oldw, oldh);
+
+    if (_theme.hasKeyboardGradient && h > 0)
+    {
+      LinearGradient gradient = new LinearGradient(
+              0,
+              0,
+              0,
+              h,
+              _theme.keyboardGradientStart,
+              _theme.keyboardGradientEnd,
+              Shader.TileMode.CLAMP);
+
+      _keyboardBackgroundPaint.setShader(gradient);
+    }
+    else
+    {
+      _keyboardBackgroundPaint.setShader(null);
+    }
+  }
+
+  @Override
   protected void onDraw(Canvas canvas)
   {
+    if (_theme.hasKeyboardGradient)
+    {
+      canvas.drawRect(
+              0,
+              0,
+              getWidth(),
+              getHeight(),
+              _keyboardBackgroundPaint);
+    }
     float y = _tc.margin_top;
     for (KeyboardData.Row row : _keyboard.rows)
     {

--- a/srcs/juloo.keyboard2/Keyboard2View.java
+++ b/srcs/juloo.keyboard2/Keyboard2View.java
@@ -340,6 +340,16 @@ public class Keyboard2View extends View
   @Override
   protected void onDraw(Canvas canvas)
   {
+    if (_tc.keyboard_background_paint != null)
+    {
+      canvas.drawRect(
+              0,
+              0,
+              getWidth(),
+              getHeight(),
+              _tc.keyboard_background_paint);
+    }
+
     float y = _tc.margin_top;
     for (KeyboardData.Row row : _keyboard.rows)
     {

--- a/srcs/juloo.keyboard2/Theme.java
+++ b/srcs/juloo.keyboard2/Theme.java
@@ -3,7 +3,9 @@ package juloo.keyboard2;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Color;
+import android.graphics.LinearGradient;
 import android.graphics.Paint;
+import android.graphics.Shader;
 import android.graphics.Typeface;
 import android.util.AttributeSet;
 
@@ -14,6 +16,11 @@ public class Theme
   public final int colorKeyActivated;
   public final int colorKeyAction;
   public final int colorKeySpaceBar;
+
+  // Optional keyboard background gradient
+  public final boolean hasKeyboardGradient;
+  public final int keyboardGradientStart;
+  public final int keyboardGradientEnd;
 
   // Label colors
   public final int lockedColor;
@@ -42,6 +49,9 @@ public class Theme
   {
     getKeyFont(context); // _key_font will be accessed
     TypedArray s = context.getTheme().obtainStyledAttributes(attrs, R.styleable.keyboard, 0, 0);
+    hasKeyboardGradient = s.hasValue(R.styleable.keyboard_keyboardGradientStart) && s.hasValue(R.styleable.keyboard_keyboardGradientEnd);
+    keyboardGradientStart = s.getColor(R.styleable.keyboard_keyboardGradientStart, 0);
+    keyboardGradientEnd = s.getColor(R.styleable.keyboard_keyboardGradientEnd, 0);
     colorKey = s.getColor(R.styleable.keyboard_colorKey, 0);
     colorKeyActivated = s.getColor(R.styleable.keyboard_colorKeyActivated, 0);
     colorKeyAction = s.getColor(R.styleable.keyboard_colorKeyAction, colorKey);
@@ -105,6 +115,7 @@ public class Theme
     public final float margin_top;
     public final float margin_left;
     public final float row_height;
+    public final Paint keyboard_background_paint;
     public final Paint indication_paint;
 
     public final Key key;
@@ -121,6 +132,7 @@ public class Theme
           (config.screenHeightPixels - config.keyboard_rows_height_pixels) / layout.keysHeight);
       vertical_margin = config.key_vertical_margin * row_height;
       horizontal_margin = config.key_horizontal_margin * keyWidth;
+      keyboard_background_paint = init_keyboard_background_paint(theme, config.marginTop + row_height * layout.keysHeight + config.margin_bottom);
       // Add half of the key margin on the left and on the top as it's also
       // added on the right and on the bottom of every keys.
       margin_top = config.marginTop + vertical_margin / 2;
@@ -132,6 +144,23 @@ public class Theme
       key_suggestion = new Key(theme, config, keyWidth, false, KeyboardData.Key.Role.Suggestion);
       indication_paint = init_label_paint(config, null);
       indication_paint.setColor(theme.subLabelColor);
+    }
+
+    static Paint init_keyboard_background_paint(Theme theme, float height)
+    {
+      if (!theme.hasKeyboardGradient)
+        return null;
+
+      Paint p = new Paint();
+      p.setShader(new LinearGradient(
+              0,
+              0,
+              0,
+              height,
+              theme.keyboardGradientStart,
+              theme.keyboardGradientEnd,
+              Shader.TileMode.CLAMP));
+      return p;
     }
 
     public static final class Key

--- a/srcs/juloo.keyboard2/Theme.java
+++ b/srcs/juloo.keyboard2/Theme.java
@@ -132,11 +132,11 @@ public class Theme
           (config.screenHeightPixels - config.keyboard_rows_height_pixels) / layout.keysHeight);
       vertical_margin = config.key_vertical_margin * row_height;
       horizontal_margin = config.key_horizontal_margin * keyWidth;
-      keyboard_background_paint = init_keyboard_background_paint(theme, config.marginTop + row_height * layout.keysHeight + config.margin_bottom);
       // Add half of the key margin on the left and on the top as it's also
       // added on the right and on the bottom of every keys.
       margin_top = config.marginTop + vertical_margin / 2;
       margin_left = horizontal_margin / 2;
+      keyboard_background_paint = init_keyboard_background_paint(theme, margin_top + row_height * layout.keysHeight + config.margin_bottom);
       key = new Key(theme, config, keyWidth, false, KeyboardData.Key.Role.Normal);
       key_action = new Key(theme, config, keyWidth, false, KeyboardData.Key.Role.Action);
       key_space_bar = new Key(theme, config, keyWidth, false, KeyboardData.Key.Role.Space_bar);

--- a/srcs/juloo.keyboard2/Theme.java
+++ b/srcs/juloo.keyboard2/Theme.java
@@ -15,6 +15,11 @@ public class Theme
   public final int colorKeyAction;
   public final int colorKeySpaceBar;
 
+  // Optional keyboard background gradient
+  public final boolean hasKeyboardGradient;
+  public final int keyboardGradientStart;
+  public final int keyboardGradientEnd;
+
   // Label colors
   public final int lockedColor;
   public final int activatedColor;
@@ -42,6 +47,9 @@ public class Theme
   {
     getKeyFont(context); // _key_font will be accessed
     TypedArray s = context.getTheme().obtainStyledAttributes(attrs, R.styleable.keyboard, 0, 0);
+    hasKeyboardGradient = s.hasValue(R.styleable.keyboard_keyboardGradientStart) && s.hasValue(R.styleable.keyboard_keyboardGradientEnd);
+    keyboardGradientStart = s.getColor(R.styleable.keyboard_keyboardGradientStart, 0);
+    keyboardGradientEnd = s.getColor(R.styleable.keyboard_keyboardGradientEnd, 0);
     colorKey = s.getColor(R.styleable.keyboard_colorKey, 0);
     colorKeyActivated = s.getColor(R.styleable.keyboard_colorKeyActivated, 0);
     colorKeyAction = s.getColor(R.styleable.keyboard_colorKeyAction, colorKey);


### PR DESCRIPTION
Adds optional support for two-color vertical gradients on the keyboard background, along with a Purple Pink Gradient theme demonstrating the feature.

## Changes

- Adds optional theme attributes for the gradient start and end colors
- Draws the gradient behind the keyboard keys
- Adds the Purple Pink Gradient theme
- (Preserves the existing solid-color rendering for themes without gradient attributes)
- (Does not modify keyboard input behavior)

(Tested on a Pixel 8 Pro API 37 emulator)

<img width="374" height="283" alt="image" src="https://github.com/user-attachments/assets/7d22dec1-9cd1-4a0d-ac98-c15f8acca141" />
