### PR TITLE
Add a personal dictionary with shortcuts

### DIFF
--- a/res/layout/dialog_personal_dict_entry.xml
+++ b/res/layout/dialog_personal_dict_entry.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:orientation="vertical" android:layout_width="fill_parent" android:layout_height="wrap_content">
+  <EditText android:id="@+id/personal_dict_word" android:hint="@string/pref_personal_dict_word_hint" android:inputType="text" android:importantForAutofill="no" android:layout_width="fill_parent" android:layout_height="wrap_content" android:layout_margin="10dp"/>
+  <EditText android:id="@+id/personal_dict_shortcut" android:hint="@string/pref_personal_dict_shortcut_hint" android:inputType="text" android:importantForAutofill="no" android:layout_width="fill_parent" android:layout_height="wrap_content" android:layout_margin="10dp"/>
+</LinearLayout>

--- a/res/layout/dialog_personal_dict_entry.xml
+++ b/res/layout/dialog_personal_dict_entry.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:orientation="vertical" android:layout_width="fill_parent" android:layout_height="wrap_content">
+  <TextView android:labelFor="@+id/personal_dict_word" android:text="@string/pref_personal_dict_word_hint" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginLeft="10dp" android:layout_marginRight="10dp" android:layout_marginTop="10dp"/>
   <EditText android:id="@+id/personal_dict_word" android:hint="@string/pref_personal_dict_word_hint" android:inputType="text" android:importantForAutofill="no" android:layout_width="fill_parent" android:layout_height="wrap_content" android:layout_margin="10dp"/>
+  <TextView android:labelFor="@+id/personal_dict_shortcut" android:text="@string/pref_personal_dict_shortcut_hint" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginLeft="10dp" android:layout_marginRight="10dp" android:layout_marginTop="10dp"/>
   <EditText android:id="@+id/personal_dict_shortcut" android:hint="@string/pref_personal_dict_shortcut_hint" android:inputType="text" android:importantForAutofill="no" android:layout_width="fill_parent" android:layout_height="wrap_content" android:layout_margin="10dp"/>
 </LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -38,6 +38,8 @@
     <string name="pref_suggestions_summary">Enable word completion and spell checking</string>
     <string name="pref_space_bar_auto_complete_title">Autocomplete with the space bar</string>
     <string name="pref_space_bar_auto_complete_summary">Enter the best suggestion by pressing space</string>
+    <string name="pref_personal_dict_title">Personal dictionary</string>
+    <string name="pref_personal_dict_summary">Words you add here appear in suggestions</string>
     <string name="pref_category_typing">Typing</string>
     <string name="pref_swipe_dist_title">Swiping distance</string>
     <string name="pref_swipe_dist_summary">Distance of characters in the corners of the keys (%s)</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -42,6 +42,8 @@
     <string name="pref_personal_dict_summary">Words you add here appear in suggestions</string>
     <string name="pref_personal_dict_word_hint">Word or text to suggest</string>
     <string name="pref_personal_dict_shortcut_hint">Shortcut (optional)</string>
+    <string name="pref_personal_dict_shortcut_too_short">Too short: suggestions only appear after typing 2 characters</string>
+    <string name="pref_personal_dict_shortcut_invalid_chars">Can only contain letters, digits and apostrophes</string>
     <string name="pref_category_typing">Typing</string>
     <string name="pref_swipe_dist_title">Swiping distance</string>
     <string name="pref_swipe_dist_summary">Distance of characters in the corners of the keys (%s)</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -40,6 +40,8 @@
     <string name="pref_space_bar_auto_complete_summary">Enter the best suggestion by pressing space</string>
     <string name="pref_personal_dict_title">Personal dictionary</string>
     <string name="pref_personal_dict_summary">Words you add here appear in suggestions</string>
+    <string name="pref_personal_dict_word_hint">Word or text to suggest</string>
+    <string name="pref_personal_dict_shortcut_hint">Shortcut (optional)</string>
     <string name="pref_category_typing">Typing</string>
     <string name="pref_swipe_dist_title">Swiping distance</string>
     <string name="pref_swipe_dist_summary">Distance of characters in the corners of the keys (%s)</string>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -16,6 +16,9 @@
   <PreferenceCategory android:title="@string/pref_category_suggestions">
     <CheckBoxPreference android:key="suggestions" android:title="@string/pref_suggestions_title" android:summary="@string/pref_suggestions_summary" android:defaultValue="true"/>
     <CheckBoxPreference android:key="space_bar_auto_complete" android:title="@string/pref_space_bar_auto_complete_title" android:summary="@string/pref_space_bar_auto_complete_summary" android:defaultValue="false"/>
+    <PreferenceScreen android:title="@string/pref_personal_dict_title" android:summary="@string/pref_personal_dict_summary">
+      <juloo.keyboard2.prefs.PersonalDictionaryPreference/>
+    </PreferenceScreen>
   </PreferenceCategory>
   <PreferenceCategory android:title="@string/pref_category_typing">
     <ListPreference android:key="swipe_dist" android:title="@string/pref_swipe_dist_title" android:summary="@string/pref_swipe_dist_summary" android:defaultValue="15" android:entries="@array/pref_swipe_dist_entries" android:entryValues="@array/pref_swipe_dist_values"/>

--- a/srcs/juloo.keyboard2/Config.java
+++ b/srcs/juloo.keyboard2/Config.java
@@ -13,6 +13,7 @@ import juloo.keyboard2.dict.Dictionaries;
 import juloo.keyboard2.prefs.CustomExtraKeysPreference;
 import juloo.keyboard2.prefs.ExtraKeysPreference;
 import juloo.keyboard2.prefs.LayoutsPreference;
+import juloo.keyboard2.prefs.PersonalDictionaryPreference;
 
 public final class Config
 {
@@ -87,6 +88,7 @@ public final class Config
   public DeviceLocales device_locales = null;
   public Cdict current_dictionary = null; // Might be 'null'.
   public Cdict emoji_dictionary = null; // Might be 'null'.
+  public PersonalDictionary personal_dictionary = null;
   /** Whether to show the dictionary switching button in the candidates view. */
   public boolean should_show_dictionary_switch = false;
   public IKeyEventHandler handler;
@@ -199,6 +201,7 @@ public final class Config
     clipboard_history_enabled = _prefs.getBoolean("clipboard_history_enabled", false);
     clipboard_history_duration = Integer.parseInt(_prefs.getString("clipboard_history_duration", "5"));
     space_bar_auto_complete = _prefs.getBoolean("space_bar_auto_complete", false);
+    personal_dictionary = new PersonalDictionary(PersonalDictionaryPreference.get(_prefs));
     physical_keyboard_hide = _prefs.getString("physical_keyboard_behavior", "hide").equals("hide");
     float screen_width_dp = dm.widthPixels / dm.density;
     wide_screen = screen_width_dp >= WIDE_DEVICE_THRESHOLD;

--- a/srcs/juloo.keyboard2/PersonalDictionary.java
+++ b/srcs/juloo.keyboard2/PersonalDictionary.java
@@ -3,42 +3,78 @@ package juloo.keyboard2;
 import java.util.ArrayList;
 import java.util.List;
 
-/** A user-maintained list of words suggested when their prefix is typed. Kept
-    separate from the compiled Cdict dictionaries, which are immutable. */
+/** A user-maintained list of words suggested when their prefix is typed. An
+    entry can have a shortcut attached: typing the shortcut exactly suggests
+    the word. Kept separate from the compiled Cdict dictionaries, which are
+    immutable. */
 public final class PersonalDictionary
 {
-  final List<String> _words;
+  final List<Entry> _entries;
 
-  public PersonalDictionary(List<String> words)
+  public PersonalDictionary(List<Entry> entries)
   {
-    _words = (words != null) ? words : new ArrayList<String>();
+    _entries = (entries != null) ? entries : new ArrayList<Entry>();
   }
 
-  public boolean is_empty() { return _words.isEmpty(); }
+  public boolean is_empty() { return _entries.isEmpty(); }
 
-  /** Up to [max] words matching [typed] as a case-insensitive prefix. Exact
-      (case-insensitive) matches first, then prefix matches in insertion order.
-      Stored casing is preserved; case-insensitive duplicates returned once. */
+  /** Up to [max] words matching [typed]. Ranked: words whose shortcut is
+      exactly [typed] (case-insensitive), then words equal to [typed], then
+      words starting with [typed], in insertion order. Word matches are
+      capitalized when [typed] starts with an upper-case letter; shortcut
+      expansions are always returned verbatim. Case-insensitive duplicates
+      are returned once. */
   public List<String> query(String typed, int max)
   {
+    List<String> out = new ArrayList<String>();
+    if (max <= 0 || typed.length() == 0)
+      return out;
+    List<String> shortcut = new ArrayList<String>();
     List<String> exact = new ArrayList<String>();
     List<String> prefix = new ArrayList<String>();
     String t = typed.toLowerCase();
-    for (String w : _words)
+    boolean capitalize = Character.isUpperCase(typed.charAt(0));
+    for (Entry e : _entries)
     {
-      String lw = w.toLowerCase();
-      if (lw.equals(t)) exact.add(w);
-      else if (lw.startsWith(t)) prefix.add(w);
+      if (!e.shortcut.isEmpty() && e.shortcut.equalsIgnoreCase(typed))
+      {
+        shortcut.add(e.word);
+        continue;
+      }
+      String lw = e.word.toLowerCase();
+      if (lw.equals(t)) exact.add(capitalized(e.word, capitalize));
+      else if (lw.startsWith(t)) prefix.add(capitalized(e.word, capitalize));
     }
-    List<String> out = new ArrayList<String>();
+    for (String w : shortcut) { add_unique(out, w); if (out.size() >= max) return out; }
     for (String w : exact) { add_unique(out, w); if (out.size() >= max) return out; }
     for (String w : prefix) { add_unique(out, w); if (out.size() >= max) return out; }
     return out;
+  }
+
+  static String capitalized(String w, boolean capitalize)
+  {
+    if (!capitalize || w.isEmpty() || Character.isUpperCase(w.charAt(0)))
+      return w;
+    return w.substring(0, 1).toUpperCase() + w.substring(1);
   }
 
   static void add_unique(List<String> out, String w)
   {
     for (String o : out) if (o.equalsIgnoreCase(w)) return;
     out.add(w);
+  }
+
+  /** A word and its optional shortcut. */
+  public static final class Entry
+  {
+    public final String word;
+    /** Empty string when no shortcut is attached. */
+    public final String shortcut;
+
+    public Entry(String word, String shortcut)
+    {
+      this.word = word;
+      this.shortcut = (shortcut != null) ? shortcut : "";
+    }
   }
 }

--- a/srcs/juloo.keyboard2/PersonalDictionary.java
+++ b/srcs/juloo.keyboard2/PersonalDictionary.java
@@ -1,0 +1,44 @@
+package juloo.keyboard2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** A user-maintained list of words suggested when their prefix is typed. Kept
+    separate from the compiled Cdict dictionaries, which are immutable. */
+public final class PersonalDictionary
+{
+  final List<String> _words;
+
+  public PersonalDictionary(List<String> words)
+  {
+    _words = (words != null) ? words : new ArrayList<String>();
+  }
+
+  public boolean is_empty() { return _words.isEmpty(); }
+
+  /** Up to [max] words matching [typed] as a case-insensitive prefix. Exact
+      (case-insensitive) matches first, then prefix matches in insertion order.
+      Stored casing is preserved; case-insensitive duplicates returned once. */
+  public List<String> query(String typed, int max)
+  {
+    List<String> exact = new ArrayList<String>();
+    List<String> prefix = new ArrayList<String>();
+    String t = typed.toLowerCase();
+    for (String w : _words)
+    {
+      String lw = w.toLowerCase();
+      if (lw.equals(t)) exact.add(w);
+      else if (lw.startsWith(t)) prefix.add(w);
+    }
+    List<String> out = new ArrayList<String>();
+    for (String w : exact) { add_unique(out, w); if (out.size() >= max) return out; }
+    for (String w : prefix) { add_unique(out, w); if (out.size() >= max) return out; }
+    return out;
+  }
+
+  static void add_unique(List<String> out, String w)
+  {
+    for (String o : out) if (o.equalsIgnoreCase(w)) return;
+    out.add(w);
+  }
+}

--- a/srcs/juloo.keyboard2/PersonalDictionary.java
+++ b/srcs/juloo.keyboard2/PersonalDictionary.java
@@ -13,42 +13,83 @@ public final class PersonalDictionary
 
   public PersonalDictionary(List<Entry> entries)
   {
-    _entries = (entries != null) ? entries : new ArrayList<Entry>();
+    _entries = new ArrayList<Entry>();
+    if (entries == null)
+      return;
+    for (Entry e : entries)
+    {
+      // Pre-normalize for matching: lower-cased with the same substitutions
+      // that are applied to the typed text and the compiled dictionaries.
+      _entries.add(new Entry(e.word, normalized(e.word),
+          e.shortcut, normalized(e.shortcut)));
+    }
   }
 
   public boolean is_empty() { return _entries.isEmpty(); }
 
-  /** Up to [max] words matching [typed]. Ranked: words whose shortcut is
-      exactly [typed] (case-insensitive), then words equal to [typed], then
-      words starting with [typed], in insertion order. Word matches are
-      capitalized when [typed] starts with an upper-case letter; shortcut
-      expansions are always returned verbatim. Case-insensitive duplicates
-      are returned once. */
-  public List<String> query(String typed, int max)
+  /** Up to [max] expansions of shortcuts exactly equal to [typed]
+      (case-insensitive), returned verbatim in insertion order.
+      Case-insensitive duplicates are returned once. */
+  public List<String> query_shortcuts(String typed, int max)
   {
     List<String> out = new ArrayList<String>();
     if (max <= 0 || typed.length() == 0)
       return out;
-    List<String> shortcut = new ArrayList<String>();
-    List<String> exact = new ArrayList<String>();
-    List<String> prefix = new ArrayList<String>();
-    String t = typed.toLowerCase();
-    boolean capitalize = Character.isUpperCase(typed.charAt(0));
+    String t = normalized(typed);
     for (Entry e : _entries)
     {
-      if (!e.shortcut.isEmpty() && e.shortcut.equalsIgnoreCase(typed))
-      {
-        shortcut.add(e.word);
+      if (e.norm_shortcut.isEmpty() || !e.norm_shortcut.equals(t))
         continue;
-      }
-      String lw = e.word.toLowerCase();
-      if (lw.equals(t)) exact.add(capitalized(e.word, capitalize));
-      else if (lw.startsWith(t)) prefix.add(capitalized(e.word, capitalize));
+      add_unique(out, e.word);
+      if (out.size() >= max)
+        return out;
     }
-    for (String w : shortcut) { add_unique(out, w); if (out.size() >= max) return out; }
-    for (String w : exact) { add_unique(out, w); if (out.size() >= max) return out; }
-    for (String w : prefix) { add_unique(out, w); if (out.size() >= max) return out; }
     return out;
+  }
+
+  /** Up to [max] words matching [typed]: words equal to [typed] first, then
+      words starting with [typed], in insertion order. Matching is
+      case-insensitive and uses the same substitutions as the compiled
+      dictionaries; word matches are capitalized when [capitalize] is set.
+      Case-insensitive duplicates are returned once. */
+  public List<String> query_word_matches(String typed, boolean capitalize,
+      int max)
+  {
+    List<String> out = new ArrayList<String>();
+    if (max <= 0 || typed.length() == 0)
+      return out;
+    List<String> prefix = new ArrayList<String>();
+    String t = normalized(typed);
+    for (Entry e : _entries)
+    {
+      if (e.norm_word.equals(t))
+        add_unique(out, capitalized(e.word, capitalize));
+      else if (e.norm_word.startsWith(t))
+        prefix.add(e.word);
+      if (out.size() >= max)
+        return out;
+    }
+    for (String w : prefix)
+    {
+      add_unique(out, capitalized(w, capitalize));
+      if (out.size() >= max)
+        return out;
+    }
+    return out;
+  }
+
+  /** [w] lower-cased and transformed with the same character substitutions
+      that were applied when building the compiled dictionaries. */
+  static String normalized(String w)
+  {
+    StringBuilder b = new StringBuilder(w.toLowerCase());
+    for (int i = 0; i < b.length(); i++)
+    {
+      char r =
+        ComposeKey.transform_char(ComposeKeyData.substitutions, b.charAt(i));
+      if (r != 0) b.setCharAt(i, r);
+    }
+    return b.toString();
   }
 
   static String capitalized(String w, boolean capitalize)
@@ -64,17 +105,31 @@ public final class PersonalDictionary
     out.add(w);
   }
 
-  /** A word and its optional shortcut. */
+  /** A word and its optional shortcut. [norm_word] and [norm_shortcut] are
+      the normalized forms used for matching. */
   public static final class Entry
   {
     public final String word;
     /** Empty string when no shortcut is attached. */
     public final String shortcut;
+    final String norm_word;
+    final String norm_shortcut;
 
+    /** An entry to be stored; normalization happens in the enclosing
+        dictionary. */
     public Entry(String word, String shortcut)
+    {
+      this(word, null, shortcut, null);
+    }
+
+    Entry(String word, String norm_word, String shortcut, String norm_shortcut)
     {
       this.word = word;
       this.shortcut = (shortcut != null) ? shortcut : "";
+      this.norm_word =
+        (norm_word != null) ? norm_word : ((word != null) ? word : "");
+      this.norm_shortcut =
+        (norm_shortcut != null) ? norm_shortcut : this.shortcut;
     }
   }
 }

--- a/srcs/juloo.keyboard2/prefs/ListGroupPreference.java
+++ b/srcs/juloo.keyboard2/prefs/ListGroupPreference.java
@@ -283,7 +283,12 @@ public abstract class ListGroupPreference<E> extends PreferenceGroup
 
   public static class StringSerializer implements Serializer<String>
   {
-    public String load_item(Object obj) { return (String)obj; }
+    public String load_item(Object obj) throws JSONException
+    {
+      if (!(obj instanceof String))
+        throw new JSONException("Expected a string");
+      return (String)obj;
+    }
     public Object save_item(String v) { return v; }
   }
 }

--- a/srcs/juloo.keyboard2/prefs/PersonalDictionaryPreference.java
+++ b/srcs/juloo.keyboard2/prefs/PersonalDictionaryPreference.java
@@ -61,19 +61,51 @@ public class PersonalDictionaryPreference
       word_input.setText(old_value.word);
       shortcut_input.setText(old_value.shortcut);
     }
-    new AlertDialog.Builder(getContext())
+    final AlertDialog dialog = new AlertDialog.Builder(getContext())
       .setView(content)
-      .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener(){
-        public void onClick(DialogInterface dialog, int which)
+      .setPositiveButton(android.R.string.ok, null)
+      .setNegativeButton(android.R.string.cancel, null)
+      .show();
+    // Override the OK button to keep the dialog open on invalid input.
+    dialog.getButton(DialogInterface.BUTTON_POSITIVE)
+      .setOnClickListener(new View.OnClickListener(){
+        public void onClick(View v)
         {
           String w = word_input.getText().toString().trim();
           String s = shortcut_input.getText().toString().trim();
-          if (!w.equals(""))
-            callback.select(new PersonalDictionary.Entry(w, s));
+          if (w.equals(""))
+          {
+            word_input.setError(
+                getContext().getString(R.string.pref_personal_dict_word_hint));
+            return;
+          }
+          int invalid = invalid_shortcut_error(s);
+          if (invalid != 0)
+          {
+            shortcut_input.setError(getContext().getString(invalid));
+            return;
+          }
+          callback.select(new PersonalDictionary.Entry(w, s));
+          dialog.dismiss();
         }
-      })
-      .setNegativeButton(android.R.string.cancel, null)
-      .show();
+      });
+  }
+
+  /** [0] when [s] is a shortcut that can actually be typed, else the
+      resource of a string explaining why it can never fire. An empty
+      shortcut is valid and means the entry has no shortcut. */
+  static int invalid_shortcut_error(String s)
+  {
+    if (s.isEmpty())
+      return 0;
+    if (s.length() < 2)
+      return R.string.pref_personal_dict_shortcut_too_short;
+    for (int i = 0; i < s.length(); i++)
+    {
+      if (!CurrentlyTypedWord.is_word_char(s.charAt(i)))
+        return R.string.pref_personal_dict_shortcut_invalid_chars;
+    }
+    return 0;
   }
 
   @Override

--- a/srcs/juloo.keyboard2/prefs/PersonalDictionaryPreference.java
+++ b/srcs/juloo.keyboard2/prefs/PersonalDictionaryPreference.java
@@ -7,19 +7,24 @@ import android.content.SharedPreferences;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.EditText;
-import android.widget.TextView;
 import java.util.ArrayList;
 import java.util.List;
 import juloo.keyboard2.*;
+import org.json.JSONException;
+import org.json.JSONObject;
 
-/** Lets the user enter custom words suggested when their prefix is typed.
-    Shows at the top of the "Personal dictionary" settings screen. */
-public class PersonalDictionaryPreference extends ListGroupPreference<String>
+/** Lets the user enter custom words suggested when their prefix or an
+    optional shortcut is typed. Shows at the top of the "Personal dictionary"
+    settings screen. */
+public class PersonalDictionaryPreference
+  extends ListGroupPreference<PersonalDictionary.Entry>
 {
-  /** This pref stores a list of strings encoded as JSON. */
+  /** This pref stores a list encoded as JSON. Items are either a plain
+      string (a word with no shortcut) or an object with the keys [word] and
+      [shortcut]. */
   static final String KEY = "personal_dictionary";
-  static final ListGroupPreference.Serializer<String> SERIALIZER =
-    new ListGroupPreference.StringSerializer();
+  static final ListGroupPreference.Serializer<PersonalDictionary.Entry>
+    SERIALIZER = new EntrySerializer();
 
   public PersonalDictionaryPreference(Context context, AttributeSet attrs)
   {
@@ -27,29 +32,44 @@ public class PersonalDictionaryPreference extends ListGroupPreference<String>
     setKey(KEY);
   }
 
-  /** The stored words. Never [null]. */
-  public static List<String> get(SharedPreferences prefs)
+  /** The stored entries. Never [null]. */
+  public static List<PersonalDictionary.Entry> get(SharedPreferences prefs)
   {
-    List<String> words = load_from_preferences(KEY, prefs, null, SERIALIZER);
-    return (words != null) ? words : new ArrayList<String>();
+    List<PersonalDictionary.Entry> entries =
+      load_from_preferences(KEY, prefs, null, SERIALIZER);
+    return (entries != null) ? entries : new ArrayList<PersonalDictionary.Entry>();
   }
 
-  String label_of_value(String value, int i) { return value; }
+  String label_of_value(PersonalDictionary.Entry value, int i)
+  {
+    return value.shortcut.isEmpty() ? value.word
+      : value.shortcut + " \u2192 " + value.word;
+  }
 
   @Override
-  void select(final SelectionCallback<String> callback, String old_value)
+  void select(final SelectionCallback<PersonalDictionary.Entry> callback,
+      PersonalDictionary.Entry old_value)
   {
-    View content = View.inflate(getContext(), R.layout.dialog_edit_text, null);
-    ((TextView)content.findViewById(R.id.text)).setText(old_value);
+    View content =
+      View.inflate(getContext(), R.layout.dialog_personal_dict_entry, null);
+    final EditText word_input =
+      (EditText)content.findViewById(R.id.personal_dict_word);
+    final EditText shortcut_input =
+      (EditText)content.findViewById(R.id.personal_dict_shortcut);
+    if (old_value != null)
+    {
+      word_input.setText(old_value.word);
+      shortcut_input.setText(old_value.shortcut);
+    }
     new AlertDialog.Builder(getContext())
       .setView(content)
       .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener(){
         public void onClick(DialogInterface dialog, int which)
         {
-          EditText input = (EditText)((AlertDialog)dialog).findViewById(R.id.text);
-          final String w = input.getText().toString().trim();
+          String w = word_input.getText().toString().trim();
+          String s = shortcut_input.getText().toString().trim();
           if (!w.equals(""))
-            callback.select(w);
+            callback.select(new PersonalDictionary.Entry(w, s));
         }
       })
       .setNegativeButton(android.R.string.cancel, null)
@@ -57,5 +77,28 @@ public class PersonalDictionaryPreference extends ListGroupPreference<String>
   }
 
   @Override
-  Serializer<String> get_serializer() { return SERIALIZER; }
+  Serializer<PersonalDictionary.Entry> get_serializer() { return SERIALIZER; }
+
+  static class EntrySerializer
+    implements ListGroupPreference.Serializer<PersonalDictionary.Entry>
+  {
+    public PersonalDictionary.Entry load_item(Object obj) throws JSONException
+    {
+      if (obj instanceof String)
+        return new PersonalDictionary.Entry((String)obj, "");
+      JSONObject o = (JSONObject)obj;
+      return new PersonalDictionary.Entry(o.getString("word"),
+          o.optString("shortcut", ""));
+    }
+
+    public Object save_item(PersonalDictionary.Entry v) throws JSONException
+    {
+      if (v.shortcut.isEmpty())
+        return v.word;
+      JSONObject o = new JSONObject();
+      o.put("word", v.word);
+      o.put("shortcut", v.shortcut);
+      return o;
+    }
+  }
 }

--- a/srcs/juloo.keyboard2/prefs/PersonalDictionaryPreference.java
+++ b/srcs/juloo.keyboard2/prefs/PersonalDictionaryPreference.java
@@ -1,0 +1,61 @@
+package juloo.keyboard2.prefs;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.TextView;
+import java.util.ArrayList;
+import java.util.List;
+import juloo.keyboard2.*;
+
+/** Lets the user enter custom words suggested when their prefix is typed.
+    Shows at the top of the "Personal dictionary" settings screen. */
+public class PersonalDictionaryPreference extends ListGroupPreference<String>
+{
+  /** This pref stores a list of strings encoded as JSON. */
+  static final String KEY = "personal_dictionary";
+  static final ListGroupPreference.Serializer<String> SERIALIZER =
+    new ListGroupPreference.StringSerializer();
+
+  public PersonalDictionaryPreference(Context context, AttributeSet attrs)
+  {
+    super(context, attrs);
+    setKey(KEY);
+  }
+
+  /** The stored words. Never [null]. */
+  public static List<String> get(SharedPreferences prefs)
+  {
+    List<String> words = load_from_preferences(KEY, prefs, null, SERIALIZER);
+    return (words != null) ? words : new ArrayList<String>();
+  }
+
+  String label_of_value(String value, int i) { return value; }
+
+  @Override
+  void select(final SelectionCallback<String> callback, String old_value)
+  {
+    View content = View.inflate(getContext(), R.layout.dialog_edit_text, null);
+    ((TextView)content.findViewById(R.id.text)).setText(old_value);
+    new AlertDialog.Builder(getContext())
+      .setView(content)
+      .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener(){
+        public void onClick(DialogInterface dialog, int which)
+        {
+          EditText input = (EditText)((AlertDialog)dialog).findViewById(R.id.text);
+          final String w = input.getText().toString().trim();
+          if (!w.equals(""))
+            callback.select(w);
+        }
+      })
+      .setNegativeButton(android.R.string.cancel, null)
+      .show();
+  }
+
+  @Override
+  Serializer<String> get_serializer() { return SERIALIZER; }
+}

--- a/srcs/juloo.keyboard2/suggestions/Suggestions.java
+++ b/srcs/juloo.keyboard2/suggestions/Suggestions.java
@@ -7,6 +7,7 @@ import juloo.keyboard2.dict.Dictionaries;
 import juloo.keyboard2.Config;
 import juloo.keyboard2.ComposeKey;
 import juloo.keyboard2.ComposeKeyData;
+import juloo.keyboard2.PersonalDictionary;
 
 /** Keep track of the word being typed and provide suggestions for
     [CandidatesView]. */
@@ -67,14 +68,16 @@ public final class Suggestions
     boolean first_char_upper = Character.isUpperCase(word.charAt(0));
     String subst = apply_substitutions(word);
     Cdict dict = _config.current_dictionary;
-    // Personal dictionary first. When a dictionary is installed, leave one
-    // slot for it so personal words can't hide it entirely.
-    if (_config.personal_dictionary != null)
+    // Personal dictionary entries are matched against the raw typed word;
+    // they are normalized with the same substitutions when the dictionary is
+    // loaded. Shortcut expansions take the first slots; personal word
+    // matches fill the slots left unused by the compiled dictionary.
+    PersonalDictionary pd = _config.personal_dictionary;
+    if (pd != null)
     {
-      int budget = (dict != null) ? MAX_COUNT - 1 : MAX_COUNT;
-      List<String> personal = _config.personal_dictionary.query(subst, budget);
-      for (int j = 0; j < personal.size() && i < MAX_COUNT; j++)
-        suggestions[i++] = personal.get(j);
+      List<String> shortcuts = pd.query_shortcuts(word, MAX_COUNT);
+      for (int j = 0; j < shortcuts.size() && i < MAX_COUNT; j++)
+        suggestions[i++] = shortcuts.get(j);
     }
     if (dict != null && i < MAX_COUNT)
     {
@@ -101,6 +104,16 @@ public final class Suggestions
           cw = cw.substring(0, 1).toUpperCase() + cw.substring(1);
         if (!contains_ignore_case(i, cw))
           suggestions[i++] = cw;
+      }
+    }
+    if (pd != null && i < MAX_COUNT)
+    {
+      List<String> word_matches =
+        pd.query_word_matches(word, first_char_upper, MAX_COUNT);
+      for (int j = 0; j < word_matches.size() && i < MAX_COUNT; j++)
+      {
+        if (!contains_ignore_case(i, word_matches.get(j)))
+          suggestions[i++] = word_matches.get(j);
       }
     }
     emoji_suggestion = query_emoji(subst);

--- a/srcs/juloo.keyboard2/suggestions/Suggestions.java
+++ b/srcs/juloo.keyboard2/suggestions/Suggestions.java
@@ -41,7 +41,11 @@ public final class Suggestions
   {
     if (!_enabled)
       return;
-    if (word.length() < 2 || _config.current_dictionary == null)
+    boolean has_personal =
+      _config.personal_dictionary != null
+      && !_config.personal_dictionary.is_empty();
+    if (word.length() < 2
+        || (_config.current_dictionary == null && !has_personal))
       clear();
     else
       query_suggestions(word);
@@ -58,36 +62,56 @@ public final class Suggestions
 
   int query_suggestions(String word)
   {
-    Cdict dict = _config.current_dictionary;
-    boolean first_char_upper = Character.isUpperCase(word.charAt(0));
-    word = apply_substitutions(word);
-    Cdict.Result r = dict.find(word);
+    clear();
     int i = 0;
-    if (r.found)
-      suggestions[i++] = dict.word(r.index);
-    int[] suffixes = dict.suffixes(r, MAX_COUNT);
-    // Disable distance search for small words
-    int[] dist = (word.length() < 3 || i + 1 >= MAX_COUNT) ? NO_RESULTS :
-      dict.distance(word, 1, MAX_COUNT);
-    for (int j = 0; j < MAX_COUNT && i < MAX_COUNT; j++)
+    // Personal dictionary first; stored casing preserved.
+    if (_config.personal_dictionary != null)
     {
-      if (suffixes.length > j)
-        suggestions[i++] = dict.word(suffixes[j]);
-      if (dist.length > j && i < MAX_COUNT)
-        suggestions[i++] = dict.word(dist[j]);
+      List<String> personal = _config.personal_dictionary.query(word, MAX_COUNT);
+      for (int j = 0; j < personal.size() && i < MAX_COUNT; j++)
+        suggestions[i++] = personal.get(j);
     }
-    if (first_char_upper)
-      capitalize_results();
-    emoji_suggestion = query_emoji(word); // word with substitutions applied
+    Cdict dict = _config.current_dictionary;
+    if (dict != null && i < MAX_COUNT)
+    {
+      boolean first_char_upper = Character.isUpperCase(word.charAt(0));
+      String subst = apply_substitutions(word);
+      Cdict.Result r = dict.find(subst);
+      String[] cdict_words = new String[MAX_COUNT];
+      int c = 0;
+      if (r.found)
+        cdict_words[c++] = dict.word(r.index);
+      int[] suffixes = dict.suffixes(r, MAX_COUNT);
+      // Disable distance search for small words
+      int[] dist = (subst.length() < 3 || c + 1 >= MAX_COUNT) ? NO_RESULTS :
+        dict.distance(subst, 1, MAX_COUNT);
+      for (int j = 0; j < MAX_COUNT && c < MAX_COUNT; j++)
+      {
+        if (suffixes.length > j)
+          cdict_words[c++] = dict.word(suffixes[j]);
+        if (dist.length > j && c < MAX_COUNT)
+          cdict_words[c++] = dict.word(dist[j]);
+      }
+      for (int j = 0; j < c && i < MAX_COUNT; j++)
+      {
+        String cw = cdict_words[j];
+        if (first_char_upper)
+          cw = cw.substring(0, 1).toUpperCase() + cw.substring(1);
+        if (!contains_ignore_case(i, cw))
+          suggestions[i++] = cw;
+      }
+    }
+    emoji_suggestion = query_emoji(apply_substitutions(word));
     count = i;
     return i;
   }
 
-  void capitalize_results()
+  boolean contains_ignore_case(int upto, String w)
   {
-    for (int i = 0; i < count; i++)
-      suggestions[i] = suggestions[i].substring(0, 1).toUpperCase()
-        + suggestions[i].substring(1);
+    for (int k = 0; k < upto; k++)
+      if (suggestions[k] != null && suggestions[k].equalsIgnoreCase(w))
+        return true;
+    return false;
   }
 
   String query_emoji(String word)

--- a/srcs/juloo.keyboard2/suggestions/Suggestions.java
+++ b/srcs/juloo.keyboard2/suggestions/Suggestions.java
@@ -64,18 +64,20 @@ public final class Suggestions
   {
     clear();
     int i = 0;
-    // Personal dictionary first; stored casing preserved.
+    boolean first_char_upper = Character.isUpperCase(word.charAt(0));
+    String subst = apply_substitutions(word);
+    Cdict dict = _config.current_dictionary;
+    // Personal dictionary first. When a dictionary is installed, leave one
+    // slot for it so personal words can't hide it entirely.
     if (_config.personal_dictionary != null)
     {
-      List<String> personal = _config.personal_dictionary.query(word, MAX_COUNT);
+      int budget = (dict != null) ? MAX_COUNT - 1 : MAX_COUNT;
+      List<String> personal = _config.personal_dictionary.query(subst, budget);
       for (int j = 0; j < personal.size() && i < MAX_COUNT; j++)
         suggestions[i++] = personal.get(j);
     }
-    Cdict dict = _config.current_dictionary;
     if (dict != null && i < MAX_COUNT)
     {
-      boolean first_char_upper = Character.isUpperCase(word.charAt(0));
-      String subst = apply_substitutions(word);
       Cdict.Result r = dict.find(subst);
       String[] cdict_words = new String[MAX_COUNT];
       int c = 0;
@@ -101,7 +103,7 @@ public final class Suggestions
           suggestions[i++] = cw;
       }
     }
-    emoji_suggestion = query_emoji(apply_substitutions(word));
+    emoji_suggestion = query_emoji(subst);
     count = i;
     return i;
   }

--- a/test/juloo.keyboard2/PersonalDictionaryTest.java
+++ b/test/juloo.keyboard2/PersonalDictionaryTest.java
@@ -1,0 +1,33 @@
+package juloo.keyboard2;
+
+import java.util.Arrays;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class PersonalDictionaryTest
+{
+  @Test
+  public void prefix_and_exact_matching()
+  {
+    PersonalDictionary d = new PersonalDictionary(Arrays.asList(
+      "Nafisa", "Ashu", "aardvark", "Ashley"));
+    // Case-insensitive prefix; stored case preserved; insertion order.
+    assertEquals(Arrays.asList("Ashu", "Ashley"), d.query("as", 3));
+    // Exact match; no other word has "ashu" as a prefix.
+    assertEquals(Arrays.asList("Ashu"), d.query("ashu", 3));
+    // 'a' prefix returns a-words in insertion order.
+    assertEquals(Arrays.asList("Ashu", "aardvark", "Ashley"), d.query("a", 5));
+    // No match.
+    assertEquals(Arrays.asList(), d.query("z", 3));
+    // Respects max.
+    assertEquals(Arrays.asList("Ashu"), d.query("a", 1));
+  }
+
+  @Test
+  public void empty_dictionary()
+  {
+    PersonalDictionary d = new PersonalDictionary(null);
+    assertTrue(d.is_empty());
+    assertEquals(Arrays.asList(), d.query("a", 3));
+  }
+}

--- a/test/juloo.keyboard2/PersonalDictionaryTest.java
+++ b/test/juloo.keyboard2/PersonalDictionaryTest.java
@@ -16,34 +16,60 @@ public class PersonalDictionaryTest
     return l;
   }
 
+  /** Combined suggestions as assembled by the keyboard: shortcut expansions
+      first, then word matches. */
+  static List<String> suggest(PersonalDictionary d, String typed, int max)
+  {
+    boolean capitalize =
+      typed.length() > 0 && Character.isUpperCase(typed.charAt(0));
+    List<String> out = new ArrayList<String>(d.query_shortcuts(typed, max));
+    out.addAll(d.query_word_matches(typed, capitalize, max - out.size()));
+    return out;
+  }
+
   @Test
   public void prefix_and_exact_matching()
   {
     PersonalDictionary d = new PersonalDictionary(words(
       "Nafisa", "Ashu", "aardvark", "Ashley"));
     // Case-insensitive prefix; stored case preserved; insertion order.
-    assertEquals(Arrays.asList("Ashu", "Ashley"), d.query("as", 3));
+    assertEquals(Arrays.asList("Ashu", "Ashley"),
+        d.query_word_matches("as", false, 3));
     // Exact match; no other word has "ashu" as a prefix.
-    assertEquals(Arrays.asList("Ashu"), d.query("ashu", 3));
+    assertEquals(Arrays.asList("Ashu"),
+        d.query_word_matches("ashu", false, 3));
     // 'a' prefix returns a-words in insertion order.
-    assertEquals(Arrays.asList("Ashu", "aardvark", "Ashley"), d.query("a", 5));
+    assertEquals(Arrays.asList("Ashu", "aardvark", "Ashley"),
+        d.query_word_matches("a", false, 5));
     // No match.
-    assertEquals(Arrays.asList(), d.query("z", 3));
+    assertEquals(Arrays.asList(), d.query_word_matches("z", false, 3));
     // Respects max.
-    assertEquals(Arrays.asList("Ashu"), d.query("a", 1));
+    assertEquals(Arrays.asList("Ashu"), d.query_word_matches("a", false, 1));
     // max <= 0 returns nothing.
-    assertEquals(Arrays.asList(), d.query("a", 0));
+    assertEquals(Arrays.asList(), d.query_word_matches("a", false, 0));
+    assertEquals(Arrays.asList(), d.query_shortcuts("a", 0));
   }
 
   @Test
   public void word_matches_follow_typed_capitalization()
   {
     PersonalDictionary d = new PersonalDictionary(words("aardvark", "Ashu"));
-    // Upper-case typed prefix capitalizes lower-case stored words.
-    assertEquals(Arrays.asList("Aardvark", "Ashu"), d.query("A", 5));
-    assertEquals(Arrays.asList("Aardvark"), d.query("Aa", 3));
-    // Lower-case typed prefix leaves stored casing untouched.
-    assertEquals(Arrays.asList("aardvark", "Ashu"), d.query("a", 5));
+    // Capitalize flag capitalizes lower-case stored words.
+    assertEquals(Arrays.asList("Aardvark", "Ashu"),
+        d.query_word_matches("a", true, 5));
+    // Without the flag, stored casing is preserved.
+    assertEquals(Arrays.asList("aardvark", "Ashu"),
+        d.query_word_matches("a", false, 5));
+  }
+
+  @Test
+  public void matching_applies_dictionary_substitutions()
+  {
+    PersonalDictionary d = new PersonalDictionary(words("café"));
+    // Typing without diacritics matches the accented stored word.
+    assertEquals(Arrays.asList("café"), d.query_word_matches("cafe", false, 3));
+    // Typing with diacritics also matches.
+    assertEquals(Arrays.asList("café"), d.query_word_matches("café", false, 3));
   }
 
   @Test
@@ -53,14 +79,16 @@ public class PersonalDictionaryTest
     es.add(new PersonalDictionary.Entry("gareth@example.com", "aa"));
     PersonalDictionary d = new PersonalDictionary(es);
     // Exact shortcut match expands, case-insensitively.
-    assertEquals(Arrays.asList("gareth@example.com"), d.query("aa", 3));
-    assertEquals(Arrays.asList("gareth@example.com"), d.query("AA", 3));
+    assertEquals(Arrays.asList("gareth@example.com"), d.query_shortcuts("aa", 3));
+    assertEquals(Arrays.asList("gareth@example.com"), d.query_shortcuts("AA", 3));
     // Expansion is returned verbatim, never capitalized.
-    assertEquals(Arrays.asList("gareth@example.com"), d.query("Aa", 3));
+    assertEquals(Arrays.asList("gareth@example.com"),
+        suggest(d, "Aa", 3));
     // Longer text does not fire the shortcut.
-    assertEquals(Arrays.asList(), d.query("aaa", 3));
+    assertEquals(Arrays.asList(), d.query_shortcuts("aaa", 3));
     // Shortcut entries still behave as words for prefix matching.
-    assertEquals(Arrays.asList("gareth@example.com"), d.query("gareth", 3));
+    assertEquals(Arrays.asList("gareth@example.com"),
+        d.query_word_matches("gareth", false, 3));
   }
 
   @Test
@@ -70,7 +98,7 @@ public class PersonalDictionaryTest
     es.add(new PersonalDictionary.Entry("gareth@example.com", "aa"));
     PersonalDictionary d = new PersonalDictionary(es);
     assertEquals(Arrays.asList("gareth@example.com", "aardvark"),
-      d.query("aa", 3));
+        suggest(d, "aa", 3));
   }
 
   @Test
@@ -79,8 +107,10 @@ public class PersonalDictionaryTest
     PersonalDictionary d = new PersonalDictionary(words(
       "Ashu", "ashu", "ASHU"));
     // First stored casing wins; later case variants are dropped.
-    assertEquals(Arrays.asList("Ashu"), d.query("ashu", 3));
-    assertEquals(Arrays.asList("Ashu"), d.query("as", 3));
+    assertEquals(Arrays.asList("Ashu"),
+        d.query_word_matches("ashu", false, 3));
+    assertEquals(Arrays.asList("Ashu"),
+        d.query_word_matches("as", false, 3));
   }
 
   @Test
@@ -88,6 +118,7 @@ public class PersonalDictionaryTest
   {
     PersonalDictionary d = new PersonalDictionary(null);
     assertTrue(d.is_empty());
-    assertEquals(Arrays.asList(), d.query("a", 3));
+    assertEquals(Arrays.asList(), d.query_word_matches("a", false, 3));
+    assertEquals(Arrays.asList(), d.query_shortcuts("a", 3));
   }
 }

--- a/test/juloo.keyboard2/PersonalDictionaryTest.java
+++ b/test/juloo.keyboard2/PersonalDictionaryTest.java
@@ -1,15 +1,25 @@
 package juloo.keyboard2;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class PersonalDictionaryTest
 {
+  static List<PersonalDictionary.Entry> words(String... ws)
+  {
+    List<PersonalDictionary.Entry> l = new ArrayList<PersonalDictionary.Entry>();
+    for (String w : ws)
+      l.add(new PersonalDictionary.Entry(w, ""));
+    return l;
+  }
+
   @Test
   public void prefix_and_exact_matching()
   {
-    PersonalDictionary d = new PersonalDictionary(Arrays.asList(
+    PersonalDictionary d = new PersonalDictionary(words(
       "Nafisa", "Ashu", "aardvark", "Ashley"));
     // Case-insensitive prefix; stored case preserved; insertion order.
     assertEquals(Arrays.asList("Ashu", "Ashley"), d.query("as", 3));
@@ -21,6 +31,56 @@ public class PersonalDictionaryTest
     assertEquals(Arrays.asList(), d.query("z", 3));
     // Respects max.
     assertEquals(Arrays.asList("Ashu"), d.query("a", 1));
+    // max <= 0 returns nothing.
+    assertEquals(Arrays.asList(), d.query("a", 0));
+  }
+
+  @Test
+  public void word_matches_follow_typed_capitalization()
+  {
+    PersonalDictionary d = new PersonalDictionary(words("aardvark", "Ashu"));
+    // Upper-case typed prefix capitalizes lower-case stored words.
+    assertEquals(Arrays.asList("Aardvark", "Ashu"), d.query("A", 5));
+    assertEquals(Arrays.asList("Aardvark"), d.query("Aa", 3));
+    // Lower-case typed prefix leaves stored casing untouched.
+    assertEquals(Arrays.asList("aardvark", "Ashu"), d.query("a", 5));
+  }
+
+  @Test
+  public void shortcut_expands_exactly()
+  {
+    List<PersonalDictionary.Entry> es = words("Ashu");
+    es.add(new PersonalDictionary.Entry("gareth@example.com", "aa"));
+    PersonalDictionary d = new PersonalDictionary(es);
+    // Exact shortcut match expands, case-insensitively.
+    assertEquals(Arrays.asList("gareth@example.com"), d.query("aa", 3));
+    assertEquals(Arrays.asList("gareth@example.com"), d.query("AA", 3));
+    // Expansion is returned verbatim, never capitalized.
+    assertEquals(Arrays.asList("gareth@example.com"), d.query("Aa", 3));
+    // Longer text does not fire the shortcut.
+    assertEquals(Arrays.asList(), d.query("aaa", 3));
+    // Shortcut entries still behave as words for prefix matching.
+    assertEquals(Arrays.asList("gareth@example.com"), d.query("gareth", 3));
+  }
+
+  @Test
+  public void shortcut_ranks_before_word_matches()
+  {
+    List<PersonalDictionary.Entry> es = words("aardvark");
+    es.add(new PersonalDictionary.Entry("gareth@example.com", "aa"));
+    PersonalDictionary d = new PersonalDictionary(es);
+    assertEquals(Arrays.asList("gareth@example.com", "aardvark"),
+      d.query("aa", 3));
+  }
+
+  @Test
+  public void case_insensitive_duplicates_returned_once()
+  {
+    PersonalDictionary d = new PersonalDictionary(words(
+      "Ashu", "ashu", "ASHU"));
+    // First stored casing wins; later case variants are dropped.
+    assertEquals(Arrays.asList("Ashu"), d.query("ashu", 3));
+    assertEquals(Arrays.asList("Ashu"), d.query("as", 3));
   }
 
   @Test


### PR DESCRIPTION
Adds a user-maintained personal dictionary: words and abbreviations entered in settings appear in the suggestion bar, independent of the compiled dictionaries.

## Features

- New **Personal dictionary** settings screen (under *Suggestions*) using `ListGroupPreference`; entries are stored as JSON (plain strings, or `{word, shortcut}` objects when a shortcut is attached — old plain-string lists keep loading).
- Words are suggested on a case-insensitive prefix match; stored casing is preserved and follows the capitalization of the typed word, matching the behavior of compiled-dictionary suggestions.
- **Shortcuts**: typing a shortcut exactly expands to the full word/text (e.g. `aa` → an email address). Expansions rank first and are returned verbatim.
- Matching uses the same substitution table as the compiled dictionaries (`ComposeKey.transform_char(ComposeKeyData.substitutions, …)`), normalized once at load time, so typing `cafe` matches a stored `café` and vice-versa.
- Suggestion slots: shortcut expansions take the first slots, then the compiled dictionary, then personal word matches fill whatever slots remain — personal words can never hide dictionary results entirely, and an empty dictionary result never wastes a slot.
- The entry dialog rejects shortcuts that can never fire (shorter than the 2-character suggestion gate, or containing non-word characters per `CurrentlyTypedWord.is_word_char`).
- Personal suggestions work with no dictionary installed.

## Also in this PR

- `ListGroupPreference.StringSerializer.load_item` now throws `JSONException` instead of `ClassCastException` when an item isn't a string, so a future format change degrades to an empty list instead of crashing `Config.refresh` on downgrade/upgrade.
- Unit tests for `PersonalDictionary` (matching, ranking, capitalization, substitutions, dedup, truncation): 7 tests.

Tested on-device (debug build, installed as a separate app id).