### PR TITLE
Add key mappings for Vietnamese keyboard layout

### DIFF
--- a/srcs/layouts/latn_qwerty_vi.xml
+++ b/srcs/layouts/latn_qwerty_vi.xml
@@ -8,10 +8,10 @@
     <key key0="r" key2="4" key3="$" key1="accent_hook_above"/>
     <key key0="t" key2="5" key3="%"/>
     <key key0="y" key2="6" key3="^"/>
-    <key key0="u" key2="7" key3="&amp;"/>
+    <key key0="u" key2="7" key3="&amp;" key4="ư"/>
     <key key0="i" key2="8" key3="*"/>
-    <key key0="o" key1="ô" key2="9" key3="(" key4=")"/>
-    <key key0="p" key2="0"/>
+    <key key0="o" key1="ô" key2="9" key3="(" key4="ơ"/>
+    <key key0="p" key2="0" key3=")"/>
   </row>
   <row>
     <key shift="0.5" key0="a" key1="loc tab" key2="ă" key3="â"/>


### PR DESCRIPTION
I added ư and ơ for better and faster typing in Vietnamese