### PR TITLE
Add additional virama sign to Sinhala layout

### DIFF
--- a/gen_sinhala_phonetic_layout.py
+++ b/gen_sinhala_phonetic_layout.py
@@ -27,7 +27,6 @@ conflicts e. g. when trying to move a symbol into occupied position.
 
 import argparse
 import logging
-
 from enum import StrEnum
 from pathlib import Path
 from xml.etree import ElementTree
@@ -302,7 +301,7 @@ class LayoutBuilder:
 
     @staticmethod
     def _parse_reference_layout() -> list[ElementTree.Element]:
-        return ElementTree.parse(REFERENCE_LAYOUT_FILE).findall('row')
+        return ElementTree.parse(REFERENCE_LAYOUT_FILE).findall('row')  # noqa: S314
 
     @staticmethod
     def _move_untransited_to_new_map(
@@ -339,7 +338,10 @@ class LayoutBuilder:
             row_num, key_num = to_coord
             key = new_map[row_num][key_num]
             if (existing := key.get(to_plc)) is not None:
-                msg = f'Trying to add char to <{to_key_name}:{to_plc}>, but already contains "{existing}"'
+                msg = (
+                    f'Trying to add char to <{to_key_name}:{to_plc}>, '
+                    f'but already contains "{existing}"'
+                )
                 raise LayoutGenError(msg)
             key.set(to_plc, char)
             LOGGER.info(
@@ -382,7 +384,7 @@ class LayoutBuilder:
                 val = from_key.attrib.pop(from_plc)
             except KeyError:
                 msg = f'No value in key {from_key_name}, placement {from_plc} to move'
-                raise LayoutGenError(msg)
+                raise LayoutGenError(msg) from None
             if to_plc is not None:
                 if to_key.get(to_plc):
                     msg = f'Second transition to key {to_key_name}, placement {to_plc}'

--- a/gen_sinhala_phonetic_layout.py
+++ b/gen_sinhala_phonetic_layout.py
@@ -204,6 +204,7 @@ TRANSITIONS_MAP: dict[tuple[str, Placement], tuple[str, Placement | None]] = {
 CHARS_EXTRA = {
     # In XKB ZWJ is on `/` key, and ZWNJ is on spacebar
     'zwj': ('m', Placement.SE),
+    '\N{Sinhala Sign Al-Lakuna}': ('r', Placement.NE),
 }
 
 

--- a/gen_sinhala_phonetic_layout.py
+++ b/gen_sinhala_phonetic_layout.py
@@ -25,8 +25,11 @@ conflicts e. g. when trying to move a symbol into occupied position.
   - Requires Python >= 3.11
 """
 
+# ruff: noqa: E501
+
 import argparse
 import logging
+import unicodedata
 from enum import StrEnum
 from pathlib import Path
 from xml.etree import ElementTree
@@ -44,36 +47,41 @@ class Placement(StrEnum):
     W = 'w'
 
 
+def vow(name: str) -> str:
+    """ Helper shotcut for Sinhala vowels unicode names"""
+    return unicodedata.lookup(f'Sinhala Vowel Sign {name}')
+
+
 # Based on XKB Sinhala (phonetic)
 KEYS_MAP: dict[str, tuple[str, str, str, str]] = {
     # Row 1 ###########################################
-    'q': ('ඍ', 'ඎ', '\u0DD8', '\u0DF2'),
-    'w': ('ඇ', 'ඈ', '\u0DD0', '\u0DD1'),
-    'e': ('එ', 'ඒ', '\u0DD9', '\u0DDA'),
+    'q': ('ඍ', 'ඎ', vow('Gaetta-Pilla'), vow('Diga Gaetta-Pilla')),
+    'w': ('ඇ', 'ඈ', vow('Ketti Aeda-Pilla'), vow('Diga Aeda-Pilla')),
+    'e': ('එ', 'ඒ', vow('Kombuva'), vow('Diga Kombuva')),
     'r': ('ර', '', '', ''),  # In XKB virama is on layer 2
     't': ('ත', 'ථ', 'ට', 'ඨ'),
     'y': ('ය', '', '', ''),  # In XKB virama is on layer 2
-    'u': ('උ', 'ඌ', '\u0DD4', '\u0DD6'),
-    'i': ('ඉ', 'ඊ', '\u0DD2', '\u0DD3'),
-    'o': ('ඔ', 'ඕ', '\u0DDC', '\u0DDD'),
+    'u': ('උ', 'ඌ', vow('Ketti Paa-Pilla'), vow('Diga Paa-Pilla')),
+    'i': ('ඉ', 'ඊ', vow('Ketti Is-Pilla'), vow('Diga Is-Pilla')),
+    'o': ('ඔ', 'ඕ', vow('Kombuva Haa Aela-Pilla'), vow('Kombuva Haa Diga Aela-Pilla')),
     'p': ('ප', 'ඵ', '', ''),
     # Row 2 ###########################################
-    'a': ('අ', 'ආ', '\u0DCA', '\u0DCF'),
+    'a': ('අ', 'ආ', '\N{Sinhala Sign Al-Lakuna}', vow('Aela-Pilla')),
     's': ('ස', 'ශ', 'ෂ', ''),
     'd': ('ද', 'ධ', 'ඩ', 'ඪ'),
-    'f': ('ෆ', '\u0D93', '', '\u0DDB'),  # In XKB aiyanna placed otherwise
+    'f': ('ෆ', '\N{Sinhala Letter Aiyanna}', '', vow('Kombu Deka')),  # In XKB aiyanna placed otherwise
     'g': ('ග', 'ඝ', 'ඟ', ''),
-    'h': ('හ', '\u0D83', '\u0DDE', 'ඖ'),
+    'h': ('හ', '\N{Sinhala Sign Visargaya}', vow('Kombuva Haa Gayanukitta'), 'ඖ'),
     'j': ('ජ', 'ඣ', 'ඦ', ''),
     'k': ('ක', 'ඛ', 'ඦ', 'ඐ'),
-    'l': ('ල', 'ළ', '\u0DDF', '\u0DF3'),
+    'l': ('ල', 'ළ', vow('Gayanukitta'), vow('Diga Gayanukitta')),
     # Row 3 ###########################################
     'z': ('ඤ', 'ඥ', '', ''),  # In XKB contains bar, broken bar
     'x': ('ඳ', 'ඬ', '', ''),
     'c': ('ච', 'ඡ', '', ''),
     'v': ('ව', '', '', ''),
     'b': ('බ', 'භ', '', ''),
-    'n': ('න', 'ණ', '\u0D82', 'ඞ'),
+    'n': ('න', 'ණ', '\N{Sinhala Sign Anusvaraya}', 'ඞ'),
     'm': ('ම', 'ඹ', '', ''),
 }
 
@@ -109,7 +117,7 @@ MODMAP_EXTRA: dict[str, dict[str, str]] = {
         # Kunddaliya
         '.': '෴',
         # Extra broken bar intead z key in XKB
-        '\u007C': '\u00A6',
+        '\N{Vertical Line}': '\N{Broken Bar}',
         # Special whitespaces
         'zwj': 'zwnj',
     },
@@ -135,8 +143,7 @@ MODMAP_EXTRA: dict[str, dict[str, str]] = {
         'ක': '𑇲',  # 90
         'ල': '𑇳',  # 100
         'ළ': '𑇴',  # 1000
-        # Sinhala candrabindu for Sanskrit
-        'ණ': '\u0D81',
+        'ණ': '\N{Sinhala Sign Candrabindu}',
     },
 }
 

--- a/srcs/layouts/sinhala_phonetic.xml
+++ b/srcs/layouts/sinhala_phonetic.xml
@@ -8,7 +8,7 @@ Based on XKB Sinhala (phonetic) layout.
     <key sw="loc esc" se="1" c="ඍ" ne="ඎ" />
     <key se="2" c="ඇ" nw="~" sw="\@" ne="ඈ" />
     <key se="3" c="එ" nw="!" sw="\#" ne="ඒ" />
-    <key nw="loc €" se="4" c="ර" sw="$" />
+    <key nw="loc €" se="4" c="ර" sw="$" ne="&#x0DCA;" />
     <key se="5" c="ත" sw="%" ne="ථ" />
     <key se="6" c="ය" sw="^" />
     <key se="7" c="උ" sw="&amp;" ne="ඌ" />
@@ -28,7 +28,7 @@ Based on XKB Sinhala (phonetic) layout.
     <key nw="|" c="ල" sw="\\" ne="ළ" />
   </row>
   <row>
-    <key role="action" width="1.5" c="shift" ne="loc capslock" />
+    <key width="1.5" role="action" c="shift" ne="loc capslock" />
     <key c="ඤ" ne="ඥ" />
     <key nw="loc †" c="ඳ" ne="ඬ" />
     <key nw="&lt;" c="ච" sw="." ne="ඡ" />
@@ -36,7 +36,7 @@ Based on XKB Sinhala (phonetic) layout.
     <key nw="\?" c="බ" sw="/" ne="භ" />
     <key nw=":" c="න" sw=";" ne="ණ" />
     <key nw="&quot;" c="ම" sw="'" se="zwj" ne="ඹ" />
-    <key role="action" width="1.5" c="backspace" ne="delete" />
+    <key width="1.5" role="action" c="backspace" ne="delete" />
   </row>
   <modmap>
     <shift a="ඍ" b="&#x0DD8;" />


### PR DESCRIPTION
XKB Sinhala (phonetic) layout has multiple virama (al-lakuna) signs, but Unexpected Keyboard layout based on XKB one currently has only one virama on layer 2 (Shift + අ). Because it is a frequent sign the PR adds another one on NE of rayanna (ර) key.

Also numeric codes in a script replaced with human-readable Unicode char names.