### PR TITLE
Fix a crash: `Arrays.binarySearch` a `null` value

### DIFF
--- a/srcs/juloo.keyboard2/dict/SupportedDictionaries.java
+++ b/srcs/juloo.keyboard2/dict/SupportedDictionaries.java
@@ -29,6 +29,8 @@ public class SupportedDictionaries
   /** Find the index for a given dictionary name. Return [-1] if not found. */
   public int find(String dict_name)
   {
+    if (dict_name == null)
+      return -1;
     int i = Arrays.binarySearch(locales, dict_name);
     return (i < 0) ? -1 : i;
   }


### PR DESCRIPTION
Crash report:
```
Generated by AppErrorsTracking 1.3-d4875d7(6)
Project URL: https://github.com/KitsunePie/AppErrorsTracking
===============
[Device Brand]: Redmi
[Device Model]: 23113RKC6C
[Display]: AQ3A.240912.001
[Android Version]: 15
[Android API Level]: 35
[System Locale]: zh_CN
[Process ID]: 653
[User ID]: 0
[CPU ABI]: arm64-v8a
[Package Name]: juloo.keyboard2
[Version Name]: 2.0.4
[Version Code]: 55
[Target SDK]: 36
[Min SDK]: 21
[Error Type]: JVM
[Crash Time]: 2026-08-17T17:25:24.477
[Stack Trace]:
java.lang.NullPointerException: rhs == null
	at java.lang.String.compareTo(Native Method)
	at java.lang.String.compareTo(String.java:134)
	at java.util.Arrays.binarySearch0(Arrays.java:2282)
	at java.util.Arrays.binarySearch(Arrays.java:2222)
	at juloo.keyboard2.Keyboard2.i(r8-map-id-a9863cef79b6b3346410c1e7cbc9e52527bfb8a33b88656bf8833236dbe7be4f:199)
	at juloo.keyboard2.Keyboard2.onCurrentInputMethodSubtypeChanged(r8-map-id-a9863cef79b6b3346410c1e7cbc9e52527bfb8a33b88656bf8833236dbe7be4f:4)
	at android.inputmethodservice.InputMethodService.dispatchOnCurrentInputMethodSubtypeChanged(InputMethodService.java:4340)
	at android.inputmethodservice.InputMethodService.-$$Nest$mdispatchOnCurrentInputMethodSubtypeChanged(Unknown Source:0)
	at android.inputmethodservice.InputMethodService$InputMethodImpl.changeInputMethodSubtype(InputMethodService.java:1283)
	at android.inputmethodservice.IInputMethodWrapper.executeMessage(IInputMethodWrapper.java:274)
	at com.android.internal.os.HandlerCaller$MyHandler.handleMessage(HandlerCaller.java:44)
	at android.os.Handler.dispatchMessage(Handler.java:107)
	at android.os.Looper.loopOnce(Looper.java:249)
	at android.os.Looper.loop(Looper.java:337)
	at android.app.ActivityThread.main(ActivityThread.java:9608)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:615)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```