### PR TITLE
Show the current language name in the candidates view

### DIFF
--- a/res/layout/keyboard.xml
+++ b/res/layout/keyboard.xml
@@ -5,6 +5,7 @@
     <TextView android:id="@+id/candidates_left" style="@style/candidates_item"/>
     <TextView android:id="@+id/candidates_middle" style="@style/candidates_item"/>
     <TextView android:id="@+id/candidates_right" style="@style/candidates_item"/>
+    <TextView android:id="@+id/candidates_lang_name" style="@style/candidates_lang_name"/>
     <Button android:id="@+id/dictionary_switch" style="@style/change_dictionary"/>
   </juloo.keyboard2.suggestions.CandidatesView>
   <juloo.keyboard2.Keyboard2View android:id="@+id/keyboard_view" android:layout_width="match_parent" android:layout_height="wrap_content"/>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -44,6 +44,13 @@
     <item name="android:gravity">center</item>
     <item name="android:textColor">?attr/colorLabel</item>
   </style>
+  <style name="candidates_lang_name">
+    <item name="android:layout_width">match_parent</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:gravity">end|center_vertical</item>
+    <item name="android:textColor">?attr/colorSubLabel</item>
+    <item name="android:layout_marginEnd">@dimen/candidates_gap</item>
+  </style>
   <!-- Emoji pane -->
   <style name="emojiTypeButton">
     <item name="android:padding">1px</item>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -87,6 +87,7 @@ public final class Config
   public DeviceLocales device_locales = null;
   public Cdict current_dictionary = null; // Might be 'null'.
   public Cdict emoji_dictionary = null; // Might be 'null'.
+  public String current_dictionary_name = null; // Display name for the current language
   /** Whether to show the dictionary switching button in the candidates view. */
   public boolean should_show_dictionary_switch = false;
   public IKeyEventHandler handler;

--- a/srcs/juloo.keyboard2/Keyboard2.java
+++ b/srcs/juloo.keyboard2/Keyboard2.java
@@ -29,6 +29,7 @@ import juloo.cdict.Cdict;
 import juloo.keyboard2.dict.Dictionaries;
 import juloo.keyboard2.dict.DictionariesActivity;
 import juloo.keyboard2.dict.DictionarySwitcher;
+import juloo.keyboard2.dict.SupportedDictionaries;
 import juloo.keyboard2.prefs.LayoutsPreference;
 import juloo.keyboard2.suggestions.CandidatesView;
 import juloo.keyboard2.suggestions.Suggestions;
@@ -190,11 +191,13 @@ public class Keyboard2 extends InputMethodService
   {
     _config.should_show_dictionary_switch =
       (_config.device_locales.installed.size() > 0);
-    String selected = _dictionaries.get_selected(_config);
-    String fallback = (_config.device_locales.default_ != null) ?
-      _config.device_locales.default_.dictionary : null;
-    _dictionaries.set_current_dictionary(_config,
-        (selected != null) ? selected : fallback);
+    String dict_name = _dictionaries.get_selected(_config);
+    if (dict_name == null)
+      dict_name = (_config.device_locales.default_ != null) ?
+        _config.device_locales.default_.dictionary : null;
+    _dictionaries.set_current_dictionary(_config, dict_name);
+    _config.current_dictionary_name =
+      SupportedDictionaries.get(getResources()).get_display_name(dict_name);
   }
 
   /** Remember and apply the dictionary chosen by the user for the current

--- a/srcs/juloo.keyboard2/suggestions/CandidatesView.java
+++ b/srcs/juloo.keyboard2/suggestions/CandidatesView.java
@@ -39,6 +39,8 @@ public class CandidatesView extends LinearLayout
   View _dictionary_switch_button;
   boolean should_show_dictionary_switch = false;
 
+  TextView _lang_name_view;
+
   public CandidatesView(Context context, AttributeSet attrs)
   {
     super(context, attrs);
@@ -53,6 +55,7 @@ public class CandidatesView extends LinearLayout
     setup_item_view(2, R.id.candidates_left);
     setup_item_view(3, R.id.candidates_emoji);
     setup_dictionary_switch_button();
+    _lang_name_view = (TextView)findViewById(R.id.candidates_lang_name);
   }
 
   public void set_candidates(Suggestions s)
@@ -77,9 +80,10 @@ public class CandidatesView extends LinearLayout
         v.setVisibility(View.GONE);
       }
     }
-    _dictionary_switch_button.setVisibility(
-        (should_show_dictionary_switch && s.count == 0) ?
-        View.VISIBLE : View.GONE);
+    int dict_vis =
+      (should_show_dictionary_switch && s.count == 0) ? View.VISIBLE : View.GONE;
+    _dictionary_switch_button.setVisibility(dict_vis);
+    _lang_name_view.setVisibility(dict_vis);
   }
 
   void clear_candidates()
@@ -102,6 +106,7 @@ public class CandidatesView extends LinearLayout
       _status_no_dict.setVisibility(View.GONE);
     should_show_dictionary_switch = config.should_show_dictionary_switch;
     set_sizes(config);
+    _lang_name_view.setText(config.current_dictionary_name);
   }
 
   /** Set the height of the suggestion row and the text size. */


### PR DESCRIPTION
Related: https://github.com/Julow/Unexpected-Keyboard/issues/1360

When several dictionaries are installed, the selected one is shown on the candidates view next to the switching button.