### PR TITLE
Allow `symbol:slider`, make single sliders not macro in this syntax

### DIFF
--- a/srcs/juloo.keyboard2/KeyModifier.java
+++ b/srcs/juloo.keyboard2/KeyModifier.java
@@ -455,7 +455,7 @@ public final class KeyModifier
           case Cursor_left: name = "selection_cursor_left"; break;
           case Cursor_right: name = "selection_cursor_right"; break;
         }
-        break;
+        return (name == null) ? k : KeyValue.getSpecialKeyByName(name).withSymbol(k.getString());
       case Keyevent:
         switch (k.getKeyevent())
         {

--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -226,7 +226,7 @@ public final class KeyValue implements Comparable<KeyValue>
   /** Defined only when [getKind() == Kind.Slider]. */
   public Slider getSlider()
   {
-    return (Slider)_payload;
+    return ((SliderWithSymbol)_payload).getSlider();
   }
 
   /** Defined only when [getKind() == Kind.Slider]. */
@@ -281,6 +281,8 @@ public final class KeyValue implements Comparable<KeyValue>
         if (symbol.length() > 1)
           flags |= FLAG_SMALLER_FONT;
         return new KeyValue(symbol, _code, _code, flags);
+      case Slider:
+        return new KeyValue(new SliderWithSymbol(getSlider(), symbol), _code, _code, flags);
       case Macro:
         return makeMacro(symbol, getMacro(), flags);
       default:
@@ -415,7 +417,7 @@ public final class KeyValue implements Comparable<KeyValue>
   public static KeyValue sliderKey(Slider s, int repeatition)
   {
     // Casting to a short then back to a int to preserve the sign bit.
-    return new KeyValue(s, Kind.Slider, (short)repeatition & 0xFFFF,
+    return new KeyValue(new SliderWithSymbol(s), Kind.Slider, (short)repeatition & 0xFFFF,
         FLAG_SPECIAL | FLAG_SECONDARY | FLAG_KEY_FONT);
   }
 
@@ -876,6 +878,12 @@ public final class KeyValue implements Comparable<KeyValue>
 
     final String symbol;
     final boolean vertical;
+    
+    private static final Slider[] VALUES = Slider.values();
+    public static Slider fromOrdinal(int index)
+    {
+      return VALUES[index];
+    }
 
     Slider(int symbol_, boolean vertical)
     {
@@ -893,7 +901,59 @@ public final class KeyValue implements Comparable<KeyValue>
     @Override
     public String describe() { return name(); }
   };
+  
+  
+  public static final class SliderWithSymbol implements Comparable<SliderWithSymbol>, Describe
+  {
+    final String symbol;
+    final int index;
 
+    public SliderWithSymbol(String symbol, int index)
+    {
+      this.symbol = symbol;
+      this.index = index;
+    }
+
+    public SliderWithSymbol(Slider slider)
+    {
+      this.symbol = slider.symbol;
+      this.index = slider.ordinal();
+    }
+    
+    public SliderWithSymbol(Slider slider, String symbol)
+    {
+      this.symbol = symbol;
+      this.index = slider.ordinal();
+    }
+    
+    public Slider getSlider()
+    {
+        return Slider.fromOrdinal(index);
+    }
+    
+    public boolean isVertical() {
+      return getSlider().isVertical();
+    }
+
+    @Override
+    public String toString() { return symbol; }
+
+    @Override
+    public String describe() { return getSlider().name(); }
+    
+    @Override
+    public int compareTo(SliderWithSymbol snd)
+    {
+      return index != snd.index ? Integer.compare(index, snd.index) : symbol.compareTo(snd.symbol);
+    }
+    
+    @Override
+    public boolean equals(Object obj)
+    {
+      return (obj != null) && index == ((SliderWithSymbol)obj).index && symbol.equals(((SliderWithSymbol)obj).symbol);
+    }
+  };
+  
   public static final class Macro implements Comparable<Macro>, Describe
   {
     public final KeyValue[] keys;

--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -266,7 +266,9 @@ public final class KeyValue implements Comparable<KeyValue>
 
   public KeyValue withSymbol(String symbol)
   {
-    int flags = getFlags() & ~(FLAG_KEY_FONT | FLAG_SMALLER_FONT);
+    int flags = getFlags() & ~FLAG_SMALLER_FONT;
+    if (symbol.length() == 0 || Character.getType(symbol.codePointAt(0)) != Character.PRIVATE_USE)
+      flags &= ~FLAG_KEY_FONT;
     switch (getKind())
     {
       case Char:
@@ -282,6 +284,8 @@ public final class KeyValue implements Comparable<KeyValue>
           flags |= FLAG_SMALLER_FONT;
         return new KeyValue(symbol, _code, _code, flags);
       case Slider:
+        if (symbol.length() > 1)
+          flags |= FLAG_SMALLER_FONT;
         return new KeyValue(new SliderWithSymbol(getSlider(), symbol), _code, _code, flags);
       case Macro:
         return makeMacro(symbol, getMacro(), flags);


### PR DESCRIPTION
Currently keys like `cursor_up` does not work if configured with the long syntax.